### PR TITLE
feat(editor): add mobile-only indent/outdent toolbar buttons

### DIFF
--- a/e2e/issue-60-mobile-indent-outdent.spec.js
+++ b/e2e/issue-60-mobile-indent-outdent.spec.js
@@ -1,0 +1,155 @@
+import { test, expect } from './fixtures'
+
+test.describe('Issue #60 mobile indent/outdent toolbar buttons', () => {
+  test('mobile: indent/outdent buttons appear and work on list items', async ({ page, isMobile }) => {
+    test.skip(!isMobile, 'Mobile-only toolbar buttons')
+
+    await page.goto('/')
+    await page.waitForSelector('.app:not(.app-auth)', { timeout: 15000 })
+
+    // Seed data check: need Test Section page with a list
+    const testSection = page.locator('.sidebar-title', { hasText: 'Test Section' }).first()
+    let seedVisible = true
+    try {
+      await testSection.waitFor({ state: 'visible', timeout: 5000 })
+    } catch {
+      seedVisible = false
+    }
+    test.skip(!seedVisible, 'Seed data missing Test Section page')
+
+    await testSection.click()
+    await page.waitForSelector('.ProseMirror[contenteditable="true"]', { timeout: 10000 })
+
+    const indentBtn = page.getByRole('button', { name: '→' })
+    const outdentBtn = page.getByRole('button', { name: '←' })
+
+    // Buttons should be visible on mobile
+    await expect(indentBtn).toBeVisible()
+    await expect(outdentBtn).toBeVisible()
+
+    // Find a non-first list item to test indent/outdent
+    const weddingInvites = page.getByText('Send out wedding invites').first()
+    await expect(weddingInvites).toBeVisible({ timeout: 5000 })
+
+    // Click the item and indent it
+    await weddingInvites.click()
+    await page.waitForTimeout(300)
+
+    // Capture table row count before indent
+    const rowCountBefore = await page.evaluate(() =>
+      document.querySelectorAll('table tr').length
+    )
+
+    // Indent: the item should become nested
+    await indentBtn.click()
+    await page.waitForTimeout(500)
+
+    // Verify indentation happened — item should now be inside a nested list
+    const isNested = await page.evaluate(() => {
+      const sel = window.getSelection()
+      if (!sel?.anchorNode) return false
+      let node = sel.anchorNode
+      let listDepth = 0
+      while (node && node !== document.body) {
+        if (node.nodeName === 'UL' || node.nodeName === 'OL') listDepth++
+        node = node.parentNode
+      }
+      return listDepth >= 2
+    })
+    expect(isNested).toBe(true)
+
+    // Outdent: should return to original level
+    await outdentBtn.click()
+    await page.waitForTimeout(500)
+
+    const isFlat = await page.evaluate(() => {
+      const sel = window.getSelection()
+      if (!sel?.anchorNode) return false
+      let node = sel.anchorNode
+      let listDepth = 0
+      while (node && node !== document.body) {
+        if (node.nodeName === 'UL' || node.nodeName === 'OL') listDepth++
+        node = node.parentNode
+      }
+      return listDepth === 1
+    })
+    expect(isFlat).toBe(true)
+
+    // Table row count should be unchanged (no spurious rows created)
+    const rowCountAfter = await page.evaluate(() =>
+      document.querySelectorAll('table tr').length
+    )
+    expect(rowCountAfter).toBe(rowCountBefore)
+  })
+
+  test('mobile: indent/outdent on first list item in table does not create rows', async ({ page, isMobile }) => {
+    test.skip(!isMobile, 'Mobile-only toolbar buttons')
+
+    await page.goto('/')
+    await page.waitForSelector('.app:not(.app-auth)', { timeout: 15000 })
+
+    const testSection = page.locator('.sidebar-title', { hasText: 'Test Section' }).first()
+    let seedVisible = true
+    try {
+      await testSection.waitFor({ state: 'visible', timeout: 5000 })
+    } catch {
+      seedVisible = false
+    }
+    test.skip(!seedVisible, 'Seed data missing Test Section page')
+
+    await testSection.click()
+    await page.waitForSelector('.ProseMirror[contenteditable="true"]', { timeout: 10000 })
+
+    const indentBtn = page.getByRole('button', { name: '→' })
+    const outdentBtn = page.getByRole('button', { name: '←' })
+
+    // Click on the first list item (can't be indented or outdented)
+    const djItem = page.getByText('Get DJ scheduled').first()
+    await expect(djItem).toBeVisible({ timeout: 5000 })
+    await djItem.click()
+    await page.waitForTimeout(300)
+
+    const rowCountBefore = await page.evaluate(() =>
+      document.querySelectorAll('table tr').length
+    )
+
+    // Indent on first item should be a no-op
+    await indentBtn.click()
+    await page.waitForTimeout(500)
+
+    // Outdent on top-level item in table should be a no-op
+    await outdentBtn.click()
+    await page.waitForTimeout(500)
+
+    // Table should have same number of rows — no spurious rows created
+    const rowCountAfter = await page.evaluate(() =>
+      document.querySelectorAll('table tr').length
+    )
+    expect(rowCountAfter).toBe(rowCountBefore)
+  })
+
+  test('desktop: indent/outdent buttons are not visible', async ({ page, isMobile }) => {
+    test.skip(isMobile, 'Desktop-only check')
+
+    await page.goto('/')
+    await page.waitForSelector('.app:not(.app-auth)', { timeout: 15000 })
+
+    const testSection = page.locator('.sidebar-title', { hasText: 'Test Section' }).first()
+    let seedVisible = true
+    try {
+      await testSection.waitFor({ state: 'visible', timeout: 5000 })
+    } catch {
+      seedVisible = false
+    }
+    test.skip(!seedVisible, 'Seed data missing Test Section page')
+
+    await testSection.click()
+    await page.waitForSelector('.ProseMirror[contenteditable="true"]', { timeout: 10000 })
+
+    // Indent/outdent buttons should not exist on desktop
+    const indentBtn = page.getByRole('button', { name: '→' })
+    const outdentBtn = page.getByRole('button', { name: '←' })
+    await expect(indentBtn).not.toBeVisible()
+    await expect(outdentBtn).not.toBeVisible()
+  })
+})

