### PR TITLE
Fix autosave race that can overwrite the wrong page

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -135,7 +135,7 @@ function App() {
 
   const uploadImageRef = useRef(null)
 
-  const editor = useEditorSetup({
+  const { editor, editorLocked } = useEditorSetup({
     session,
     activeTrackerId,
     activeTracker,
@@ -362,6 +362,7 @@ function App() {
         {isTemplateEditing && (
           <EditorPanel
             editor={editor}
+            editorLocked={editorLocked}
             title="Daily Template"
             onTitleChange={() => {}}
             onDelete={() => {}}
@@ -389,6 +390,7 @@ function App() {
           <>
             <EditorPanel
               editor={editor}
+              editorLocked={editorLocked}
               title={titleDraft}
               onTitleChange={(value) => handleTitleChange(value, editor)}
               onDelete={deleteTracker}

--- a/src/hooks/useEditorSetup.js
+++ b/src/hooks/useEditorSetup.js
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useCallback } from 'react'
+import { useEffect, useLayoutEffect, useRef, useCallback, useState } from 'react'
 import { useEditor } from '@tiptap/react'
 import StarterKit from '@tiptap/starter-kit'
 import ListItem from '@tiptap/extension-list-item'
@@ -56,6 +56,7 @@ export const useEditorSetup = ({
 }) => {
   const suppressSaveRef = useRef(false)
   const contentOwnerTrackerIdRef = useRef(null)
+  const [editorLocked, setEditorLocked] = useState(false)
   const pasteInfoRef = useRef({
     summary: null,
     preFrom: null,
@@ -192,11 +193,15 @@ export const useEditorSetup = ({
     [session?.user?.id],
   )
 
-  useEffect(() => {
+  // Lock the editor during page/settings transitions so users can't type into content
+  // that is about to be replaced (which can otherwise feel like "lost edits").
+  useLayoutEffect(() => {
     if (!editor) return
     let mounted = true
     const setContent = async () => {
       suppressSaveRef.current = true
+      setEditorLocked(true)
+      if (!editor.isDestroyed) editor.setEditable(false)
       if (settingsMode === 'daily-template') {
         const rawContent = normalizeContent(templateContentRef.current)
         const hydrated = await hydrateContentWithSignedUrls(rawContent)
@@ -209,11 +214,14 @@ export const useEditorSetup = ({
         })
         contentOwnerTrackerIdRef.current = null
         suppressSaveRef.current = false
+        setEditorLocked(false)
+        if (!editor.isDestroyed) editor.setEditable(true)
         return
       }
       if (settingsMode) {
         contentOwnerTrackerIdRef.current = null
         suppressSaveRef.current = false
+        setEditorLocked(false)
         return
       }
 
@@ -222,6 +230,8 @@ export const useEditorSetup = ({
       if (JSON.stringify(currentContent) === JSON.stringify(rawContent)) {
         contentOwnerTrackerIdRef.current = activeTrackerId ?? null
         suppressSaveRef.current = false
+        setEditorLocked(false)
+        if (!editor.isDestroyed) editor.setEditable(true)
         return
       }
       const hydrated = await hydrateContentWithSignedUrls(rawContent)
@@ -234,6 +244,8 @@ export const useEditorSetup = ({
       })
       contentOwnerTrackerIdRef.current = activeTrackerId ?? null
       suppressSaveRef.current = false
+      setEditorLocked(false)
+      if (!editor.isDestroyed) editor.setEditable(true)
       const attemptScroll = (attempts = 0) => {
         if (!mounted) return
         const pending = pendingNavRef.current
@@ -252,6 +264,7 @@ export const useEditorSetup = ({
       // reflect the previous page while React state already points at the next page.
       // Keep saves suppressed until the next effect finishes setting content/owner.
       suppressSaveRef.current = true
+      if (!editor.isDestroyed) editor.setEditable(false)
     }
   }, [
     editor,
@@ -378,5 +391,5 @@ export const useEditorSetup = ({
     return () => editor.off('transaction', handleTransaction)
   }, [editor, getListDepthAt, getListItemTypeAt])
 
-  return editor
+  return { editor, editorLocked }
 }


### PR DESCRIPTION
This fixes an autosave race where the editor could write content to the wrong `pages.id` during navigation / mode switches.

Changes:
- Keep saves suppressed during page/settings transitions.
- Only autosave when we have a known content owner (`contentOwnerTrackerIdRef`); never fall back to `activeTrackerId`.

Manual test:
- Edit Scratchpad, immediately click Tracker (and confirm navigation while saving). Verify Scratchpad content does not overwrite Tracker.
- Open/close Settings (hub) while typing and switching pages; verify no cross-page overwrites.
