### PR TITLE
fix: lazy-per-section page cache so expanding any section shows its pages immediately

### DIFF
--- a/e2e/notebook-section-hydration.spec.js
+++ b/e2e/notebook-section-hydration.spec.js
@@ -26,6 +26,8 @@ test.describe('notebook section hydration', () => {
   let sectionB1 = null
   let sectionB2 = null
   let pageA = null
+  let pageB1 = null
+  let pageB2 = null
 
   test.beforeAll(async () => {
     const { client, userId } = await getSupabase()
@@ -40,6 +42,14 @@ test.describe('notebook section hydration', () => {
     pageA = await createPage(client, userId, sectionA.id, 'Page A-One', {
       type: 'doc',
       content: [{ type: 'paragraph', content: [{ type: 'text', text: 'Page A content' }] }],
+    })
+    pageB1 = await createPage(client, userId, sectionB1.id, 'Page B-One', {
+      type: 'doc',
+      content: [{ type: 'paragraph', content: [{ type: 'text', text: 'Page B1 content' }] }],
+    })
+    pageB2 = await createPage(client, userId, sectionB2.id, 'Page B-Two', {
+      type: 'doc',
+      content: [{ type: 'paragraph', content: [{ type: 'text', text: 'Page B2 content' }] }],
     })
   })
 
@@ -107,5 +117,48 @@ test.describe('notebook section hydration', () => {
 
     // Section A-One should still be visible in A's tree
     await expect(page.locator('.tree-node', { hasText: 'Section A-One' })).toBeVisible()
+  })
+
+  test('expanding a section in a non-active notebook immediately shows its pages', async ({ page }) => {
+    // Start in notebook A — A is active, B is non-active
+    await waitForApp(page, `#nb=${notebookA.id}&sec=${sectionA.id}&pg=${pageA.id}`)
+    await ensureNavigationVisible(page)
+
+    // Expand notebook B via chevron only (do not select it)
+    await clickNavigationItem(page, chevronFor(page, notebookB.title))
+    await expect(rowFor(page, notebookB.title)).toHaveAttribute('aria-expanded', 'true')
+    await expect(page.locator('.tree-node', { hasText: 'Section B-One' })).toBeVisible()
+
+    // Expand section B-One via its chevron only (do not select it)
+    await clickNavigationItem(page, chevronFor(page, 'Section B-One'))
+
+    // Page B-One must be visible
+    await expect(
+      page.locator('.tree-node-page', { hasText: pageB1.title }),
+    ).toBeVisible({ timeout: 8000 })
+
+    // Active state must not have changed
+    await expect(rowFor(page, notebookA.title)).toHaveClass(/active/)
+    await expect(page.locator('.tree-node-section', { hasText: 'Section B-One' })).not.toHaveClass(/active/)
+  })
+
+  test('expanding a non-active section within the active notebook shows its pages without selecting it', async ({ page }) => {
+    // Start in notebook B with section B-Two active
+    await waitForApp(page, `#nb=${notebookB.id}&sec=${sectionB2.id}&pg=${pageB2.id}`)
+    await ensureNavigationVisible(page)
+
+    await expect(page.locator('.tree-node-section', { hasText: 'Section B-Two' })).toHaveClass(/active/)
+
+    // Expand section B-One via its chevron only (do not click the section row)
+    await clickNavigationItem(page, chevronFor(page, 'Section B-One'))
+
+    // Page B-One must be visible
+    await expect(
+      page.locator('.tree-node-page', { hasText: pageB1.title }),
+    ).toBeVisible({ timeout: 8000 })
+
+    // Section B-Two must still be active
+    await expect(page.locator('.tree-node-section', { hasText: 'Section B-Two' })).toHaveClass(/active/)
+    await expect(page.locator('.tree-node-section', { hasText: 'Section B-One' })).not.toHaveClass(/active/)
   })
 })

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -151,6 +151,8 @@ function App() {
 
   const {
     trackers,
+    pagesBySection,
+    loadSectionPagesMeta,
     activeTrackerId,
     setActiveTrackerId,
     activeTracker,
@@ -711,6 +713,7 @@ function App() {
           notebooks={notebooks}
           sections={sections}
           trackers={trackers}
+          pagesBySection={pagesBySection}
           activeNotebookId={activeNotebookId}
           activeSectionId={activeSectionId}
           activeTrackerId={activeTrackerId}
@@ -726,6 +729,7 @@ function App() {
           onCreatePage={() => createTracker(session, activeSectionId)}
           onReorderPages={reorderTrackers}
           onOpenContextMenu={handleOpenTreeContextMenu}
+          onLoadSectionPages={loadSectionPagesMeta}
           onCreateWithContent={(title, content) =>
             createTrackerWithContent(session, activeSectionId, title, content)
           }

--- a/src/components/app/NavigationTree.jsx
+++ b/src/components/app/NavigationTree.jsx
@@ -281,6 +281,11 @@ function NavigationTree({
                       notebookSections.map((section) => {
                         const sectionActive = section.id === activeSectionId
                         const sectionExpanded = expandedSections.has(section.id)
+                        const sectionPages = sectionActive
+                          ? trackers
+                          : getSectionPages(pagesBySection, section.id)
+                        const pagesLoading = (sectionActive && loading) ||
+                          (!sectionActive && pagesBySection[section.id] === null)
 
                         return (
                           <div key={section.id} className="tree-branch">
@@ -311,14 +316,9 @@ function NavigationTree({
                               <span className="tree-label sidebar-title">{section.title}</span>
                             </button>
 
-                            {sectionExpanded ? (() => {
-                              const sectionPages = sectionActive
-                                ? trackers
-                                : getSectionPages(pagesBySection, section.id)
-                              const metaLoading = !sectionActive && pagesBySection[section.id] === null
-                              return (
+                            {sectionExpanded ? (
                               <div className="tree-children tree-children-pages" role="group">
-                                {sectionActive && loading || metaLoading ? (
+                                {pagesLoading ? (
                                   <p className="subtle tree-empty">Loading pages...</p>
                                 ) : sectionPages.length === 0 ? (
                                   <p className="subtle tree-empty">No pages yet.</p>
@@ -362,8 +362,7 @@ function NavigationTree({
                                   ))
                                 )}
                               </div>
-                              )
-                            })() : null}
+                            ) : null}
                           </div>
                         )
                       })

--- a/src/components/app/NavigationTree.jsx
+++ b/src/components/app/NavigationTree.jsx
@@ -4,12 +4,14 @@ import StarterKit from '@tiptap/starter-kit'
 import { supabase } from '../../lib/supabase'
 import { resizeAndEncode } from '../../utils/imageResize'
 import PasteRecipeModal from '../editor/PasteRecipeModal'
+import { getSectionPages } from '../../utils/sectionPages'
 
 function NavigationTree({
   className = '',
   notebooks,
   sections,
   trackers,
+  pagesBySection = {},
   activeNotebookId,
   activeSectionId,
   activeTrackerId,
@@ -25,6 +27,7 @@ function NavigationTree({
   onCreatePage,
   onReorderPages,
   onOpenContextMenu,
+  onLoadSectionPages,
   onCreateWithContent,
 }) {
   const dragIdRef = useRef(null)
@@ -55,8 +58,12 @@ function NavigationTree({
   const toggleSection = (id) => {
     setExpandedSections((prev) => {
       const next = new Set(prev)
-      if (next.has(id)) next.delete(id)
-      else next.add(id)
+      if (next.has(id)) {
+        next.delete(id)
+      } else {
+        next.add(id)
+        onLoadSectionPages?.(id)
+      }
       return next
     })
   }
@@ -68,6 +75,7 @@ function NavigationTree({
 
   const handleSelectSection = (id) => {
     setExpandedSections((prev) => new Set(prev).add(id))
+    onLoadSectionPages?.(id)
     onSelectSection?.(id)
   }
 
@@ -303,22 +311,27 @@ function NavigationTree({
                               <span className="tree-label sidebar-title">{section.title}</span>
                             </button>
 
-                            {sectionExpanded && sectionActive ? (
+                            {sectionExpanded ? (() => {
+                              const sectionPages = sectionActive
+                                ? trackers
+                                : getSectionPages(pagesBySection, section.id)
+                              const metaLoading = !sectionActive && pagesBySection[section.id] === null
+                              return (
                               <div className="tree-children tree-children-pages" role="group">
-                                {loading ? (
+                                {sectionActive && loading || metaLoading ? (
                                   <p className="subtle tree-empty">Loading pages...</p>
-                                ) : trackers.length === 0 ? (
+                                ) : sectionPages.length === 0 ? (
                                   <p className="subtle tree-empty">No pages yet.</p>
                                 ) : (
-                                  trackers.map((tracker) => (
+                                  sectionPages.map((tracker) => (
                                     <div
                                       key={tracker.id}
                                       className={`tree-page-row ${overId === tracker.id ? 'drag-over' : ''}`}
-                                      draggable={!loading}
-                                      onDragStart={handleDragStart(tracker.id)}
-                                      onDragOver={handleDragOver(tracker.id)}
-                                      onDrop={handleDrop(tracker.id)}
-                                      onDragEnd={handleDragEnd}
+                                      draggable={sectionActive && !loading}
+                                      onDragStart={sectionActive ? handleDragStart(tracker.id) : undefined}
+                                      onDragOver={sectionActive ? handleDragOver(tracker.id) : undefined}
+                                      onDrop={sectionActive ? handleDrop(tracker.id) : undefined}
+                                      onDragEnd={sectionActive ? handleDragEnd : undefined}
                                     >
                                       <button
                                         type="button"
@@ -349,7 +362,8 @@ function NavigationTree({
                                   ))
                                 )}
                               </div>
-                            ) : null}
+                              )
+                            })() : null}
                           </div>
                         )
                       })

--- a/src/hooks/useTrackers.js
+++ b/src/hooks/useTrackers.js
@@ -10,6 +10,7 @@ import { runSupabaseQueryWithRetry } from '../utils/supabaseRetry'
 
 export const useTrackers = (userId, activeSectionId, pendingNavRef, savedSelectionRef) => {
   const [trackers, setTrackers] = useState([])
+  const [pagesBySection, setPagesBySection] = useState({})
   const [activeTrackerId, setActiveTrackerId] = useState(null)
   const [dataLoading, setDataLoading] = useState(false)
   const [trackerPageSaving, setTrackerPageSaving] = useState(false)
@@ -93,6 +94,7 @@ export const useTrackers = (userId, activeSectionId, pendingNavRef, savedSelecti
   useEffect(() => {
     if (userId) return
     setTrackers([])
+    setPagesBySection({})
     setActiveTrackerId(null)
     setDataLoading(false)
     setTrackerPageSaving(false)
@@ -109,6 +111,57 @@ export const useTrackers = (userId, activeSectionId, pendingNavRef, savedSelecti
     draftWriteTimersByTrackerRef.current = {}
     latestDraftKeyByTrackerRef.current = {}
   }, [userId])
+
+  // Fetch light page metadata (no content) for a section on first expand.
+  // Results are cached in pagesBySection so subsequent expands are instant.
+  const loadSectionPagesMeta = useCallback(async (sectionId) => {
+    if (!userId || !sectionId) return
+    setPagesBySection((prev) => {
+      if (prev[sectionId]) return prev
+      return prev
+    })
+    // Check synchronously whether we already have data for this section.
+    // We can't read state inside a callback reliably, so we set a sentinel
+    // and let the updater decide.
+    setPagesBySection((prev) => {
+      if (prev[sectionId] !== undefined) return prev
+      // Mark as loading with null so a second call before the fetch
+      // completes does not fire a duplicate request.
+      return { ...prev, [sectionId]: null }
+    })
+  }, [userId])
+
+  // Perform the actual fetch whenever pagesBySection gains a null sentinel.
+  useEffect(() => {
+    const pending = Object.entries(pagesBySection)
+      .filter(([, v]) => v === null)
+      .map(([id]) => id)
+
+    if (pending.length === 0 || !userId) return
+
+    const fetchMeta = async (sectionId) => {
+      const { data, error } = await runSupabaseQueryWithRetry(() =>
+        supabase
+          .from('pages')
+          .select('id, title, section_id, sort_order, is_tracker_page')
+          .eq('section_id', sectionId)
+          .order('sort_order', { ascending: true, nullsLast: true }),
+      )
+      if (error) {
+        setPagesBySection((prev) => {
+          const next = { ...prev }
+          delete next[sectionId]
+          return next
+        })
+        return
+      }
+      setPagesBySection((prev) => ({ ...prev, [sectionId]: data ?? [] }))
+    }
+
+    for (const sectionId of pending) {
+      fetchMeta(sectionId)
+    }
+  }, [pagesBySection, userId])
 
   // Immediately write any debounced localStorage drafts for all trackers.
   const flushAllPendingDrafts = useCallback(() => {
@@ -245,6 +298,17 @@ export const useTrackers = (userId, activeSectionId, pendingNavRef, savedSelecti
       setTrackers((prev) =>
         prev.map((item) => (item.id === trackerId ? { ...item, ...payload } : item)),
       )
+      if (typeof payload.title === 'string') {
+        setPagesBySection((prev) => {
+          const sectionId = trackersRef.current.find((t) => t.id === trackerId)?.section_id
+          const existing = sectionId ? prev[sectionId] : null
+          if (!existing) return prev
+          return {
+            ...prev,
+            [sectionId]: existing.map((p) => (p.id === trackerId ? { ...p, title: payload.title } : p)),
+          }
+        })
+      }
 
       if (trackerId === activeTrackerRef.current?.id) {
         setSaveStatus('Saved')
@@ -466,6 +530,12 @@ export const useTrackers = (userId, activeSectionId, pendingNavRef, savedSelecti
     }
 
     setTrackers((prev) => [...prev, { ...data, sort_order: nextSortOrder }])
+    setPagesBySection((prev) => {
+      const existing = prev[sectionId]
+      if (existing === undefined || existing === null) return prev
+      const meta = { id: data.id, title: data.title, section_id: sectionId, sort_order: nextSortOrder, is_tracker_page: false }
+      return { ...prev, [sectionId]: [...existing, meta] }
+    })
     setActiveTrackerId(data.id)
   }
 
@@ -496,6 +566,12 @@ export const useTrackers = (userId, activeSectionId, pendingNavRef, savedSelecti
     }
 
     setTrackers((prev) => [...prev, { ...data, sort_order: nextSortOrder }])
+    setPagesBySection((prev) => {
+      const existing = prev[sectionId]
+      if (existing === undefined || existing === null) return prev
+      const meta = { id: data.id, title: pageTitle, section_id: sectionId, sort_order: nextSortOrder, is_tracker_page: false }
+      return { ...prev, [sectionId]: [...existing, meta] }
+    })
     setActiveTrackerId(data.id)
     return data
   }
@@ -508,6 +584,14 @@ export const useTrackers = (userId, activeSectionId, pendingNavRef, savedSelecti
         sort_order: index + 1,
       }))
       setTrackers(reordered)
+      setPagesBySection((prev) => {
+        if (!activeSectionId || !prev[activeSectionId]) return prev
+        const orderMap = Object.fromEntries(reordered.map((item) => [item.id, item.sort_order]))
+        const updated = prev[activeSectionId].map((p) =>
+          orderMap[p.id] !== undefined ? { ...p, sort_order: orderMap[p.id] } : p,
+        )
+        return { ...prev, [activeSectionId]: updated }
+      })
       const updates = reordered.map((item) =>
         supabase.from('pages').update({ sort_order: item.sort_order }).eq('id', item.id),
       )
@@ -517,7 +601,7 @@ export const useTrackers = (userId, activeSectionId, pendingNavRef, savedSelecti
         setMessage(error.message)
       }
     },
-    [userId],
+    [userId, activeSectionId],
   )
 
   const setTrackerPage = useCallback(
@@ -535,6 +619,12 @@ export const useTrackers = (userId, activeSectionId, pendingNavRef, savedSelecti
           is_tracker_page: item.id === pageId,
         })),
       )
+      setPagesBySection((prev) => {
+        const existing = prev[activeSectionId]
+        if (!existing) return prev
+        const updated = existing.map((p) => ({ ...p, is_tracker_page: p.id === pageId }))
+        return { ...prev, [activeSectionId]: updated }
+      })
 
       const { error: clearError } = await supabase
         .from('pages')
@@ -604,6 +694,12 @@ export const useTrackers = (userId, activeSectionId, pendingNavRef, savedSelecti
     clearNavHierarchyCache()
     const nextTrackers = trackers.filter((item) => item.id !== tracker.id)
     setTrackers(nextTrackers)
+    setPagesBySection((prev) => {
+      const sectionId = tracker.section_id ?? activeSectionId
+      const existing = prev[sectionId]
+      if (!existing) return prev
+      return { ...prev, [sectionId]: existing.filter((p) => p.id !== tracker.id) }
+    })
     delete pendingTitleByTrackerRef.current[tracker.id]
     clearPageDraft(tracker.id)
     setActiveTrackerId((prev) => (prev === tracker.id ? nextTrackers[0]?.id ?? null : prev))
@@ -629,6 +725,8 @@ export const useTrackers = (userId, activeSectionId, pendingNavRef, savedSelecti
 
   return {
     trackers,
+    pagesBySection,
+    loadSectionPagesMeta,
     activeTrackerId,
     setActiveTrackerId,
     activeTracker,

--- a/src/utils/__tests__/sectionPages.test.js
+++ b/src/utils/__tests__/sectionPages.test.js
@@ -1,0 +1,53 @@
+import { describe, it, expect } from 'vitest'
+import { getSectionPages } from '../sectionPages'
+
+const makePages = () => [
+  { id: 'p1', title: 'Alpha', section_id: 's1', sort_order: 2, is_tracker_page: false },
+  { id: 'p2', title: 'Beta',  section_id: 's1', sort_order: 1, is_tracker_page: false },
+  { id: 'p3', title: 'Gamma', section_id: 's2', sort_order: 1, is_tracker_page: true },
+]
+
+describe('getSectionPages', () => {
+  it('returns pages for a known section sorted ascending by sort_order', () => {
+    const pagesBySection = { s1: [makePages()[0], makePages()[1]] }
+    const result = getSectionPages(pagesBySection, 's1')
+    expect(result.map((p) => p.id)).toEqual(['p2', 'p1'])
+  })
+
+  it('returns an empty array for an unknown section', () => {
+    expect(getSectionPages({ s1: [] }, 'unknown')).toEqual([])
+  })
+
+  it('returns an empty array when pagesBySection is an empty object', () => {
+    expect(getSectionPages({}, 's1')).toEqual([])
+  })
+
+  it('returns a single page without error', () => {
+    const pagesBySection = { s2: [makePages()[2]] }
+    const result = getSectionPages(pagesBySection, 's2')
+    expect(result).toHaveLength(1)
+    expect(result[0].id).toBe('p3')
+  })
+
+  it('sorts null sort_order to the end', () => {
+    const pagesBySection = {
+      s1: [
+        { id: 'pA', sort_order: null },
+        { id: 'pB', sort_order: 1 },
+        { id: 'pC', sort_order: 3 },
+      ],
+    }
+    const result = getSectionPages(pagesBySection, 's1')
+    expect(result.map((p) => p.id)).toEqual(['pB', 'pC', 'pA'])
+  })
+
+  it('does not mutate the source array', () => {
+    const source = [
+      { id: 'p2', sort_order: 2 },
+      { id: 'p1', sort_order: 1 },
+    ]
+    const pagesBySection = { s1: source }
+    getSectionPages(pagesBySection, 's1')
+    expect(source[0].id).toBe('p2')
+  })
+})

--- a/src/utils/sectionPages.js
+++ b/src/utils/sectionPages.js
@@ -1,0 +1,17 @@
+/**
+ * Returns a sorted copy of the pages cached for a given section.
+ * Pages with a null/undefined sort_order sort to the end.
+ *
+ * @param {Record<string, Array>} pagesBySection - keyed by section ID
+ * @param {string} sectionId
+ * @returns {Array}
+ */
+export function getSectionPages(pagesBySection, sectionId) {
+  const pages = pagesBySection[sectionId]
+  if (!pages || pages.length === 0) return []
+  return [...pages].sort((a, b) => {
+    const aOrder = a.sort_order ?? Infinity
+    const bOrder = b.sort_order ?? Infinity
+    return aOrder - bOrder
+  })
+}


### PR DESCRIPTION
## Summary

Fixes a regression from #135 where expanding a section's chevron never showed its pages. Only the active section ever rendered pages; any other section's expand was a no-op because the render was gated on `sectionActive` and `trackers` only held pages for the active section.

## Root Cause

Two compounding bugs (diagnosed against Notesnook and Docmost reference implementations):

1. **`NavigationTree.jsx` line 306** — pages block rendered only when `sectionExpanded && sectionActive`. Clicking the chevron (`toggleSection`) stops propagation, so the section gained `expanded` but never gained `active`.
2. **`useTrackers.js`** — `trackers` is fetched with `.eq('section_id', activeSectionId)` — it only contains pages for the currently active section. Even removing the `sectionActive` gate would show "No pages yet" for every other section.

## Fix

Implements the **lazy-per-section cache** pattern used by both Notesnook and Docmost: fetch light page metadata (no `content`) per section on first chevron expand, cache by `sectionId`. Content remains lazy — only loaded when a page becomes active (editor).

## Changes

**`src/utils/sectionPages.js`** _(new)_
- `getSectionPages(pagesBySection, sectionId)` — pure helper; filters and sorts cached pages for a section; returns `[]` for unknown sections

**`src/hooks/useTrackers.js`**
- Add `pagesBySection` state — `Record<sectionId, Page[] | null>`, where `null` is the in-flight sentinel
- Add `loadSectionPagesMeta(sectionId)` — sets sentinel then an effect performs the fetch via `runSupabaseQueryWithRetry`; second call before fetch completes is a no-op (sentinel already set)
- Patch all mutation paths to keep `pagesBySection` in sync: `createTracker`, `createTrackerWithContent`, `deleteTracker`, `reorderTrackers`, `setTrackerPage`, `flushSaveForTracker` (title saves)
- `pagesBySection` and `loadSectionPagesMeta` added to return object

**`src/components/app/NavigationTree.jsx`**
- Accept `pagesBySection` and `onLoadSectionPages` props
- `toggleSection` — calls `onLoadSectionPages(id)` when expanding (lazy fetch trigger)
- `handleSelectSection` — also calls `onLoadSectionPages(id)` (so clicking a section row pre-warms its cache)
- Removed `&& sectionActive` gate on the pages block
- Derive `sectionPages` = `trackers` (active) or `getSectionPages(pagesBySection, section.id)` (non-active)
- `pagesLoading` = `sectionActive && loading` OR `!sectionActive && pagesBySection[section.id] === null`
- DnD (`draggable`, `onDragStart`, `onDragOver`, `onDrop`, `onDragEnd`) scoped to active section only — `handleDrop` closes over `trackers` so cross-section drops would reorder the wrong list

**`src/App.jsx`**
- Destructure `pagesBySection` and `loadSectionPagesMeta` from `useTrackers`
- Pass as `pagesBySection` and `onLoadSectionPages` to `<NavigationTree />`

## Files Changed

| File | Change |
|---|---|
| `src/utils/sectionPages.js` | Added |
| `src/utils/__tests__/sectionPages.test.js` | Added |
| `src/hooks/useTrackers.js` | Modified |
| `src/components/app/NavigationTree.jsx` | Modified |
| `src/App.jsx` | Modified |
| `e2e/notebook-section-hydration.spec.js` | Modified |

## Testing

**Unit tests (Vitest)** — 6 new cases in `sectionPages.test.js`, all passing (135/135 total):
- Returns pages sorted ascending by `sort_order`
- Returns `[]` for unknown section
- Returns `[]` for empty map
- Single-page section
- `null` sort_order sorts to end
- Does not mutate source array

**E2E tests (Playwright)** — 2 new cases in `notebook-section-hydration.spec.js`:
- `expanding a section in a non-active notebook immediately shows its pages` — navigates to notebook A, expands notebook B chevron, expands section B-One chevron, asserts page title visible, asserts notebook A still active
- `expanding a non-active section within the active notebook shows its pages without selecting it` — activates section B-Two, expands section B-One chevron, asserts page B-One visible, asserts B-Two still active

E2E runs on CI (Desktop Chrome + Mobile Chrome).

## Related Issues

Closes #136