### PR TITLE
feat: eagerly load all sections so expanding any notebook shows its children immediately

### DIFF
--- a/e2e/notebook-section-hydration.spec.js
+++ b/e2e/notebook-section-hydration.spec.js
@@ -1,0 +1,111 @@
+/**
+ * Verifies that expanding a non-active notebook immediately shows its sections
+ * without requiring the user to click/select that notebook first.
+ *
+ * Before the fix, expanding a non-active notebook showed:
+ *   "Select notebook to load sections."
+ * After the fix, all sections are loaded eagerly and filtered client-side,
+ * so any expanded notebook shows its children right away.
+ */
+import { test, expect } from './fixtures'
+import {
+  clickNavigationItem,
+  createNotebook,
+  createPage,
+  createSection,
+  deleteNotebookById,
+  ensureNavigationVisible,
+  getSupabase,
+  waitForApp,
+} from './test-helpers'
+
+test.describe('notebook section hydration', () => {
+  let notebookA = null
+  let notebookB = null
+  let sectionA = null
+  let sectionB1 = null
+  let sectionB2 = null
+  let pageA = null
+
+  test.beforeAll(async () => {
+    const { client, userId } = await getSupabase()
+
+    notebookA = await createNotebook(client, userId, `Hydration NbA ${Date.now()}`, -9998)
+    notebookB = await createNotebook(client, userId, `Hydration NbB ${Date.now()}`, -9997)
+
+    sectionA = await createSection(client, userId, notebookA.id, 'Section A-One', 0)
+    sectionB1 = await createSection(client, userId, notebookB.id, 'Section B-One', 0)
+    sectionB2 = await createSection(client, userId, notebookB.id, 'Section B-Two', 1)
+
+    pageA = await createPage(client, userId, sectionA.id, 'Page A-One', {
+      type: 'doc',
+      content: [{ type: 'paragraph', content: [{ type: 'text', text: 'Page A content' }] }],
+    })
+  })
+
+  test.afterAll(async () => {
+    const { client } = await getSupabase()
+    await deleteNotebookById(client, notebookA?.id)
+    await deleteNotebookById(client, notebookB?.id)
+  })
+
+  const chevronFor = (page, label) =>
+    page.locator('.tree-node', { hasText: label }).locator('.tree-chevron').first()
+
+  const rowFor = (page, label) =>
+    page.locator('.tree-node', { hasText: label }).first()
+
+  test('expanding a non-active notebook immediately shows its sections', async ({ page }) => {
+    // Start in notebook A so A is the active notebook
+    await waitForApp(page, `#nb=${notebookA.id}&sec=${sectionA.id}&pg=${pageA.id}`)
+    await ensureNavigationVisible(page)
+
+    // Notebook A is active and expanded — its section should be visible
+    await expect(rowFor(page, notebookA.title)).toHaveClass(/active/)
+    await expect(page.locator('.tree-node', { hasText: 'Section A-One' })).toBeVisible()
+
+    // Notebook B is NOT active. Expand it via its chevron only (do not click the row).
+    await clickNavigationItem(page, chevronFor(page, notebookB.title))
+    await expect(rowFor(page, notebookB.title)).toHaveAttribute('aria-expanded', 'true')
+
+    // Notebook A should still be active (we didn't select B)
+    await expect(rowFor(page, notebookA.title)).toHaveClass(/active/)
+
+    // Sections of notebook B should be immediately visible — no select-to-load gate
+    await expect(page.locator('.tree-node', { hasText: 'Section B-One' })).toBeVisible()
+    await expect(page.locator('.tree-node', { hasText: 'Section B-Two' })).toBeVisible()
+
+    // The stale "select notebook" prompt must not appear anywhere
+    await expect(page.locator('text=Select notebook to load sections')).toHaveCount(0)
+  })
+
+  test('clicking a non-active notebook switches active section to its first section', async ({ page }) => {
+    await waitForApp(page, `#nb=${notebookA.id}&sec=${sectionA.id}&pg=${pageA.id}`)
+    await ensureNavigationVisible(page)
+
+    // Click notebook B row to select it (not just expand)
+    await clickNavigationItem(page, rowFor(page, notebookB.title))
+
+    // Notebook B is now active
+    await expect(rowFor(page, notebookB.title)).toHaveClass(/active/)
+
+    // Its first section should become active automatically
+    await expect(rowFor(page, 'Section B-One')).toHaveClass(/active/)
+  })
+
+  test('switching back to a previously-active notebook retains its section state', async ({ page }) => {
+    await waitForApp(page, `#nb=${notebookA.id}&sec=${sectionA.id}&pg=${pageA.id}`)
+    await ensureNavigationVisible(page)
+
+    // Switch to notebook B
+    await clickNavigationItem(page, rowFor(page, notebookB.title))
+    await expect(rowFor(page, notebookB.title)).toHaveClass(/active/)
+
+    // Switch back to notebook A
+    await clickNavigationItem(page, rowFor(page, notebookA.title))
+    await expect(rowFor(page, notebookA.title)).toHaveClass(/active/)
+
+    // Section A-One should still be visible in A's tree
+    await expect(page.locator('.tree-node', { hasText: 'Section A-One' })).toBeVisible()
+  })
+})