--- a/src/components/EditorPanel.jsx
+++ b/src/components/EditorPanel.jsx
@@ -95,6 +95,47 @@ function EditorPanel({
   const [findQuery, setFindQuery] = useState('')
   const [findStatus, setFindStatus] = useState({ query: '', matches: [], index: -1 })
   const gridSize = 5
+  const isTouchOnly = useMemo(() => isTouchOnlyDevice(), [])
+
+  const isInList = editor?.isActive('bulletList') || editor?.isActive('orderedList') || editor?.isActive('taskList')
+
+  // Find the enclosing listItem/taskItem depth and its index within the parent list
+  const getListItemInfo = useCallback(() => {
+    if (!editor) return null
+    const { $from } = editor.state.selection
+    const itemTypeName = editor.isActive('taskList') || editor.isActive('taskItem') ? 'taskItem' : 'listItem'
+    let itemDepth = null
+    for (let depth = $from.depth; depth > 0; depth -= 1) {
+      const node = $from.node(depth)
+      if (node.type?.name === 'listItem' || node.type?.name === 'taskItem') {
+        itemDepth = depth
+        break
+      }
+    }
+    if (!itemDepth) return null
+    const listDepth = itemDepth - 1
+    const index = $from.index(listDepth)
+    const listParentDepth = listDepth - 1
+    const listParent = listParentDepth > 0 ? $from.node(listParentDepth) : null
+    const isNested = listParent?.type?.name === 'listItem' || listParent?.type?.name === 'taskItem'
+    return { itemTypeName, itemDepth, listDepth, index, isNested }
+  }, [editor])
+
+  const handleIndent = useCallback(() => {
+    if (!editor) return
+    const info = getListItemInfo()
+    // Can't indent the first item (no previous sibling to nest under)
+    if (!info || info.index === 0) return
+    editor.chain().focus().sinkListItem(info.itemTypeName).run()
+  }, [editor, getListItemInfo])
+
+  const handleOutdent = useCallback(() => {
+    if (!editor) return
+    const info = getListItemInfo()
+    // Only outdent if nested inside another list item (prevents breaking table cells)
+    if (!info || !info.isNested) return
+    editor.chain().focus().liftListItem(info.itemTypeName).run()
+  }, [editor, getListItemInfo])
 
   useEffect(() => {
     if (aiDailyPickerOpen) {
@@ -1324,6 +1365,26 @@ function EditorPanel({
         >
           ☑ List
         </button>
+        {isTouchOnly && (
+          <>
+            <button
+              type="button"
+              onClick={handleOutdent}
+              disabled={!hasTracker || !isInList}
+              title="Outdent"
+            >
+              ←
+            </button>
+            <button
+              type="button"
+              onClick={handleIndent}
+              disabled={!hasTracker || !isInList}
+              title="Indent"
+            >
+              →
+            </button>
+          </>
+        )}
 
         <div className="toolbar-divider" />
 


### PR DESCRIPTION
## Summary
- Adds ← (outdent) and → (indent) buttons to the mobile toolbar, visible only on touch devices
- Guards prevent indent on first list items (no previous sibling) and outdent on top-level items inside table cells (prevents corrupting table structure)
- Includes E2E regression tests for mobile indent/outdent behavior and desktop button visibility

Closes #60

## Test plan
- [x] Desktop: indent/outdent buttons do NOT appear in toolbar
- [x] Mobile: buttons appear and correctly indent/outdent non-first list items
- [x] Mobile: indent/outdent on first item in table does not create spurious rows
- [x] All existing E2E tests pass (12 passed, 5 skipped)
- [x] New regression tests pass for indent/outdent and table safety

🤖 Generated with [Claude Code](https://claude.com/claude-code)