### PR TITLE
feat: move indent/outdent buttons to collapsed mobile toolbar

### DIFF
--- a/e2e/issue-124-keyboard-toolbar.spec.js
+++ b/e2e/issue-124-keyboard-toolbar.spec.js
@@ -91,6 +91,20 @@ test('bold button works from the mobile toolbar', async ({ page, isMobile }) => 
   expect(hasBold).toBe(true)
 })
 
+test('indent and outdent buttons are visible in collapsed mobile toolbar without expanding', async ({ page, isMobile }) => {
+  test.skip(!isMobile, 'Mobile-only test')
+
+  const hash = `#nb=${seedIds.notebook.id}&sec=${seedIds.section.id}&pg=${seedIds.page.id}`
+  await waitForApp(page, hash, { expectedText: 'Keyboard toolbar test content' })
+
+  // Do NOT click expand toggle — buttons must be reachable in collapsed state
+  const indentBtn = page.getByTestId('toolbar-indent')
+  const outdentBtn = page.getByTestId('toolbar-outdent')
+
+  await expect(indentBtn).toBeVisible()
+  await expect(outdentBtn).toBeVisible()
+})
+
 test('editor-panel reserves space so content is not hidden behind the toolbar', async ({ page, isMobile }) => {
   test.skip(!isMobile, 'Mobile-only test')
 

--- a/src/components/editor/Toolbar.jsx
+++ b/src/components/editor/Toolbar.jsx
@@ -276,6 +276,32 @@ function Toolbar({
           >
             <BulletListIcon />
           </button>
+          {isTouchOnly && (
+            <>
+              <button
+                type="button"
+                className="toolbar-btn"
+                onClick={handleOutdent}
+                disabled={!hasTracker || !isInList}
+                title="Outdent"
+                aria-label="Outdent list item"
+                data-testid="toolbar-outdent"
+              >
+                <OutdentIcon />
+              </button>
+              <button
+                type="button"
+                className="toolbar-btn"
+                onClick={handleIndent}
+                disabled={!hasTracker || !isInList}
+                title="Indent"
+                aria-label="Indent list item"
+                data-testid="toolbar-indent"
+              >
+                <IndentIcon />
+              </button>
+            </>
+          )}
         </div>
 
         {/* Link + Undo group */}
@@ -429,32 +455,6 @@ function Toolbar({
           >
             <TaskListIcon />
           </button>
-          {isTouchOnly && (
-            <>
-              <button
-                type="button"
-                className="toolbar-btn"
-                onClick={handleOutdent}
-                disabled={!hasTracker || !isInList}
-                title="Outdent"
-                aria-label="Outdent list item"
-                data-testid="toolbar-outdent"
-              >
-                <OutdentIcon />
-              </button>
-              <button
-                type="button"
-                className="toolbar-btn"
-                onClick={handleIndent}
-                disabled={!hasTracker || !isInList}
-                title="Indent"
-                aria-label="Indent list item"
-                data-testid="toolbar-indent"
-              >
-                <IndentIcon />
-              </button>
-            </>
-          )}
         </div>
 
         {/* Alignment */}


### PR DESCRIPTION
## Summary

Indent and outdent buttons were only reachable after tapping the expand toggle on the mobile toolbar. This PR moves both buttons into the always-visible collapsed toolbar (`.toolbar-core`) so they are a single tap away during list editing.

## Changes

- **`src/components/editor/Toolbar.jsx`**: Added Outdent + Indent buttons to `.toolbar-core` Group 1 (after BulletList, guarded by `isTouchOnly`). Removed the now-redundant `{isTouchOnly && ...}` block from `.toolbar-extra`.
- **`e2e/issue-124-keyboard-toolbar.spec.js`**: New Mobile Chrome test asserting both buttons are visible in the collapsed toolbar without tapping the expand toggle.

## Files Changed

| File | Change |
|------|--------|
| `src/components/editor/Toolbar.jsx` | Modified |
| `e2e/issue-124-keyboard-toolbar.spec.js` | Modified |

## Testing

- All 102 unit tests pass (`npm run test:unit`).
- New E2E test: `indent and outdent buttons are visible in collapsed mobile toolbar without expanding` — runs on Mobile Chrome project in CI.
- Desktop toolbar unchanged (block is gated by `isTouchOnly`).
- No duplicate buttons when expanded (removed from `.toolbar-extra`).

## Related Issues

None