### PR TITLE
fix: blur editor on internal link tap and restore block selection

### DIFF
--- a/src/extensions/editorExtensions.js
+++ b/src/extensions/editorExtensions.js
@@ -79,7 +79,7 @@ export const InternalLink = Link.extend({
 
     const internalLinkPlugin = new Plugin({
       props: {
-        handleClick: (_view, _pos, event) => {
+        handleClick: (view, _pos, event) => {
           const raw = event.target
           const target = raw instanceof Element ? raw : raw?.parentElement
           const link = target?.closest?.('a')
@@ -88,6 +88,7 @@ export const InternalLink = Link.extend({
           event.preventDefault()
           event.stopPropagation()
           if (href.startsWith('#pg=') || href.startsWith('#sec=') || href.startsWith('#nb=')) {
+            view.dom.blur()
             onNavigateHash?.(href)
             return true
           }

--- a/src/utils/navigationHelpers.js
+++ b/src/utils/navigationHelpers.js
@@ -39,6 +39,11 @@ export const updateHash = (hash, mode = 'replace') => {
 export const scrollToBlock = (blockId, attempts = 0) => {
   const target = document.getElementById(blockId)
   if (target) {
+    const range = document.createRange()
+    range.selectNodeContents(target)
+    const sel = window.getSelection()
+    sel.removeAllRanges()
+    sel.addRange(range)
     requestAnimationFrame(() => {
       requestAnimationFrame(() => {
         target.scrollIntoView({ behavior: 'auto', block: 'center' })


### PR DESCRIPTION
## Summary
- Blur the editor (`view.dom.blur()`) before following an internal link so the mobile keyboard dismisses on tap instead of persisting through navigation
- Restore the DOM selection in `scrollToBlock` — safe now that `suppressFocusRef` (from #57) blocks the `selectionchange→view.focus()` path; gives iOS a visible text-selection highlight on the target block after deep-link navigation

## Test plan
- [ ] Tap an internal link on Android Chrome — keyboard must NOT appear after navigation
- [ ] Tap an internal link on iOS Safari — keyboard must NOT appear; target block should have visible selection highlight
- [ ] Tap to edit after following a link — keyboard opens normally
- [ ] Desktop: clicking internal links still navigates and highlights normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)