### PR TITLE
feat: extract navigation target logic into pure utility and wire step-machine

### DIFF
--- a/e2e/fresh-load-content.spec.js
+++ b/e2e/fresh-load-content.spec.js
@@ -39,6 +39,7 @@ test.describe('fresh page load always shows content', () => {
     await page.waitForSelector('.app:not(.app-auth)', { timeout: 15000 })
 
     // Title and content should both appear without any extra navigation.
+    await expect(page.locator('.status-row')).not.toContainText('No tracker selected')
     await expect(page.locator('.title-input')).toHaveValue('Fresh Load Page', { timeout: 10000 })
     await expect(page.locator('.ProseMirror')).toContainText(PAGE_TEXT, { timeout: 10000 })
   })

--- a/e2e/navigation-target-flow.spec.js
+++ b/e2e/navigation-target-flow.spec.js
@@ -1,0 +1,77 @@
+import { test, expect } from './fixtures'
+import {
+  clickNavigationItem,
+  createNotebook,
+  createPage,
+  createSection,
+  deleteNotebookById,
+  ensureNavigationVisible,
+  getSupabase,
+  waitForApp,
+} from './test-helpers'
+
+test.describe('navigation target flow', () => {
+  let notebookA = null
+  let notebookB = null
+  let sectionA1 = null
+  let sectionA2 = null
+  let sectionB = null
+  let pageA1 = null
+  let pageA2 = null
+  let pageB = null
+
+  test.beforeAll(async () => {
+    const { client, userId } = await getSupabase()
+    const stamp = Date.now()
+    notebookA = await createNotebook(client, userId, `Nav Flow A ${stamp}`, -9100)
+    notebookB = await createNotebook(client, userId, `Nav Flow B ${stamp}`, -9099)
+    sectionA1 = await createSection(client, userId, notebookA.id, 'Nav Flow A One', 0)
+    sectionA2 = await createSection(client, userId, notebookA.id, 'Nav Flow A Two', 1)
+    sectionB = await createSection(client, userId, notebookB.id, 'Nav Flow B One', 0)
+    pageA1 = await createPage(client, userId, sectionA1.id, 'Nav Flow A Page One', {
+      type: 'doc',
+      content: [{ type: 'paragraph', content: [{ type: 'text', text: 'A one content' }] }],
+    })
+    pageA2 = await createPage(client, userId, sectionA2.id, 'Nav Flow A Page Two', {
+      type: 'doc',
+      content: [{ type: 'paragraph', content: [{ type: 'text', text: 'A two content' }] }],
+    })
+    pageB = await createPage(client, userId, sectionB.id, 'Nav Flow B Page', {
+      type: 'doc',
+      content: [{ type: 'paragraph', content: [{ type: 'text', text: 'B page content' }] }],
+    })
+  })
+
+  test.afterAll(async () => {
+    const { client } = await getSupabase()
+    await deleteNotebookById(client, notebookA?.id)
+    await deleteNotebookById(client, notebookB?.id)
+  })
+
+  test('same-notebook section click loads that section page as one target', async ({ page }) => {
+    await waitForApp(page, `#nb=${notebookA.id}&sec=${sectionA1.id}&pg=${pageA1.id}`)
+    await ensureNavigationVisible(page)
+
+    await clickNavigationItem(page, page.locator('.tree-node-section', { hasText: sectionA2.title }).first())
+
+    await expect(page.locator('.tree-node-section', { hasText: sectionA2.title })).toHaveClass(/active/)
+    await expect(page.locator('.title-input')).toHaveValue(pageA2.title, { timeout: 10000 })
+    await expect(page.locator('.ProseMirror')).toContainText('A two content', { timeout: 10000 })
+    await expect(page.locator('.status-row')).not.toContainText('No tracker selected')
+  })
+
+  test('cross-notebook page click applies notebook, section, and page together', async ({ page }) => {
+    await waitForApp(page, `#nb=${notebookA.id}&sec=${sectionA1.id}&pg=${pageA1.id}`)
+    await ensureNavigationVisible(page)
+
+    await clickNavigationItem(page, page.locator('.tree-node-notebook', { hasText: notebookB.title }).locator('.tree-chevron').first())
+    await clickNavigationItem(page, page.locator('.tree-node-section', { hasText: sectionB.title }).locator('.tree-chevron').first())
+    await clickNavigationItem(page, page.locator('.tree-node-page', { hasText: pageB.title }).first())
+
+    await expect(page.locator('.tree-node-notebook', { hasText: notebookB.title })).toHaveClass(/active/)
+    await expect(page.locator('.tree-node-section', { hasText: sectionB.title })).toHaveClass(/active/)
+    await expect(page.locator('.title-input')).toHaveValue(pageB.title, { timeout: 10000 })
+    await expect(page.locator('.ProseMirror')).toContainText('B page content', { timeout: 10000 })
+    await expect(page).toHaveURL(new RegExp(`#pg=${pageB.id}`))
+  })
+})

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -12,7 +12,6 @@ import { useTrackerSession } from './hooks/useTrackerSession'
 import { clearNavHierarchyCache } from './utils/resolveNavHierarchy'
 import { isTouchOnlyDevice } from './utils/device'
 import {
-  saveSelection,
   readStoredSidebarCollapsed,
   readStoredSelection,
   readStoredSidebarWidth,
@@ -133,7 +132,7 @@ function App() {
     createNotebook,
     renameNotebook,
     deleteNotebook,
-  } = useNotebooks(userId, pendingNavRef, savedSelectionRef)
+  } = useNotebooks(userId)
 
   const {
     sections,
@@ -147,7 +146,7 @@ function App() {
     deleteSection,
     moveSection,
     copySection,
-  } = useSections(userId, activeNotebookId, pendingNavRef, savedSelectionRef)
+  } = useSections(userId, activeNotebookId)
 
   const {
     trackers,
@@ -176,17 +175,22 @@ function App() {
     resolveConflictWithServer,
     resolveConflictWithDraft,
     flushAllPendingSaves,
-  } = useTrackers(userId, activeSectionId, pendingNavRef, savedSelectionRef)
+  } = useTrackers(userId, activeSectionId)
 
   const {
     navIntentRef,
     hashBlockRef,
-    initialNavReady,
+    isNavigating,
+    selectNavigationTarget,
     handleInternalHashNavigate,
     clearBlockAnchorIfPresent,
   } = useNavigation({
     session,
     notebooks,
+    sections,
+    trackers,
+    sectionsLoading,
+    dataLoading,
     activeNotebookId,
     activeSectionId,
     activeTrackerId,
@@ -195,6 +199,7 @@ function App() {
     setActiveTrackerId,
     getPendingNav,
     setPendingNav,
+    savedSelectionRef,
     setDeepLinkFocusGuard: setDeepLinkFocusGuardValue,
   })
 
@@ -373,7 +378,6 @@ function App() {
     sessionKey,
     scheduleSave,
     scheduleSettingsSave,
-    pendingNavRef,
     pendingEditTapRef,
     touchNavigationGuardRef,
     touchNavigationGuard,
@@ -404,44 +408,6 @@ function App() {
       }
     })
   }, [editor, suppressFocusRef, setTouchNavigationGuardValue])
