### PR TITLE
fix: correct mobile keyboard toolbar lift (#124 follow-up)

### DIFF
--- a/src/hooks/__tests__/useVirtualKeyboard.test.js
+++ b/src/hooks/__tests__/useVirtualKeyboard.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { computeKeyboardHeight } from '../useVirtualKeyboard'
+import { computeKeyboardHeight, updateBaseline } from '../useVirtualKeyboard'
 
 // ─── Pure computation tests ─────────────────────────────────────────────────
 // The hook's core keyboard-height formula is extracted as computeKeyboardHeight.
@@ -50,5 +50,45 @@ describe('computeKeyboardHeight', () => {
   it('handles large viewport values (tablet-sized baseline)', () => {
     // baseline=1024, current=724, delta=300; cap=724*0.6=434.4 (no cap)
     expect(computeKeyboardHeight(1024, 724)).toBe(300)
+  })
+})
+
+// ─── updateBaseline tests ──────────────────────────────────────────────────────
+// updateBaseline implements "self-correcting baseline": when the viewport grows
+// (URL bar hides) BEFORE the keyboard opens, the baseline must track upward so
+// that keyboard height is computed against the true full-screen height.
+//
+// Bug without this: baseline captured when URL bar is visible (H - 56px).
+// Keyboard opens after URL bar hides → delta = keyboard - 56 px instead of
+// keyboard → toolbar is lifted 56 px too low → keyboard overlaps toolbar.
+
+describe('updateBaseline', () => {
+  it('returns null unchanged when baseline has not yet been captured', () => {
+    // null = focusin has not fired yet; nothing to update
+    expect(updateBaseline(null, 800)).toBeNull()
+  })
+
+  it('returns baseline unchanged when viewport height equals baseline (no change)', () => {
+    expect(updateBaseline(800, 800)).toBe(800)
+  })
+
+  it('returns baseline unchanged when viewport height shrinks (keyboard opening)', () => {
+    // viewport shrinking means keyboard is opening — baseline must NOT follow down
+    expect(updateBaseline(800, 500)).toBe(800)
+  })
+
+  it('updates baseline when viewport grows (URL bar hides before keyboard opens)', () => {
+    // URL bar hides → vv.height grows from 744 to 800; baseline must track up
+    // so keyboard height is computed from the full-screen 800 reference
+    expect(updateBaseline(744, 800)).toBe(800)
+  })
+
+  it('updates baseline for any viewport growth, not just URL-bar-sized jumps', () => {
+    expect(updateBaseline(700, 750)).toBe(750)
+  })
+
+  it('does not update baseline when viewport shrinks by less than threshold', () => {
+    // A 40px shrink is browser chrome collapse, not a keyboard — baseline stays
+    expect(updateBaseline(800, 760)).toBe(800)
   })
 })

--- a/src/hooks/useVirtualKeyboard.js
+++ b/src/hooks/useVirtualKeyboard.js
@@ -19,6 +19,29 @@ export function computeKeyboardHeight(baseline, currentHeight) {
 }
 
 /**
+ * Return an updated baseline, tracking upward when the viewport grows.
+ *
+ * The URL bar on Android Chrome typically hides when the keyboard opens,
+ * which makes visualViewport.height briefly GROW before it shrinks.
+ * If the baseline was captured while the URL bar was visible it will be
+ * smaller than the post-hide height, causing computeKeyboardHeight to
+ * undercount the true keyboard height by ~urlBarHeight (~56 px) and
+ * leaving the toolbar partially covered.
+ *
+ * Fix: any time the viewport grows, update the baseline so it always
+ * reflects the largest "no keyboard" height seen since last focus.
+ *
+ * @param {number|null} baseline — current captured baseline
+ * @param {number} currentHeight — latest visualViewport.height
+ * @returns {number|null} updated baseline
+ */
+export function updateBaseline(baseline, currentHeight) {
+  if (baseline === null || baseline === undefined) return baseline
+  if (currentHeight > baseline) return currentHeight
+  return baseline
+}
+
+/**
  * Imperative keyboard-height tracking for mobile virtual keyboards.
  *
  * Uses window.visualViewport resize events to track keyboard height in real
@@ -118,6 +141,10 @@ export function useVirtualKeyboard({ enabled, toolbarRef, zoomBadgeRef, zoomHint
       // Samsung Internet fallback: documentElement.clientHeight when no visualViewport
       const currentHeight = vv ? vv.height : document.documentElement.clientHeight
 
+      // Self-correcting baseline: if the viewport grew (URL bar hid), track the new
+      // maximum so keyboard height is computed against the true full-screen reference.
+      baselineHeightRef.current = updateBaseline(baselineHeightRef.current, currentHeight)
+
       const kbHeight = computeKeyboardHeight(baselineHeightRef.current, currentHeight)
       keyboardHeightRef.current = kbHeight
       applyPositions(kbHeight)
@@ -179,6 +206,10 @@ export function useVirtualKeyboard({ enabled, toolbarRef, zoomBadgeRef, zoomHint
     const vv = window.visualViewport
     if (vv) {
       vv.addEventListener('resize', scheduleUpdate)
+      // scroll fires when the visual viewport pans (keyboard open + user scrolls).
+      // Re-applying positions on scroll prevents Chrome Android's compositor from
+      // jank-rendering the fixed toolbar at the wrong position mid-scroll.
+      vv.addEventListener('scroll', scheduleUpdate)
     } else {
       // Samsung Internet fallback: no visualViewport, use window.resize instead
       window.addEventListener('resize', scheduleUpdate)
@@ -193,6 +224,7 @@ export function useVirtualKeyboard({ enabled, toolbarRef, zoomBadgeRef, zoomHint
       cancelAnimationFrame(orientationRafId2)
       if (vv) {
         vv.removeEventListener('resize', scheduleUpdate)
+        vv.removeEventListener('scroll', scheduleUpdate)
       } else {
         window.removeEventListener('resize', scheduleUpdate)
       }

--- a/src/styles/responsive.css
+++ b/src/styles/responsive.css
@@ -94,7 +94,9 @@
     padding-bottom: env(safe-area-inset-bottom, 0px);
     flex-direction: column;
     background: var(--surface);
-    transition: bottom var(--duration-medium) var(--ease-out);
+    /* No transition: bottom — useVirtualKeyboard updates style.bottom imperatively
+       on every visualViewport resize/scroll frame. A CSS transition would fight
+       those updates and cause the toolbar to lag behind the keyboard animation. */
   }
 
   .toolbar-core {


### PR DESCRIPTION
## Summary

Follow-up to #124/#125. Three targeted fixes for two real-device bugs: the toolbar being covered by the keyboard on first open, and the toolbar losing its position while scrolling with the keyboard open.

## Root Causes & Changes

### Bug 1 — Keyboard covers toolbar on first open

**Root cause A — URL bar baseline drift** (`src/hooks/useVirtualKeyboard.js`):
The hook captured `baseline = visualViewport.height` at `focusin` time, while Android's URL bar was still visible. When the keyboard opened, the URL bar auto-hid, making `vv.height` briefly grow before shrinking. The computed keyboard height was `keyboard - urlBarHeight` (~56 px short), so the toolbar was lifted 56 px too low and the bottom of the keyboard overlapped the toolbar.

**Fix**: Export and call `updateBaseline(baseline, currentHeight)` inside `computeAndApply`. Any time `currentHeight > baseline` (viewport grew — URL bar hid), the baseline tracks upward, so keyboard height is always measured from the correct full-screen reference.

**Root cause B — CSS `transition: bottom` on `.toolbar`** (`src/styles/responsive.css`):
The transition fought the hook's imperative `style.bottom` updates. On devices where `visualViewport.resize` fires only _after_ the keyboard is fully open (not during the animation), the toolbar didn't start moving until the keyboard was already fully visible and covering it.

**Fix**: Remove `transition: bottom var(--duration-medium)` from `.toolbar`. The hook already updates on every `visualViewport.resize` frame, so no CSS transition is needed.

### Bug 2 — Toolbar drops during scroll with keyboard open

**Root cause** — missing `visualViewport.scroll` listener (`src/hooks/useVirtualKeyboard.js`):
Chrome Android fires `scroll` events (not `resize`) when the user pans content with the keyboard open. The hook only listened to `resize`, so Chrome's compositor rendered the `position: fixed` toolbar at the wrong position during the scroll animation.

**Fix**: Add `vv.addEventListener('scroll', scheduleUpdate)` alongside `resize`. Cleanup wires the corresponding `removeEventListener`.

## Files Changed

| File | Change |
|------|--------|
| `src/hooks/useVirtualKeyboard.js` | Export `updateBaseline`; call it in `computeAndApply`; add `vv.scroll` listener + cleanup |
| `src/styles/responsive.css` | Remove `transition: bottom` from `.toolbar` |
| `src/hooks/__tests__/useVirtualKeyboard.test.js` | 6 new unit tests for `updateBaseline` contract |

## Testing

- **Unit**: 6 new Vitest tests for `updateBaseline` (null passthrough, no-op when equal/shrinking, tracks upward on growth). All 112 unit tests green.
- **E2E**: Existing `e2e/issue-124-keyboard-toolbar.spec.js` viewport-simulation tests cover the lift and dismiss flows. Scroll-during-keyboard behavior requires a real Android device to verify.

## Related Issues

Closes #126 (follow-up to #124)