### PR TITLE
fix: stale local drafts overwriting newer server data

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -23,6 +23,7 @@ import TopBar from './components/app/TopBar'
 import SectionTabs from './components/app/SectionTabs'
 import SectionContextMenu from './components/app/SectionContextMenu'
 import CopyMoveModal from './components/app/CopyMoveModal'
+import ConflictModal from './components/app/ConflictModal'
 import './styles/index.css'
 
 const DEFAULT_SIDEBAR_WIDTH = 280
@@ -146,6 +147,9 @@ function App() {
     reorderTrackers,
     setTrackerPage,
     deleteTracker,
+    draftConflict,
+    resolveConflictWithServer,
+    resolveConflictWithDraft,
   } = useTrackers(userId, activeSectionId, pendingNavRef, savedSelectionRef)
 
   const {
@@ -638,6 +642,11 @@ function App() {
         onDestChange={(destId) => setCopyMoveModal((prev) => ({ ...prev, destId }))}
         onClose={closeCopyMoveModal}
         onConfirm={handleCopyMoveConfirm}
+      />
+      <ConflictModal
+        conflict={draftConflict}
+        onUseServer={resolveConflictWithServer}
+        onUseDraft={resolveConflictWithDraft}
       />
     </div>
   )

--- a/src/components/app/ConflictModal.jsx
+++ b/src/components/app/ConflictModal.jsx
@@ -1,0 +1,29 @@
+function ConflictModal({ conflict, onUseServer, onUseDraft }) {
+  if (!conflict) return null
+
+  return (
+    <div className="ai-insert-modal-backdrop">
+      <div className="ai-insert-modal conflict-modal">
+        <h3>Draft conflict detected</h3>
+        <p className="subtle">
+          A local draft exists for this page, but the server has a newer version.
+          Choose which version to keep.
+        </p>
+        <div className="conflict-timestamps">
+          <p>Server version: {new Date(conflict.serverUpdatedAt).toLocaleString()}</p>
+          <p>Local draft: {new Date(conflict.draftTs).toLocaleString()}</p>
+        </div>
+        <div className="ai-insert-actions">
+          <button type="button" className="ghost" onClick={onUseDraft}>
+            Use local version
+          </button>
+          <button type="button" onClick={onUseServer}>
+            Use server version
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export default ConflictModal

--- a/src/hooks/useTrackers.js
+++ b/src/hooks/useTrackers.js
@@ -13,6 +13,7 @@ export const useTrackers = (userId, activeSectionId, pendingNavRef, savedSelecti
   const [titleDraft, setTitleDraft] = useState('')
   const [saveStatus, setSaveStatus] = useState('Saved')
   const [hasPendingSaves, setHasPendingSaves] = useState(false)
+  const [draftConflict, setDraftConflict] = useState(null)
 
   const titleDraftRef = useRef(titleDraft)
   const activeTrackerRef = useRef(null)
@@ -32,13 +33,15 @@ export const useTrackers = (userId, activeSectionId, pendingNavRef, savedSelecti
   const activeDraft = useMemo(() => (activeTrackerId ? readPageDraft(activeTrackerId) : null), [activeTrackerId])
   const activeTracker = useMemo(() => {
     if (!activeTrackerServer) return null
+    // While a conflict is pending, show server content (modal blocks interaction).
+    if (draftConflict?.trackerId === activeTrackerId) return activeTrackerServer
     if (!activeDraft) return activeTrackerServer
     return {
       ...activeTrackerServer,
       title: typeof activeDraft.title === 'string' ? activeDraft.title : activeTrackerServer.title,
       content: activeDraft.content ?? activeTrackerServer.content,
     }
-  }, [activeDraft, activeTrackerServer])
+  }, [activeDraft, activeTrackerServer, draftConflict, activeTrackerId])
 
   useEffect(() => {
     titleDraftRef.current = titleDraft
@@ -47,6 +50,42 @@ export const useTrackers = (userId, activeSectionId, pendingNavRef, savedSelecti
   useEffect(() => {
     activeTrackerRef.current = activeTracker
   }, [activeTracker])
+
+  // Refs so the conflict-detection effect only fires when activeTrackerId changes.
+  const activeTrackerServerRef = useRef(activeTrackerServer)
+  const activeDraftRef = useRef(activeDraft)
+  useEffect(() => { activeTrackerServerRef.current = activeTrackerServer }, [activeTrackerServer])
+  useEffect(() => { activeDraftRef.current = activeDraft }, [activeDraft])
+
+  // Detect stale draft vs newer server data when switching pages.
+  useEffect(() => {
+    if (!activeTrackerId) {
+      setDraftConflict(null)
+      return
+    }
+    const server = activeTrackerServerRef.current
+    const draft = activeDraftRef.current
+    if (!server || !draft || !draft.ts) {
+      setDraftConflict(null)
+      return
+    }
+    const serverTime = new Date(server.updated_at).getTime()
+    if (serverTime > draft.ts) {
+      setDraftConflict({
+        trackerId: activeTrackerId,
+        draftTs: draft.ts,
+        serverUpdatedAt: server.updated_at,
+        draftContent: draft.content,
+        draftTitle: draft.title,
+        serverContent: server.content,
+        serverTitle: server.title,
+      })
+    } else {
+      setDraftConflict(null)
+    }
+    // Cleanup: if user navigates away while conflict is unresolved, clear it (server wins by default).
+    return () => setDraftConflict(null)
+  }, [activeTrackerId])
 
   useEffect(() => {
     trackersRef.current = trackers
@@ -468,6 +507,20 @@ export const useTrackers = (userId, activeSectionId, pendingNavRef, savedSelecti
     setActiveTrackerId((prev) => (prev === tracker.id ? nextTrackers[0]?.id ?? null : prev))
   }
 
+  const resolveConflictWithServer = useCallback(() => {
+    if (!draftConflict) return
+    clearPageDraft(draftConflict.trackerId)
+    setDraftConflict(null)
+  }, [draftConflict])
+
+  const resolveConflictWithDraft = useCallback(() => {
+    if (!draftConflict) return
+    const { trackerId, draftContent, draftTitle } = draftConflict
+    setDraftConflict(null)
+    // Push the draft content to the server via the normal save pipeline.
+    scheduleSave(draftContent, draftTitle, trackerId)
+  }, [draftConflict, scheduleSave])
+
   const sectionTrackerPage = trackers.find((item) => item.is_tracker_page) ?? null
 
   return {
@@ -492,5 +545,8 @@ export const useTrackers = (userId, activeSectionId, pendingNavRef, savedSelecti
     deleteTracker,
     activeTrackerRef,
     sectionTrackerPage,
+    draftConflict,
+    resolveConflictWithServer,
+    resolveConflictWithDraft,
   }
 }

--- a/src/styles/menus-modals.css
+++ b/src/styles/menus-modals.css
@@ -176,3 +176,17 @@
   background: #e2e8f0;
   margin: 0.25rem 0;
 }
+
+.conflict-modal {
+  width: min(440px, 100%);
+}
+
+.conflict-timestamps {
+  font-size: 0.85rem;
+  color: #64748b;
+  margin: 0.5rem 0 0.75rem;
+}
+
+.conflict-timestamps p {
+  margin: 0.2rem 0;
+}


### PR DESCRIPTION
## Summary
- When a localStorage draft exists but the server's `updated_at` is newer than the draft's timestamp, an undismissible modal appears forcing the user to choose "Use server version" or "Use local version"
- Prevents silent data loss when opening the app on a second device with an old draft in localStorage
- While the conflict modal is shown, the editor displays server content and blocks interaction

## Test plan
- [ ] Edit a tracker, let it save to server
- [ ] Manually set a stale draft: `localStorage.setItem('lifeTracker:draft:page:<id>', JSON.stringify({title:'old',content:{type:'doc',content:[]},ts:1000000000000}))`
- [ ] Reload — conflict modal should appear with timestamps
- [ ] Click "Use server version" — modal closes, editor shows server content, draft cleared
- [ ] Repeat stale draft setup, click "Use local version" — modal closes, draft loads, auto-save pushes to server
- [ ] Verify no modal appears when there is no draft or when draft is newer than server

Closes #77

🤖 Generated with [Claude Code](https://claude.com/claude-code)