### PR TITLE
Strengthen table border contrast

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -36,12 +36,14 @@
 - **Neutrals (warm stone grays):**
   - Stone 900: `#1C1917` — primary text
   - Stone 600: `#57534E` — secondary text
+  - Stone 500: `#78716C` — utility contrast, table borders
   - Stone 400: `#A8A29E` — muted text, placeholders
   - Stone 200: `#E7E5E4` — borders
   - Stone 300: `#D6D3D1` — strong borders (dividers, toolbar)
   - Stone 100: `#F5F5F4` — raised surfaces, toolbar background
   - Stone 50: `#FAFAF9` — page background
   - White: `#FFFFFF` — card/surface background
+- **Table borders:** Use Stone 500 `#78716C` for table gridlines and outer table edges so tables stay clearly legible against the warm neutral canvas without darkening other dividers.
 - **Semantic:**
   - Success: `#16A34A` — saved, completed
   - Warning: `#D97706` — unsaved changes
@@ -118,6 +120,7 @@
   --surface-raised: #F5F5F4;
   --border: #E7E5E4;
   --border-strong: #D6D3D1;
+  --table-border: #78716C;
   --text: #1C1917;
   --text-secondary: #57534E;
   --text-muted: #A8A29E;

--- a/src/styles/base.css
+++ b/src/styles/base.css
@@ -12,6 +12,7 @@
   --surface-raised: #F5F5F4;
   --border: #E7E5E4;
   --border-strong: #D6D3D1;
+  --table-border: #78716C;
   --text: #1C1917;
   --text-secondary: #57534E;
   --text-muted: #A8A29E;

--- a/src/styles/editor.css
+++ b/src/styles/editor.css
@@ -90,6 +90,7 @@
 .editor-shell table {
   width: 100%;
   border-collapse: collapse;
+  border: 1px solid var(--table-border);
   margin: 1rem 0;
 }
 
@@ -131,7 +132,7 @@
 
 .editor-shell th,
 .editor-shell td {
-  border: 1px solid var(--border-strong);
+  border: 1px solid var(--table-border);
   padding: 0.5rem;
   position: relative;
 }


### PR DESCRIPTION
## Summary
- add a dedicated `--table-border` design token for table-only contrast
- update the design system to document the stronger table border treatment
- apply the token to table outer borders and cell gridlines in the editor

## Verification
- `npm run build`

## Notes
- left unrelated untracked local files out of the commit: `.playwright-mcp/`, `recovery/`, `tmp_req25_response.json`, `tmp_req26_request.txt`, `tmp_req31_request.txt`, `tmp_req32_request.txt`, `tmp_req33_response.json`