### PR TITLE
fix(editor): restore focus after deep-link highlight clear

### DIFF
--- a/e2e/fixtures.js
+++ b/e2e/fixtures.js
@@ -1,0 +1,145 @@
+import { test as base, expect } from '@playwright/test'
+import { createClient } from '@supabase/supabase-js'
+import { config } from 'dotenv'
+import path from 'path'
+
+config({ path: path.resolve(process.cwd(), '.env.local') })
+config({ path: path.resolve(process.cwd(), '.env.test'), override: true })
+
+let supabaseClientPromise = null
+
+const clone = (value) => JSON.parse(JSON.stringify(value ?? null))
+
+const getSupabaseClient = async () => {
+  if (supabaseClientPromise) return supabaseClientPromise
+  supabaseClientPromise = (async () => {
+    const supabaseUrl = process.env.VITE_SUPABASE_URL
+    const supabaseAnonKey = process.env.VITE_SUPABASE_ANON_KEY
+    const email = process.env.TEST_USER_EMAIL
+    const password = process.env.TEST_USER_PASSWORD
+    if (!supabaseUrl || !supabaseAnonKey || !email || !password) {
+      throw new Error(
+        'Missing env vars for E2E data isolation. Set VITE_SUPABASE_URL, VITE_SUPABASE_ANON_KEY, TEST_USER_EMAIL, TEST_USER_PASSWORD.',
+      )
+    }
+
+    const client = createClient(supabaseUrl, supabaseAnonKey)
+    const { error } = await client.auth.signInWithPassword({ email, password })
+    if (error) throw error
+    return client
+  })()
+  return supabaseClientPromise
+}
+
+const readUserId = async (supabase) => {
+  const { data, error } = await supabase.auth.getUser()
+  if (error) throw error
+  const userId = data?.user?.id
+  if (!userId) throw new Error('Unable to resolve authenticated test user id')
+  return userId
+}
+
+const readSnapshot = async () => {
+  const supabase = await getSupabaseClient()
+  const userId = await readUserId(supabase)
+  const [notebooksResult, sectionsResult, pagesResult] = await Promise.all([
+    supabase
+      .from('notebooks')
+      .select('id,user_id,title,sort_order')
+      .eq('user_id', userId),
+    supabase
+      .from('sections')
+      .select('id,user_id,notebook_id,title,color,sort_order')
+      .eq('user_id', userId),
+    supabase
+      .from('pages')
+      .select('id,user_id,section_id,title,content,sort_order,is_tracker_page')
+      .eq('user_id', userId),
+  ])
+  if (notebooksResult.error) throw notebooksResult.error
+  if (sectionsResult.error) throw sectionsResult.error
+  if (pagesResult.error) throw pagesResult.error
+
+  return {
+    userId,
+    notebooks: clone(notebooksResult.data ?? []),
+    sections: clone(sectionsResult.data ?? []),
+    pages: clone(pagesResult.data ?? []),
+  }
+}
+
+const restoreSnapshot = async (snapshot) => {
+  const supabase = await getSupabaseClient()
+  const userId = snapshot.userId
+  const [currentNotebooksResult, currentSectionsResult, currentPagesResult] = await Promise.all([
+    supabase.from('notebooks').select('id').eq('user_id', userId),
+    supabase.from('sections').select('id').eq('user_id', userId),
+    supabase.from('pages').select('id').eq('user_id', userId),
+  ])
+  if (currentNotebooksResult.error) throw currentNotebooksResult.error
+  if (currentSectionsResult.error) throw currentSectionsResult.error
+  if (currentPagesResult.error) throw currentPagesResult.error
+
+  const baselineNotebookIds = new Set(snapshot.notebooks.map((row) => row.id))
+  const baselineSectionIds = new Set(snapshot.sections.map((row) => row.id))
+  const baselinePageIds = new Set(snapshot.pages.map((row) => row.id))
+
+  const extraPageIds = (currentPagesResult.data ?? [])
+    .map((row) => row.id)
+    .filter((id) => !baselinePageIds.has(id))
+  const extraSectionIds = (currentSectionsResult.data ?? [])
+    .map((row) => row.id)
+    .filter((id) => !baselineSectionIds.has(id))
+  const extraNotebookIds = (currentNotebooksResult.data ?? [])
+    .map((row) => row.id)
+    .filter((id) => !baselineNotebookIds.has(id))
+
+  if (snapshot.notebooks.length > 0) {
+    const { error } = await supabase.from('notebooks').upsert(snapshot.notebooks, { onConflict: 'id' })
+    if (error) throw error
+  }
+  if (snapshot.sections.length > 0) {
+    const { error } = await supabase.from('sections').upsert(snapshot.sections, { onConflict: 'id' })
+    if (error) throw error
+  }
+  if (snapshot.pages.length > 0) {
+    const { error } = await supabase.from('pages').upsert(snapshot.pages, { onConflict: 'id' })
+    if (error) throw error
+  }
+
+  if (extraPageIds.length > 0) {
+    const { error } = await supabase.from('pages').delete().in('id', extraPageIds)
+    if (error) throw error
+  }
+  if (extraSectionIds.length > 0) {
+    const { error } = await supabase.from('sections').delete().in('id', extraSectionIds)
+    if (error) throw error
+  }
+  if (extraNotebookIds.length > 0) {
+    const { error } = await supabase.from('notebooks').delete().in('id', extraNotebookIds)
+    if (error) throw error
+  }
+}
+
+export const test = base.extend({
+  isolateSupabaseData: [
+    async ({}, use, testInfo) => {
+      if (testInfo.project.name === 'setup') {
+        await use()
+        return
+      }
+
+      const snapshot = await readSnapshot()
+      try {
+        await use()
+      } finally {
+        // Give any in-flight autosave debounce a chance to complete before final restore.
+        await new Promise((resolve) => setTimeout(resolve, 2500))
+        await restoreSnapshot(snapshot)
+      }
+    },
+    { auto: true },
+  ],
+})
+
+export { expect }