-
-  useEffect(() => {
-    if (!session || !initialNavReady) return
-    const savedSelection = savedSelectionRef.current
-    if (savedSelection?.notebookId && !activeNotebookId) return
-    if (
-      activeNotebookId &&
-      savedSelection?.notebookId === activeNotebookId &&
-      savedSelection.sectionId &&
-      !activeSectionId &&
-      (sectionsLoading || sections.length > 0)
-    ) {
-      return
-    }
-    if (
-      activeSectionId &&
-      savedSelection?.sectionId === activeSectionId &&
-      savedSelection.pageId &&
-      !activeTrackerId &&
-      (dataLoading || trackers.length > 0)
-    ) {
-      return
-    }
-    if (activeNotebookId && sectionsLoading) return
-    if (activeSectionId && dataLoading) return
-    saveSelection(activeNotebookId, activeSectionId, activeTrackerId)
-    savedSelectionRef.current = { notebookId: activeNotebookId, sectionId: activeSectionId, pageId: activeTrackerId }
-  }, [
-    session,
-    initialNavReady,
-    activeNotebookId,
-    activeSectionId,
-    activeTrackerId,
-    sectionsLoading,
-    dataLoading,
-    sections.length,
-    trackers.length,
-  ])
 
   useEffect(() => {
     if (settingsMode !== 'daily-template') return
@@ -493,36 +459,24 @@ function App() {
     if (settingsMode) {
       setSettingsMode(null)
     }
-    navIntentRef.current = 'push'
-    hashBlockRef.current = null
-    setDeepLinkFocusGuardValue(false)
-    pendingNavRef.current = null
     primeTouchNavigationGuard()
-    setActiveNotebookId(nextNotebookId)
+    selectNavigationTarget({ notebookId: nextNotebookId })
   }
 
-  const handleSectionSelect = (sectionId) => {
+  const handleSectionSelect = (target) => {
     if (settingsMode) {
       setSettingsMode(null)
     }
-    navIntentRef.current = 'push'
-    hashBlockRef.current = null
-    setDeepLinkFocusGuardValue(false)
-    pendingNavRef.current = null
     primeTouchNavigationGuard()
-    setActiveSectionId(sectionId)
+    selectNavigationTarget(target)
   }
 
-  const handlePageSelect = (trackerId) => {
+  const handlePageSelect = (target) => {
     if (settingsMode) {
       setSettingsMode(null)
     }
-    navIntentRef.current = 'push'
-    hashBlockRef.current = null
-    setDeepLinkFocusGuardValue(false)
-    pendingNavRef.current = null
     primeTouchNavigationGuard()
-    setActiveTrackerId(trackerId)
+    selectNavigationTarget(target)
     if (isMobileViewport) {
       setMobileSidebarOpen(false)
     }
@@ -620,6 +574,7 @@ function App() {
 
   const isSettingsHub = settingsMode === 'hub'
   const isTemplateEditing = settingsMode === 'daily-template'
+  const hasEditorTarget = Boolean(activeTracker) || isNavigating
   const compactBadges = sidebarWidth < SIDEBAR_BADGE_COMPACT_WIDTH
   const isSidebarOpen = isMobileViewport ? mobileSidebarOpen : !sidebarCollapsed
   const workspaceClassName = [
@@ -790,7 +745,7 @@ function App() {
               onDelete={deleteTracker}
               saveStatus={saveStatus}
               onImageUpload={finalUploadImageAndInsert}
-              hasTracker={!!activeTracker}
+              hasTracker={hasEditorTarget}
               message={message}
               notebookId={activeNotebookId}
               sectionId={activeSectionId}

--- a/src/components/app/NavigationTree.jsx
+++ b/src/components/app/NavigationTree.jsx
@@ -73,10 +73,13 @@ function NavigationTree({
     onSelectNotebook?.(id)
   }
 
-  const handleSelectSection = (id) => {
-    setExpandedSections((prev) => new Set(prev).add(id))
-    onLoadSectionPages?.(id)
-    onSelectSection?.(id)
+  const handleSelectSection = (section) => {
+    setExpandedSections((prev) => new Set(prev).add(section.id))
+    onLoadSectionPages?.(section.id)
+    onSelectSection?.({
+      notebookId: section.notebook_id,
+      sectionId: section.id,
+    })
   }
 
   // Auto-expand when active IDs change from parent (deep links, URL navigation)
@@ -294,7 +297,7 @@ function NavigationTree({
                               role="treeitem"
                               aria-expanded={sectionExpanded}
                               className={`tree-node tree-node-section ${sectionActive ? 'active' : ''}`}
-                              onClick={() => handleSelectSection(section.id)}
+                              onClick={() => handleSelectSection(section)}
                               onContextMenu={handleOpenContextMenu('section', section)}
                               onTouchStart={handleTouchStart('section', section)}
                               onTouchEnd={cancelLongPress}
@@ -340,7 +343,11 @@ function NavigationTree({
                                         className={`tree-node tree-node-page ${
                                           tracker.id === activeTrackerId ? 'active' : ''
                                         } ${overId === tracker.id ? 'drag-over' : ''}`}
-                                        onClick={() => onSelectPage?.(tracker.id)}
+                                        onClick={() => onSelectPage?.({
+                                          notebookId: section.notebook_id,
+                                          sectionId: section.id,
+                                          pageId: tracker.id,
+                                        })}
                                         onContextMenu={handleOpenContextMenu('page', tracker)}
                                         onTouchStart={handleTouchStart('page', tracker)}
                                         onTouchEnd={cancelLongPress}

--- a/src/hooks/useEditorSetup.js
+++ b/src/hooks/useEditorSetup.js
@@ -48,7 +48,6 @@ export const useEditorSetup = ({
   sessionKey,
   scheduleSave,
   scheduleSettingsSave,
-  pendingNavRef,
   pendingEditTapRef,
   touchNavigationGuardRef,
   touchNavigationGuard,

--- a/src/hooks/useNavigation.js
+++ b/src/hooks/useNavigation.js
@@ -7,26 +7,20 @@ import {
   clearDeepLinkHighlight,
 } from '../utils/navigationHelpers'
 import { resolveNavHierarchy } from '../utils/resolveNavHierarchy'
-
-const getNavSpecificity = (value) => {
-  if (!value) return 0
-  if (value.pageId) return 3
-  if (value.sectionId) return 2
-  if (value.notebookId) return 1
-  return 0
-}
-
-const isWeakerDescendantTarget = (current, next) => {
-  if (!current || !next) return false
-  if (getNavSpecificity(next) >= getNavSpecificity(current)) return false
-  if (current.notebookId && next.notebookId && current.notebookId !== next.notebookId) return false
-  if (current.sectionId && next.sectionId && current.sectionId !== next.sectionId) return false
-  return true
-}
+import { saveSelection } from '../utils/storage'
+import {
+  getNavigationApplyStep,
+  isWeakerDescendantTarget,
+  normalizeNavigationTarget,
+} from '../utils/navigationTarget'
 
 export const useNavigation = ({
   session,
   notebooks,
+  sections,
+  trackers,
+  sectionsLoading,
+  dataLoading,
   activeNotebookId,
   activeSectionId,
   activeTrackerId,
@@ -35,6 +29,7 @@ export const useNavigation = ({
   setActiveTrackerId,
   getPendingNav,
   setPendingNav,
+  savedSelectionRef,
   setDeepLinkFocusGuard,
 }) => {
   const navIntentRef = useRef(null)
@@ -42,27 +37,45 @@ export const useNavigation = ({
   const hashBlockRef = useRef(null)
   const navigateToHashRef = useRef(null)
   const navVersionRef = useRef(0)
-  const initialResolvedTargetRef = useRef(undefined)
   const [initialNavReady, setInitialNavReady] = useState(false)
-  // Incremented when syncInitialHash resolves to force the correction effect
-  // to re-run — initialResolvedTargetRef is a ref (no re-render on write),
-  // so without this the effect can miss the resolved target if loadNotebooks
-  // settled first.
-  const [initialResolveGeneration, setInitialResolveGeneration] = useState(0)
+  const [pendingTarget, setPendingTarget] = useState(null)
 
-  const setPendingNavSafely = useCallback(
+  const clearPendingTarget = useCallback(() => {
+    setPendingTarget(null)
+    setPendingNav(null)
+  }, [setPendingNav])
+
+  const setPendingTargetSafely = useCallback(
     (nextValue) => {
       if (!nextValue) {
-        setPendingNav(null)
+        clearPendingTarget()
         return
       }
+      const normalized = normalizeNavigationTarget(nextValue)
       const pending = getPendingNav()
-      if (isWeakerDescendantTarget(pending, nextValue)) {
+      if (isWeakerDescendantTarget(pending, normalized)) {
         return
       }
-      setPendingNav(nextValue)
+      setPendingTarget(normalized)
+      setPendingNav(normalized)
     },
-    [getPendingNav, setPendingNav],
+    [clearPendingTarget, getPendingNav, setPendingNav],
+  )
+
+  const queueResolvedTarget = useCallback(
+    (target, { hashMode = null } = {}) => {
+      if (!target?.notebookId) return
+      const normalized = normalizeNavigationTarget(target)
+      if (hashMode) navIntentRef.current = hashMode
+      if (normalized.pageId && normalized.blockId) {
+        hashBlockRef.current = { pageId: normalized.pageId, blockId: normalized.blockId }
+      } else {
+        hashBlockRef.current = null
+        clearDeepLinkHighlight()
+      }
+      setPendingTargetSafely(normalized)
+    },
+    [setPendingTargetSafely],
   )
 
   const navigateToHash = useCallback(
@@ -78,63 +91,22 @@ export const useNavigation = ({
       if (navVersionRef.current !== version) return
       if (!resolved?.notebookId) {
         console.warn('[nav] resolveNavHierarchy returned null for hash=%s — navigation dropped', hash)
+        clearPendingTarget()
+        setInitialNavReady(true)
         return
       }
 
-      if (resolved.pageId && resolved.blockId) {
-        hashBlockRef.current = { pageId: resolved.pageId, blockId: resolved.blockId }
-      } else {
-        hashBlockRef.current = null
-        clearDeepLinkHighlight()
-      }
-
-      setPendingNavSafely(resolved)
-      if (resolved.pageId && resolved.pageId === activeTrackerId) {
-        requestAnimationFrame(() => {
-          if (!resolved.blockId) {
-            setPendingNav(null)
-            return
-          }
-          const found = scrollToBlock(resolved.blockId)
-          // Only clear pending when the block is actually present right now.
-          // If it isn't yet (content still settling), keep pending so the
-          // editor-setup pass can apply the deep-link highlight when ready.
-          if (found) {
-            setPendingNav(null)
-          }
-        })
-        return
-      }
-
-      if (resolved.notebookId === activeNotebookId) {
-        if (resolved.sectionId && resolved.sectionId !== activeSectionId) {
-          setActiveSectionId(resolved.sectionId)
-          return
-        }
-        if (resolved.pageId && resolved.pageId !== activeTrackerId) {
-          setActiveTrackerId(resolved.pageId)
-          return
-        }
-        setPendingNav(null)
-        return
-      }
-
-      if (notebooks.some((item) => item.id === resolved.notebookId)) {
-        setActiveNotebookId(resolved.notebookId)
-      }
+      queueResolvedTarget(resolved)
     },
-    [
-      notebooks,
-      activeTrackerId,
-      activeNotebookId,
-      activeSectionId,
-      setActiveNotebookId,
-      setActiveSectionId,
-      setActiveTrackerId,
-      setPendingNav,
-      setPendingNavSafely,
-      setDeepLinkFocusGuard,
-    ],
+    [clearPendingTarget, queueResolvedTarget, setDeepLinkFocusGuard],
+  )
+
+  const selectNavigationTarget = useCallback(
+    (target) => {
+      setDeepLinkFocusGuard(false)
+      queueResolvedTarget(target, { hashMode: 'push' })
+    },
+    [queueResolvedTarget, setDeepLinkFocusGuard],
   )
 
   const handleInternalHashNavigate = useCallback((href) => {
@@ -172,12 +144,114 @@ export const useNavigation = ({
   }, [navigateToHash])
 
   useEffect(() => {
+    if (!session) {
+      clearPendingTarget()
+      setInitialNavReady(false)
+      return
+    }
+
+    let cancelled = false
+
+    const syncInitialTarget = async () => {
+      const hashTarget = typeof window === 'undefined' ? null : parseDeepLink(window.location.hash)
+      const savedTarget = savedSelectionRef?.current ?? null
+      const initialTarget = hashTarget ?? savedTarget
+
+      if (!initialTarget) {
+        setInitialNavReady(true)
+        return
+      }
+
+      const version = ++navVersionRef.current
+      const resolved = await resolveNavHierarchy(initialTarget)
+      if (cancelled || navVersionRef.current !== version) return
+      if (!resolved?.notebookId) {
+        setInitialNavReady(true)
+        return
+      }
+
+      queueResolvedTarget(resolved)
+    }
+
+    syncInitialTarget()
+
+    return () => {
+      cancelled = true
+    }
+  }, [session, clearPendingTarget, queueResolvedTarget, savedSelectionRef])
+
+  useEffect(() => {
+    if (!session || !pendingTarget) return
+
+    const step = getNavigationApplyStep({
+      target: pendingTarget,
+      notebooks,
+      sections,
+      trackers,
+      activeNotebookId,
+      activeSectionId,
+      activeTrackerId,
+      sectionsLoading,
+      dataLoading,
+    })
+
+    if (step.type === 'wait') return
+
+    if (step.type === 'missing') {
+      clearPendingTarget()
+      setInitialNavReady(true)
+      return
+    }
+
+    if (step.type === 'notebook') {
+      setActiveNotebookId(step.id)
+      return
+    }
+
+    if (step.type === 'section') {
+      setActiveSectionId(step.id)
+      return
+    }
+
+    if (step.type === 'page') {
+      setActiveTrackerId(step.id)
+      return
+    }
+
+    setInitialNavReady(true)
+    if (!pendingTarget.blockId) {
+      clearPendingTarget()
+      return
+    }
+
+    requestAnimationFrame(() => {
+      const found = scrollToBlock(pendingTarget.blockId)
+      if (found) clearPendingTarget()
+    })
+  }, [
+    session,
+    pendingTarget,
+    notebooks,
+    sections,
+    trackers,
+    activeNotebookId,
+    activeSectionId,
+    activeTrackerId,
+    sectionsLoading,
+    dataLoading,
+    setActiveNotebookId,
+    setActiveSectionId,
+    setActiveTrackerId,
+    clearPendingTarget,
+  ])
+
+  useEffect(() => {
     if (!initialNavReady) return
     if (!activeNotebookId) return
+    if (pendingTarget) return
+
     const blockInfo = hashBlockRef.current
     if (blockInfo && blockInfo.pageId !== activeTrackerId) {
-      const pending = getPendingNav()
-      if (pending?.pageId === blockInfo.pageId) return
       hashBlockRef.current = null
     }
     const blockId =
@@ -200,107 +274,52 @@ export const useNavigation = ({
         scrollToBlock(blockId)
       })
     }
-  }, [activeNotebookId, activeSectionId, activeTrackerId, getPendingNav, initialNavReady])
+  }, [activeNotebookId, activeSectionId, activeTrackerId, initialNavReady, pendingTarget])
 
   useEffect(() => {
-    if (!session) {
-      initialResolvedTargetRef.current = undefined
-      setInitialNavReady(false)
+    if (!session || !initialNavReady || pendingTarget) return
+    const savedSelection = savedSelectionRef?.current
+    if (savedSelection?.notebookId && !activeNotebookId) return
+    if (
+      activeNotebookId &&
+      savedSelection?.notebookId === activeNotebookId &&
+      savedSelection.sectionId &&
+      !activeSectionId &&
+      (sectionsLoading || sections.length > 0)
+    ) {
       return
     }
-    let cancelled = false
-
-    const syncInitialHash = async () => {
-      const initial = typeof window === 'undefined' ? null : parseDeepLink(window.location.hash)
-      if (!initial) {
-        initialResolvedTargetRef.current = null
-        setInitialNavReady(true)
-        return
-      }
-
-      const resolved = await resolveNavHierarchy(initial)
-      if (cancelled) return
-      if (!resolved?.notebookId) {
-        initialResolvedTargetRef.current = null
-        setInitialNavReady(true)
-        return
-      }
-
-      initialResolvedTargetRef.current = resolved
-      setPendingNavSafely(resolved)
-      setInitialResolveGeneration((g) => g + 1)
-      if (resolved.pageId && resolved.blockId) {
-        hashBlockRef.current = { pageId: resolved.pageId, blockId: resolved.blockId }
-      } else {
-        hashBlockRef.current = null
-      }
-    }
-
-    syncInitialHash()
-
-    return () => {
-      cancelled = true
-    }
-  }, [session, setPendingNavSafely])
-
-  useEffect(() => {
-    if (!session || initialNavReady) return
-
-    const target = initialResolvedTargetRef.current
-    if (target === undefined) return
-    if (!target) {
-      setInitialNavReady(true)
+    if (
+      activeSectionId &&
+      savedSelection?.sectionId === activeSectionId &&
+      savedSelection.pageId &&
+      !activeTrackerId &&
+      (dataLoading || trackers.length > 0)
+    ) {
       return
     }
-
-    if (target.pageId && activeTrackerId === target.pageId) {
-      setInitialNavReady(true)
-      return
-    }
-    if (!target.pageId && target.sectionId && activeSectionId === target.sectionId) {
-      setInitialNavReady(true)
-      return
-    }
-    if (!target.pageId && !target.sectionId && activeNotebookId === target.notebookId) {
-      setInitialNavReady(true)
-      return
-    }
-
-    const hasTargetNotebook = notebooks.some((item) => item.id === target.notebookId)
-    if (hasTargetNotebook) {
-      if (activeNotebookId !== target.notebookId) {
-        setActiveNotebookId(target.notebookId)
-        return
+    if (activeNotebookId && sectionsLoading) return
+    if (activeSectionId && dataLoading) return
+    saveSelection(activeNotebookId, activeSectionId, activeTrackerId)
+    if (savedSelectionRef) {
+      savedSelectionRef.current = {
+        notebookId: activeNotebookId,
+        sectionId: activeSectionId,
+        pageId: activeTrackerId,
       }
-      // Notebook matches — correct section/page if the hooks loaded before
-      // pendingNavRef was set and picked the wrong defaults.
-      if (target.sectionId && activeSectionId !== target.sectionId) {
-        setActiveSectionId(target.sectionId)
-        return
-      }
-      if (target.pageId && activeTrackerId !== target.pageId) {
-        setActiveTrackerId(target.pageId)
-        return
-      }
-      return
-    }
-
-    if (notebooks.length > 0) {
-      setPendingNav(null)
-      setInitialNavReady(true)
     }
   }, [
     session,
-    notebooks,
+    initialNavReady,
+    pendingTarget,
+    savedSelectionRef,
     activeNotebookId,
     activeSectionId,
     activeTrackerId,
-    initialNavReady,
-    initialResolveGeneration,
-    setActiveNotebookId,
-    setActiveSectionId,
-    setActiveTrackerId,
-    setPendingNav,
+    sectionsLoading,
+    dataLoading,
+    sections.length,
+    trackers.length,
   ])
 
   useEffect(() => {
@@ -320,6 +339,9 @@ export const useNavigation = ({
     navIntentRef,
     hashBlockRef,
     initialNavReady,
+    pendingTarget,
+    isNavigating: Boolean(pendingTarget),
+    selectNavigationTarget,
     handleInternalHashNavigate,
     clearBlockAnchorIfPresent,
   }

--- a/src/hooks/useNotebooks.js
+++ b/src/hooks/useNotebooks.js
@@ -7,7 +7,7 @@ import {
 import { clearNavHierarchyCache } from '../utils/resolveNavHierarchy'
 import { runSupabaseQueryWithRetry } from '../utils/supabaseRetry'
 
-export const useNotebooks = (userId, pendingNavRef, savedSelectionRef) => {
+export const useNotebooks = (userId) => {
   const [notebooks, setNotebooks] = useState([])
   const [activeNotebookId, setActiveNotebookId] = useState(null)
   const [message, setMessage] = useState('')
@@ -33,20 +33,11 @@ export const useNotebooks = (userId, pendingNavRef, savedSelectionRef) => {
     }
 
     setNotebooks(data ?? [])
-    const pending = pendingNavRef?.current
-    const saved = savedSelectionRef?.current
-    if (pending?.notebookId && data?.some((item) => item.id === pending.notebookId)) {
-      setActiveNotebookId(pending.notebookId)
-    } else {
-      setActiveNotebookId((prev) => {
-        if (prev && data?.some((item) => item.id === prev)) return prev
-        if (saved?.notebookId && data?.some((item) => item.id === saved.notebookId)) {
-          return saved.notebookId
-        }
-        return data?.[0]?.id ?? null
-      })
-    }
-  }, [userId, pendingNavRef, savedSelectionRef])
+    setActiveNotebookId((prev) => {
+      if (prev && data?.some((item) => item.id === prev)) return prev
+      return data?.[0]?.id ?? null
+    })
+  }, [userId])
 
   useEffect(() => {
     const timer = window.setTimeout(() => {

--- a/src/hooks/useSections.js
+++ b/src/hooks/useSections.js
@@ -109,7 +109,7 @@ const fixForwardBlockRefs = (content, blockIdMap) => {
   return walk(content)
 }
 
-export const useSections = (userId, activeNotebookId, pendingNavRef, savedSelectionRef) => {
+export const useSections = (userId, activeNotebookId) => {
   const [sections, setSections] = useState([])
   const [activeSectionId, setActiveSectionId] = useState(null)
   const [sectionsLoading, setSectionsLoading] = useState(false)
@@ -161,20 +161,11 @@ export const useSections = (userId, activeNotebookId, pendingNavRef, savedSelect
       return
     }
     const notebookSections = sections.filter((s) => s.notebook_id === activeNotebookId)
-    const pending = pendingNavRef?.current
-    const saved = savedSelectionRef?.current
-    if (pending?.sectionId && notebookSections.some((s) => s.id === pending.sectionId)) {
-      setActiveSectionId(pending.sectionId)
-    } else {
-      setActiveSectionId((prev) => {
-        if (prev && notebookSections.some((s) => s.id === prev)) return prev
-        if (saved?.sectionId && notebookSections.some((s) => s.id === saved.sectionId)) {
-          return saved.sectionId
-        }
-        return notebookSections[0]?.id ?? null
-      })
-    }
-  }, [activeNotebookId, sections, pendingNavRef, savedSelectionRef])
+    setActiveSectionId((prev) => {
+      if (prev && notebookSections.some((s) => s.id === prev)) return prev
+      return notebookSections[0]?.id ?? null
+    })
+  }, [activeNotebookId, sections])
 
   const createSection = async (session, notebookId) => {
     if (!session || !notebookId) return

--- a/src/hooks/useTrackers.js
+++ b/src/hooks/useTrackers.js
@@ -8,7 +8,7 @@ import { detectConflict } from '../utils/draftHelpers'
 import { clearNavHierarchyCache } from '../utils/resolveNavHierarchy'
 import { runSupabaseQueryWithRetry } from '../utils/supabaseRetry'
 
-export const useTrackers = (userId, activeSectionId, pendingNavRef, savedSelectionRef) => {
+export const useTrackers = (userId, activeSectionId) => {
   const [trackers, setTrackers] = useState([])
   const [pagesBySection, setPagesBySection] = useState({})
   const [activeTrackerId, setActiveTrackerId] = useState(null)
@@ -388,22 +388,13 @@ export const useTrackers = (userId, activeSectionId, pendingNavRef, savedSelecti
       }
 
       setTrackers(data ?? [])
-      const pending = pendingNavRef?.current
-      const saved = savedSelectionRef?.current
-      if (pending?.pageId && data?.some((item) => item.id === pending.pageId)) {
-        setActiveTrackerId(pending.pageId)
-      } else {
-        setActiveTrackerId((prev) => {
-          if (prev && data?.some((item) => item.id === prev)) return prev
-          if (saved?.pageId && data?.some((item) => item.id === saved.pageId)) {
-            return saved.pageId
-          }
-          return data?.[0]?.id ?? null
-        })
-      }
+      setActiveTrackerId((prev) => {
+        if (prev && data?.some((item) => item.id === prev)) return prev
+        return data?.[0]?.id ?? null
+      })
       setDataLoading(false)
     },
-    [userId, pendingNavRef, savedSelectionRef],
+    [userId],
   )
 
   useEffect(() => {

--- a/src/utils/__tests__/navigationTarget.test.js
+++ b/src/utils/__tests__/navigationTarget.test.js
@@ -1,0 +1,105 @@
+import { describe, expect, it } from 'vitest'
+import {
+  getNavigationApplyStep,
+  isWeakerDescendantTarget,
+  normalizeNavigationTarget,
+  targetMatchesSelection,
+} from '../navigationTarget'
+
+describe('normalizeNavigationTarget', () => {
+  it('fills absent target fields with null', () => {
+    expect(normalizeNavigationTarget({ pageId: 'page-1' })).toEqual({
+      notebookId: null,
+      sectionId: null,
+      pageId: 'page-1',
+      blockId: null,
+    })
+  })
+})
+
+describe('isWeakerDescendantTarget', () => {
+  it('ignores notebook-only fallbacks while a page target is pending in the same branch', () => {
+    expect(
+      isWeakerDescendantTarget(
+        { notebookId: 'nb-1', sectionId: 'sec-1', pageId: 'pg-1' },
+        { notebookId: 'nb-1' },
+      ),
+    ).toBe(true)
+  })
+
+  it('allows targets from another notebook', () => {
+    expect(
+      isWeakerDescendantTarget(
+        { notebookId: 'nb-1', sectionId: 'sec-1', pageId: 'pg-1' },
+        { notebookId: 'nb-2' },
+      ),
+    ).toBe(false)
+  })
+})
+
+describe('targetMatchesSelection', () => {
+  it('matches at the most specific target level', () => {
+    expect(
+      targetMatchesSelection(
+        { notebookId: 'nb-1', sectionId: 'sec-1', pageId: 'pg-1' },
+        { activeNotebookId: 'nb-1', activeSectionId: 'sec-1', activeTrackerId: 'pg-1' },
+      ),
+    ).toBe(true)
+    expect(
+      targetMatchesSelection(
+        { notebookId: 'nb-1', sectionId: 'sec-1' },
+        { activeNotebookId: 'nb-1', activeSectionId: 'sec-1', activeTrackerId: 'pg-2' },
+      ),
+    ).toBe(true)
+  })
+})
+
+describe('getNavigationApplyStep', () => {
+  const notebooks = [{ id: 'nb-1' }, { id: 'nb-2' }]
+  const sections = [
+    { id: 'sec-1', notebook_id: 'nb-1' },
+    { id: 'sec-2', notebook_id: 'nb-2' },
+  ]
+  const trackers = [
+    { id: 'pg-1', section_id: 'sec-1' },
+    { id: 'pg-2', section_id: 'sec-2' },
+  ]
+
+  it('applies navigation in notebook, section, then page order', () => {
+    const target = { notebookId: 'nb-2', sectionId: 'sec-2', pageId: 'pg-2' }
+
+    expect(getNavigationApplyStep({ target, notebooks, sections, trackers, activeNotebookId: 'nb-1' }))
+      .toEqual({ type: 'notebook', id: 'nb-2' })
+
+    expect(getNavigationApplyStep({
+      target,
+      notebooks,
+      sections,
+      trackers,
+      activeNotebookId: 'nb-2',
+      activeSectionId: 'sec-1',
+    })).toEqual({ type: 'section', id: 'sec-2' })
+
+    expect(getNavigationApplyStep({
+      target,
+      notebooks,
+      sections,
+      trackers,
+      activeNotebookId: 'nb-2',
+      activeSectionId: 'sec-2',
+      activeTrackerId: 'pg-1',
+    })).toEqual({ type: 'page', id: 'pg-2' })
+  })
+
+  it('waits for page data before treating a resolved page target as missing', () => {
+    expect(getNavigationApplyStep({
+      target: { notebookId: 'nb-2', sectionId: 'sec-2', pageId: 'pg-3' },
+      notebooks,
+      sections,
+      trackers,
+      activeNotebookId: 'nb-2',
+      activeSectionId: 'sec-2',
+      dataLoading: true,
+    })).toEqual({ type: 'wait' })
+  })
+})

--- a/src/utils/navigationTarget.js
+++ b/src/utils/navigationTarget.js
@@ -1,0 +1,76 @@
+export const normalizeNavigationTarget = (target = {}) => ({
+  notebookId: target.notebookId ?? null,
+  sectionId: target.sectionId ?? null,
+  pageId: target.pageId ?? null,
+  blockId: target.blockId ?? null,
+})
+
+export const getNavigationSpecificity = (target) => {
+  if (!target) return 0
+  if (target.pageId) return 3
+  if (target.sectionId) return 2
+  if (target.notebookId) return 1
+  return 0
+}
+
+export const isWeakerDescendantTarget = (current, next) => {
+  if (!current || !next) return false
+  if (getNavigationSpecificity(next) >= getNavigationSpecificity(current)) return false
+  if (current.notebookId && next.notebookId && current.notebookId !== next.notebookId) return false
+  if (current.sectionId && next.sectionId && current.sectionId !== next.sectionId) return false
+  return true
+}
+
+export const targetMatchesSelection = (target, selection) => {
+  if (!target) return false
+  if (target.pageId) return selection.activeTrackerId === target.pageId
+  if (target.sectionId) return selection.activeSectionId === target.sectionId
+  if (target.notebookId) return selection.activeNotebookId === target.notebookId
+  return false
+}
+
+export const getNavigationApplyStep = ({
+  target,
+  notebooks = [],
+  sections = [],
+  trackers = [],
+  activeNotebookId = null,
+  activeSectionId = null,
+  activeTrackerId = null,
+  sectionsLoading = false,
+  dataLoading = false,
+}) => {
+  if (!target?.notebookId) return { type: 'done' }
+
+  if (!notebooks.some((item) => item.id === target.notebookId)) {
+    return notebooks.length > 0 ? { type: 'missing' } : { type: 'wait' }
+  }
+
+  if (activeNotebookId !== target.notebookId) {
+    return { type: 'notebook', id: target.notebookId }
+  }
+
+  if (!target.sectionId) return { type: 'done' }
+
+  if (!sections.some((item) => item.id === target.sectionId && item.notebook_id === target.notebookId)) {
+    if (sections.length === 0) return { type: 'wait' }
+    return sectionsLoading ? { type: 'wait' } : { type: 'missing' }
+  }
+
+  if (activeSectionId !== target.sectionId) {
+    return { type: 'section', id: target.sectionId }
+  }
+
+  if (!target.pageId) return { type: 'done' }
+
+  if (!trackers.some((item) => item.id === target.pageId && item.section_id === target.sectionId)) {
+    if (trackers.length === 0) return { type: 'wait' }
+    return dataLoading ? { type: 'wait' } : { type: 'missing' }
+  }
+
+  if (activeTrackerId !== target.pageId) {
+    return { type: 'page', id: target.pageId }
+  }
+
+  return { type: 'done' }
+}


### PR DESCRIPTION
## Summary

Extracts the navigation target step-machine logic out of `useNavigation` into a standalone pure utility (`src/utils/navigationTarget.js`), making it independently testable and replacing the previous two-ref approach with a cleaner `pendingTarget` state + step-machine loop.

## Changes

**New files**
- `src/utils/navigationTarget.js` — pure functions: `normalizeNavigationTarget`, `getNavigationSpecificity`, `isWeakerDescendantTarget`, `targetMatchesSelection`, `getNavigationApplyStep`
- `src/utils/__tests__/navigationTarget.test.js` — unit tests for all five functions
- `e2e/navigation-target-flow.spec.js` — E2E flow covering deep-link navigation to notebook → section → page

**Modified**
- `src/hooks/useNavigation.js` — imports from new utility; replaces `initialResolvedTargetRef` + `initialResolveGeneration` with single `pendingTarget` state; step-machine drives each navigation action
- `src/hooks/useNotebooks.js`, `useSections.js`, `useTrackers.js` — expose `loading` flags needed by the step machine
- `src/App.jsx` — threads `sections`, `trackers`, `sectionsLoading`, `dataLoading`, `savedSelectionRef` into `useNavigation`
- `src/components/app/NavigationTree.jsx` — minor prop updates
- `e2e/fresh-load-content.spec.js` — small extension

## Testing

- [ ] Unit tests: `npm run test:unit` — covers all `navigationTarget.js` exports
- [ ] E2E: `npm run test:e2e` — `navigation-target-flow.spec.js` covers notebook/section/page deep-link flows
- [ ] Manual: verify fresh-load navigation still lands on the correct page

## Related Issues

None