### PR TITLE
Ignore gemini-cli settings and GitHub App credentials

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,12 @@ dist-ssr
 supabase/.temp/
 .mcp.json
 
+# gemini-cli settings
+.gemini/
+
+# GitHub App credentials
+gha-creds-*.json
+
 # Editor directories and files
 .vscode/*
 !.vscode/extensions.json


### PR DESCRIPTION
### Motivation
- Prevent accidental commits of local gemini-cli settings and GitHub App credential files by adding them to the repository ignore list.

### Description
- Added entries for `.gemini/` and `gha-creds-*.json` to the ` .gitignore` file so those files are no longer tracked.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6983a824caf083218bad2af78bc371bc)