--- a/src/components/app/NavigationTree.jsx
+++ b/src/components/app/NavigationTree.jsx
@@ -239,6 +239,7 @@ function NavigationTree({
           {notebooks.map((notebook) => {
             const notebookActive = notebook.id === activeNotebookId
             const notebookExpanded = expandedNotebooks.has(notebook.id)
+            const notebookSections = sections.filter((s) => s.notebook_id === notebook.id)
 
             return (
               <div key={notebook.id} className="tree-branch">
@@ -266,12 +267,10 @@ function NavigationTree({
 
                 {notebookExpanded ? (
                   <div className="tree-children tree-children-sections" role="group">
-                    {!notebookActive ? (
-                      <p className="subtle tree-empty">Select notebook to load sections.</p>
-                    ) : sections.length === 0 ? (
+                    {notebookSections.length === 0 ? (
                       <p className="subtle tree-empty">No sections yet.</p>
                     ) : (
-                      sections.map((section) => {
+                      notebookSections.map((section) => {
                         const sectionActive = section.id === activeSectionId
                         const sectionExpanded = expandedSections.has(section.id)
 

--- a/src/hooks/useSections.js
+++ b/src/hooks/useSections.js
@@ -116,64 +116,65 @@ export const useSections = (userId, activeNotebookId, pendingNavRef, savedSelect
   const [message, setMessage] = useState('')
   const loadRequestIdRef = useRef(0)
 
-  const loadSections = useCallback(
-    async (notebookId) => {
-      if (!userId || !notebookId) return
-      const requestId = ++loadRequestIdRef.current
-      setSectionsLoading(true)
-      setMessage('')
-      const { data, error } = await runSupabaseQueryWithRetry(() =>
-        supabase
-          .from('sections')
-          .select('id, title, color, sort_order, created_at, updated_at')
-          .eq('notebook_id', notebookId)
-          .order('sort_order', { ascending: true, nullsFirst: true })
-          .order('created_at', { ascending: true }),
-      )
+  const loadSections = useCallback(async () => {
+    if (!userId) return
+    const requestId = ++loadRequestIdRef.current
+    setSectionsLoading(true)
+    setMessage('')
+    const { data, error } = await runSupabaseQueryWithRetry(() =>
+      supabase
+        .from('sections')
+        .select('id, title, color, sort_order, notebook_id, created_at, updated_at')
+        .order('sort_order', { ascending: true, nullsFirst: true })
+        .order('created_at', { ascending: true }),
+    )
 
-      if (loadRequestIdRef.current !== requestId) return
+    if (loadRequestIdRef.current !== requestId) return
 
-      if (error) {
-        setMessage(error.message)
-        setSectionsLoading(false)
-        return
-      }
-
-      setSections(data ?? [])
-      const pending = pendingNavRef?.current
-      const saved = savedSelectionRef?.current
-      if (pending?.sectionId && data?.some((item) => item.id === pending.sectionId)) {
-        setActiveSectionId(pending.sectionId)
-      } else {
-        setActiveSectionId((prev) => {
-          if (prev && data?.some((item) => item.id === prev)) return prev
-          if (saved?.sectionId && data?.some((item) => item.id === saved.sectionId)) {
-            return saved.sectionId
-          }
-          return data?.[0]?.id ?? null
-        })
-      }
+    if (error) {
+      setMessage(error.message)
       setSectionsLoading(false)
-    },
-    [userId, pendingNavRef, savedSelectionRef],
-  )
+      return
+    }
 
+    setSections(data ?? [])
+    setSectionsLoading(false)
+  }, [userId])
+
+  // Load all sections once on login; clear on logout
   useEffect(() => {
-    const timer = window.setTimeout(() => {
-      if (!userId || !activeNotebookId) {
-        loadRequestIdRef.current += 1
-        setSections([])
-        setActiveSectionId(null)
-        setSectionsLoading(false)
-        setMessage('')
-        return
-      }
+    if (!userId) {
+      loadRequestIdRef.current += 1
       setSections([])
       setActiveSectionId(null)
-      void loadSections(activeNotebookId)
-    }, 0)
-    return () => window.clearTimeout(timer)
-  }, [userId, activeNotebookId, loadSections])
+      setSectionsLoading(false)
+      setMessage('')
+      return
+    }
+    void loadSections()
+  }, [userId, loadSections])
+
+  // When the active notebook changes, pick the right section from already-loaded data
+  useEffect(() => {
+    if (!activeNotebookId) {
+      setActiveSectionId(null)
+      return
+    }
+    const notebookSections = sections.filter((s) => s.notebook_id === activeNotebookId)
+    const pending = pendingNavRef?.current
+    const saved = savedSelectionRef?.current
+    if (pending?.sectionId && notebookSections.some((s) => s.id === pending.sectionId)) {
+      setActiveSectionId(pending.sectionId)
+    } else {
+      setActiveSectionId((prev) => {
+        if (prev && notebookSections.some((s) => s.id === prev)) return prev
+        if (saved?.sectionId && notebookSections.some((s) => s.id === saved.sectionId)) {
+          return saved.sectionId
+        }
+        return notebookSections[0]?.id ?? null
+      })
+    }
+  }, [activeNotebookId, sections, pendingNavRef, savedSelectionRef])
 
   const createSection = async (session, notebookId) => {
     if (!session || !notebookId) return
@@ -257,7 +258,8 @@ export const useSections = (userId, activeNotebookId, pendingNavRef, savedSelect
     clearNavHierarchyCache()
     const nextSections = sections.filter((item) => item.id !== section.id)
     setSections(nextSections)
-    setActiveSectionId((prev) => (prev === section.id ? nextSections[0]?.id ?? null : prev))
+    const notebookSections = nextSections.filter((s) => s.notebook_id === activeNotebookId)
+    setActiveSectionId((prev) => (prev === section.id ? notebookSections[0]?.id ?? null : prev))
   }
 
   const moveSection = async (section, destNotebookId) => {
@@ -273,7 +275,11 @@ export const useSections = (userId, activeNotebookId, pendingNavRef, savedSelect
     }
 
     clearNavHierarchyCache()
-    setSections((prev) => prev.filter((item) => item.id !== section.id))
+    setSections((prev) =>
+      prev.map((item) =>
+        item.id === section.id ? { ...item, notebook_id: destNotebookId } : item,
+      ),
+    )
     return true
   }
 
@@ -440,10 +446,8 @@ export const useSections = (userId, activeNotebookId, pendingNavRef, savedSelect
       }
     }
 
-    // Show the new section only after all pages and content are fully copied
-    if (destNotebookId === activeNotebookId) {
-      setSections((prev) => [...prev, newSection])
-    }
+    // Add the new section after all pages and content are fully copied
+    setSections((prev) => [...prev, newSection])
   }
 
   const activeSection = sections.find((section) => section.id === activeSectionId) ?? null


### PR DESCRIPTION
## Summary

Fixes the UX where expanding a non-active notebook showed "Select notebook to load sections." instead of immediately displaying that notebook's sections. All sections are now fetched in a single query at login and filtered client-side per notebook in the tree — the same pattern used by Docmost and Notesnook.

## Changes

**`src/hooks/useSections.js`**
- `loadSections` now fetches all user sections (no `notebook_id` filter; RLS scopes to user) and adds `notebook_id` to the select fields
- Single load on login replaces the per-active-notebook fetch on each notebook switch
- Active-section selection split into its own `[activeNotebookId, sections]` effect so it resolves client-side without a network round-trip on every notebook click
- `deleteSection` fallback active-section now filters to the active notebook (was: `nextSections[0]` which could pick a section from a different notebook)
- `moveSection` updates `notebook_id` in local state instead of removing the row (previously relied on section reload on notebook switch)
- `copySection` always appends the new section to state instead of only when `destNotebook === activeNotebook`

**`src/components/app/NavigationTree.jsx`**
- Computes `notebookSections` per notebook via `sections.filter(s => s.notebook_id === notebook.id)`
- Removes the `!notebookActive` gate and "Select notebook to load sections." message entirely
- Each notebook renders its own filtered sections regardless of which notebook is active

**`e2e/notebook-section-hydration.spec.js`** *(new)*
- Verifies expanding a non-active notebook immediately shows its sections
- Verifies clicking a non-active notebook auto-selects its first section
- Verifies switching back to a previously-active notebook still shows its sections

## Files Changed

| File | Change |
|---|---|
| `src/hooks/useSections.js` | Modified — eager load, split effects, mutation fixes |
| `src/components/app/NavigationTree.jsx` | Modified — per-notebook section filter, gate removed |
| `e2e/notebook-section-hydration.spec.js` | Added — E2E coverage for new behavior |

## Testing

- 129 unit tests pass (`npm run test:unit`)
- Production build clean (`npm run build`)
- E2E spec added for CI validation (skipped locally per project convention)

## Related Issues

None