--- a/e2e/internal-link-navigation.spec.js
+++ b/e2e/internal-link-navigation.spec.js
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test'
+import { test, expect } from './fixtures'
 
 /**
  * Internal Link Navigation Tests

--- a/e2e/issue-61-deep-link-focus-recovery.spec.js
+++ b/e2e/issue-61-deep-link-focus-recovery.spec.js
@@ -1,0 +1,102 @@
+import { test, expect } from './fixtures'
+
+const getSelectionState = async (page) =>
+  page.evaluate(() => {
+    const root = document.querySelector('.ProseMirror')
+    const selection = window.getSelection?.()
+    const anchorNode = selection?.anchorNode ?? null
+    const focusNode = selection?.focusNode ?? null
+    const anchorEl =
+      anchorNode && anchorNode.nodeType === 1 ? anchorNode : anchorNode?.parentElement ?? null
+    const focusEl =
+      focusNode && focusNode.nodeType === 1 ? focusNode : focusNode?.parentElement ?? null
+    const activeEl = document.activeElement
+
+    return {
+      activeTag: activeEl?.tagName ?? null,
+      activeInEditor: Boolean(root && activeEl && root.contains(activeEl)),
+      selectionInEditor: Boolean(root && ((anchorEl && root.contains(anchorEl)) || (focusEl && root.contains(focusEl)))),
+      selectedText: selection?.toString() ?? '',
+    }
+  })
+
+const resolveDeepLinkTarget = async (page) => {
+  await page.locator('.sidebar-title', { hasText: 'Test Scratchpad' }).click()
+  await page.waitForSelector('.ProseMirror[contenteditable="true"]', { timeout: 5000 })
+
+  const internalLink = page.locator('.ProseMirror a[href*="pg="]').first()
+  await expect(internalLink).toBeVisible({ timeout: 10000 })
+  const href = await internalLink.getAttribute('href')
+  const blockId = href ? new URL('http://x/' + href.replace('#', '?')).searchParams.get('block') : null
+  test.skip(!href || !blockId, 'Seed data missing deep-link href with block id')
+
+  await page.locator('.sidebar-title', { hasText: 'Test Section' }).click()
+  await page.waitForSelector('.ProseMirror[contenteditable="true"]', { timeout: 5000 })
+  await page.evaluate((targetHref) => {
+    window.location.hash = targetHref
+  }, href)
+
+  const styleLocator = page.locator('#deep-link-target-style')
+  await expect(async () => {
+    const content = await styleLocator.textContent()
+    expect(content).toContain(blockId)
+  }).toPass({ timeout: 10000 })
+
+  return { blockId, styleLocator }
+}
+
+test.describe('Issue #61 deep-link focus recovery', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/')
+    await page.waitForSelector('.app:not(.app-auth)', { timeout: 10000 })
+  })
+
+  test('desktop: first click-back after highlight clear keeps keyboard scope in editor', async ({ page, isMobile }) => {
+    test.skip(isMobile, 'Desktop keyboard shortcut regression path')
+
+    const { blockId, styleLocator } = await resolveDeepLinkTarget(page)
+
+    await page.locator('.topbar').click({ position: { x: 12, y: 12 } })
+    await expect(async () => {
+      const content = await styleLocator.textContent()
+      expect(content?.trim() || '').toBe('')
+    }).toPass({ timeout: 5000 })
+
+    const targetBlock = page.locator(`[id="${blockId}"]`)
+    await expect(targetBlock).toBeVisible({ timeout: 5000 })
+    const box = await targetBlock.boundingBox()
+    test.skip(!box, 'Deep-link target block is not clickable')
+
+    // Click near the left edge so this is not dependent on clicking exact text glyphs.
+    await page.mouse.click(box.x + 4, box.y + Math.max(4, Math.min(box.height - 4, box.height / 2)))
+    await page.keyboard.press('ControlOrMeta+a')
+
+    const selectionState = await getSelectionState(page)
+    expect(selectionState.activeTag).not.toBe('BODY')
+    expect(selectionState.activeInEditor || selectionState.selectionInEditor).toBeTruthy()
+    expect(selectionState.selectedText.length).toBeGreaterThan(0)
+    expect(selectionState.selectedText).not.toContain('Life Tracker')
+    expect(selectionState.selectedText).not.toContain('Signed in as')
+  })
+
+  test('mobile: deep-link landing avoids auto-focus and still supports tap-back editing flow', async ({ page, isMobile }) => {
+    test.skip(!isMobile, 'Mobile guard regression path')
+
+    const { blockId, styleLocator } = await resolveDeepLinkTarget(page)
+    const initialState = await getSelectionState(page)
+    expect(initialState.activeInEditor).toBeFalsy()
+
+    await page.locator('.topbar').click({ position: { x: 12, y: 12 } })
+    await expect(async () => {
+      const content = await styleLocator.textContent()
+      expect(content?.trim() || '').toBe('')
+    }).toPass({ timeout: 5000 })
+
+    const targetBlock = page.locator(`[id="${blockId}"]`)
+    await expect(targetBlock).toBeVisible({ timeout: 5000 })
+    await targetBlock.click({ position: { x: 8, y: 8 } })
+
+    const stateAfterTapBack = await getSelectionState(page)
+    expect(stateAfterTapBack.activeInEditor || stateAfterTapBack.selectionInEditor).toBeTruthy()
+  })
+})

--- a/e2e/issue-62-highlight-paste.spec.js
+++ b/e2e/issue-62-highlight-paste.spec.js
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test'
+import { test, expect } from './fixtures'
 
 const readExpenseState = async (page) =>
   page.evaluate(() => {
@@ -19,49 +19,35 @@ test.describe('Issue #62 highlight paste regression', () => {
     await page.waitForSelector('.app:not(.app-auth)', { timeout: 15000 })
     await page.locator('.sidebar-title', { hasText: 'Test Section' }).click()
     await page.waitForSelector('.ProseMirror[contenteditable="true"]', { timeout: 10000 })
-
     const baselineState = await readExpenseState(page)
-    const baselineSignature = JSON.stringify(baselineState)
     const hasSeedLine = baselineState.some((line) => line.text.includes('Expenses due 2/22'))
     const hasSeedHighlight = baselineState.some(
       (line) => line.text.includes('Expenses due 2/22') && line.marks.includes('2/22'),
     )
     test.skip(!hasSeedLine || !hasSeedHighlight, 'Seed data missing highlighted "Expenses due 2/22" line')
 
-    try {
-      const sourceLine = page.locator('.ProseMirror p, .ProseMirror li', { hasText: 'Expenses due 2/22' }).first()
-      await sourceLine.click()
+    const sourceLine = page.locator('.ProseMirror p, .ProseMirror li', { hasText: 'Expenses due 2/22' }).first()
+    await sourceLine.click()
 
-      // Mirrors the recorded flow: copy selected scope, duplicate under source line, edit date.
-      await page.keyboard.press('End')
-      await page.keyboard.press('Shift+Home')
-      await page.keyboard.press('ControlOrMeta+c')
-      await page.keyboard.press('ArrowRight')
-      await page.keyboard.press('Enter')
-      await page.keyboard.press('ControlOrMeta+v')
+    // Mirrors the recorded flow: copy selected scope, duplicate under source line, edit date.
+    await page.keyboard.press('End')
+    await page.keyboard.press('Shift+Home')
+    await page.keyboard.press('ControlOrMeta+c')
+    await page.keyboard.press('ArrowRight')
+    await page.keyboard.press('Enter')
+    await page.keyboard.press('ControlOrMeta+v')
 
-      // Replace pasted date 2/22 -> 3/7.
-      await page.keyboard.press('Backspace')
-      await page.keyboard.press('Backspace')
-      await page.keyboard.press('Backspace')
-      await page.keyboard.press('Backspace')
-      await page.keyboard.type('3/7')
+    // Replace pasted date 2/22 -> 3/7.
+    await page.keyboard.press('Backspace')
+    await page.keyboard.press('Backspace')
+    await page.keyboard.press('Backspace')
+    await page.keyboard.press('Backspace')
+    await page.keyboard.type('3/7')
 
-      const stateAfterEdit = await readExpenseState(page)
-      const editedLine = stateAfterEdit.find((line) => line.text.includes('Expenses due 3/7')) ?? null
-      expect(editedLine).toBeTruthy()
-      expect(editedLine.marks).toContain('3/7')
-      expect(editedLine.marks).not.toContain('Expenses due 3/7')
-    } finally {
-      // Cleanup: undo until the document returns to the exact baseline state.
-      for (let i = 0; i < 10; i += 1) {
-        const current = await readExpenseState(page)
-        if (JSON.stringify(current) === baselineSignature) break
-        await page.keyboard.press('ControlOrMeta+z')
-      }
-    }
-
-    const afterCleanup = await readExpenseState(page)
-    expect(JSON.stringify(afterCleanup)).toBe(baselineSignature)
+    const stateAfterEdit = await readExpenseState(page)
+    const editedLine = stateAfterEdit.find((line) => line.text.includes('Expenses due 3/7')) ?? null
+    expect(editedLine).toBeTruthy()
+    expect(editedLine.marks).toContain('3/7')
+    expect(editedLine.marks).not.toContain('Expenses due 3/7')
   })
 })

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -5,7 +5,8 @@ export default defineConfig({
   fullyParallel: true,
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 2 : 0,
-  workers: process.env.CI ? 1 : undefined,
+  // Run one test worker at a time to avoid cross-test data interference.
+  workers: 1,
   reporter: 'html',
 
   use: {

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -238,11 +238,13 @@ function App() {
       const isInternalLink = Boolean(
         target.closest('a[href^="#pg="], a[href^="#sec="], a[href^="#nb="]'),
       )
+      const isEditorContent = Boolean(target.closest('.ProseMirror'))
       pointerGestureRef.current = {
         pointerId: event.pointerId,
         startX: event.clientX,
         startY: event.clientY,
         isInternalLink,
+        isEditorContent,
       }
     },
     [],
@@ -261,7 +263,11 @@ function App() {
         return
       }
       if (deepLinkFocusGuardRef.current) {
-        pendingEditTapRef.current = { left: event.clientX, top: event.clientY }
+        pendingEditTapRef.current = {
+          left: event.clientX,
+          top: event.clientY,
+          inEditor: gesture.isEditorContent,
+        }
       } else {
         pendingEditTapRef.current = null
       }

--- a/src/hooks/useEditorSetup.js
+++ b/src/hooks/useEditorSetup.js
@@ -92,6 +92,7 @@ export const useEditorSetup = ({
   })
   const pendingPasteFixRef = useRef(false)
   const previousDeepLinkFocusGuardRef = useRef(deepLinkFocusGuard)
+  const pendingDesktopDeepLinkRecoveryRef = useRef(false)
 
   const getListDepthAt = useCallback((state, pos) => {
     const $pos = state.doc.resolve(pos)
@@ -493,10 +494,12 @@ export const useEditorSetup = ({
   useEffect(() => {
     if (!editor || editor.isDestroyed) return
     if (editorLocked || settingsMode) return
+    const isTouchDevice = isTouchOnlyDevice()
     const wasGuarded = previousDeepLinkFocusGuardRef.current
     previousDeepLinkFocusGuardRef.current = deepLinkFocusGuard
-    const suppressProgrammaticFocus = isTouchOnlyDevice() && deepLinkFocusGuard
+    const suppressProgrammaticFocus = isTouchDevice && deepLinkFocusGuard
     if (suppressProgrammaticFocus) {
+      pendingDesktopDeepLinkRecoveryRef.current = false
       editor.setEditable(false)
       editor.view.dom.blur()
       requestAnimationFrame(() => {
@@ -507,12 +510,20 @@ export const useEditorSetup = ({
       return
     }
     const tapIntent = pendingEditTapRef?.current
-    if (wasGuarded && tapIntent && isTouchOnlyDevice()) {
-      const pos = editor.view.posAtCoords(tapIntent)
-      if (pos?.pos != null) {
-        editor.commands.setTextSelection(pos.pos)
-      }
+    let handledInEditorTap = false
+    if (wasGuarded && tapIntent?.inEditor) {
+      const pos = editor.view.posAtCoords({
+        left: tapIntent.left,
+        top: tapIntent.top,
+      })
+      if (pos?.pos != null) editor.commands.setTextSelection(pos.pos)
+      handledInEditorTap = true
+    }
+    if (wasGuarded) {
+      pendingDesktopDeepLinkRecoveryRef.current = !isTouchDevice && !handledInEditorTap
       pendingEditTapRef.current = null
+    }
+    if (handledInEditorTap) {
       editor.setEditable(true)
       requestAnimationFrame(() => {
         if (!editor.isDestroyed) {
@@ -523,6 +534,46 @@ export const useEditorSetup = ({
     }
     editor.setEditable(true)
   }, [editor, editorLocked, settingsMode, deepLinkFocusGuard, pendingEditTapRef])
+
+  // Desktop fallback for issue #61: when a deep-link highlight is cleared by a click
+  // outside the editor, recover focus/caret on the next in-editor click.
+  useEffect(() => {
+    if (!editor || editor.isDestroyed) return
+    if (isTouchOnlyDevice()) return
+    const root = editor.view?.dom
+    if (!root) return
+
+    const handlePointerDown = (event) => {
+      if (event.pointerType === 'touch') return
+      if (!pendingDesktopDeepLinkRecoveryRef.current) return
+      if (editorLocked || settingsMode) return
+      if (deepLinkFocusGuard || deepLinkFocusGuardRef.current) return
+      if (editor.view.hasFocus()) {
+        pendingDesktopDeepLinkRecoveryRef.current = false
+        return
+      }
+
+      const activeTag = document.activeElement?.tagName
+      if (activeTag && activeTag !== 'BODY' && activeTag !== 'HTML') {
+        pendingDesktopDeepLinkRecoveryRef.current = false
+        return
+      }
+
+      const pos = editor.view.posAtCoords({
+        left: event.clientX,
+        top: event.clientY,
+      })
+      if (pos?.pos != null) editor.commands.setTextSelection(pos.pos)
+
+      pendingDesktopDeepLinkRecoveryRef.current = false
+      requestAnimationFrame(() => {
+        if (!editor.isDestroyed) editor.view.focus()
+      })
+    }
+
+    root.addEventListener('pointerdown', handlePointerDown, true)
+    return () => root.removeEventListener('pointerdown', handlePointerDown, true)
+  }, [editor, editorLocked, settingsMode, deepLinkFocusGuard, deepLinkFocusGuardRef])
 
   // If the DOM selection is inside the editor but focus has fallen back to <body>,
   // typing/backspace does nothing. This can happen after programmatic selections,


### PR DESCRIPTION
## Summary
- restores deterministic editor focus/caret recovery after deep-link highlight clear on desktop
- keeps the existing mobile deep-link focus guard behavior and adds a mobile regression check
- adds `e2e/issue-61-deep-link-focus-recovery.spec.js` for desktop + mobile deep-link flows
- adds global E2E Supabase snapshot/restore fixture to protect test account data across runs
- updates E2E specs to use the fixture and runs suite serially (`workers: 1`) for stability

## Testing
- `npm run test:e2e`
- `npm run test:e2e -- e2e/internal-link-navigation.spec.js e2e/issue-61-deep-link-focus-recovery.spec.js`

Closes #61