### PR TITLE
fix: body background gradient cuts off on mobile scroll

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -14,13 +14,12 @@
 }
 
 html {
-  height: 100%;
+  min-height: 100%;
 }
 
 body {
   margin: 0;
-  height: 100%;
-  min-height: 100vh;
+  min-height: 100%;
   background: radial-gradient(circle at top, #f8fafc 0%, #e2e8f0 100%);
 }
 


### PR DESCRIPTION
## Summary
- Change `html` and `body` from `height: 100%` to `min-height: 100%` so they grow with content
- On mobile, document scrolling makes the body taller than the viewport, but the gradient only rendered for the viewport height — leaving a visible gray line where the flat `#f1f5f9` background showed through
- Desktop is unaffected since it scrolls inside the editor panel with `overflow: hidden`

## Test plan
- [ ] Open on mobile viewport, scroll through a long tracker page — no gray line / background cutoff
- [ ] Check desktop view still looks correct
- [ ] Inspect `<body>` — offsetHeight should match `#root` height

🤖 Generated with [Claude Code](https://claude.com/claude-code)