### PR TITLE
fix(ai-daily): remove stale bucket

### DIFF
--- a/src/components/EditorPanel.jsx
+++ b/src/components/EditorPanel.jsx
@@ -940,7 +940,6 @@ function EditorPanel({
           ? data.tasks
           : []
       const fyiTasks = Array.isArray(data?.fyi) ? data.fyi : []
-      const staleTasks = Array.isArray(data?.stale) ? data.stale : []
       let templateNodes = []
       try {
         templateNodes = await loadDailyTemplateNodes()
@@ -948,7 +947,7 @@ function EditorPanel({
         console.error('Failed to load daily template:', err)
         templateNodes = []
       }
-      if (asapTasks.length === 0 && fyiTasks.length === 0 && staleTasks.length === 0 && templateNodes.length === 0) {
+      if (asapTasks.length === 0 && fyiTasks.length === 0 && templateNodes.length === 0) {
         alert('No tasks generated. Check your tracker pages have content.')
         return
       }
@@ -1034,7 +1033,6 @@ function EditorPanel({
         content: [
           makeRow('ASAP', asapTasks, templateNodes),
           makeRow('FYI', fyiTasks),
-          makeRow('STALE', staleTasks),
         ],
       }
 

--- a/src/extensions/editorExtensions.js
+++ b/src/extensions/editorExtensions.js
@@ -28,13 +28,13 @@ export const EnsureNodeIds = Extension.create({
             // Ensure every node has a unique ID for deep linking
             if (!id || seen.has(id)) {
               id = crypto.randomUUID?.() ?? Math.random().toString(36).slice(2, 10)
-              // If the block identity changes, reset creation time for stale-task logic.
+              // If the block identity changes, reset creation time.
               createdAt = new Date().toISOString()
               nodeUpdated = true
             }
             seen.add(id)
 
-            // Track creation date to identify stale tasks later
+            // Track creation date for future workflows/analytics.
             if (!createdAt) {
               createdAt = new Date().toISOString()
               nodeUpdated = true


### PR DESCRIPTION
## Summary
- Reverts AI Daily output back to **ASAP + FYI only**.
- Removes the STALE bucket end-to-end and stops sending age-based metadata to the LLM.

## Changes
- Frontend AI Daily insertion table now only renders ASAP/FYI (no `data.stale`).
- `generate-daily` Edge Function prompt/response shape is back to `{ asap, fyi }` (plus `warning`, `rawText`).
- Candidate payload no longer includes `age_days` / stale logic.
- Keeps `created_at` tracking on nodes for future use; AI Daily no longer uses it.

## Testing
- `npm run build`