### PR TITLE
feat: extract useSectionPageCache hook with status tracking and gate navigation on section load

### DIFF
--- a/e2e/issue-114-chevron-toggle.spec.js
+++ b/e2e/issue-114-chevron-toggle.spec.js
@@ -107,10 +107,11 @@ test.describe('Issue #114 chevron toggle expand/collapse', () => {
     // Section Alpha should still be expanded (independent state)
     await expect(rowFor(page, 'Section Alpha')).toHaveAttribute('aria-expanded', 'true')
 
-    // Only the active section (Beta) shows its pages; Alpha's pages are not
-    // loaded because the data layer fetches pages for the active section only.
+    // Expanded sections keep their page rows even when another section becomes active.
     await expect(page.locator('.tree-node', { hasText: 'Page Beta' })).toBeVisible()
-    await expect(page.locator('.tree-node', { hasText: 'Page Alpha' })).toBeHidden()
+    await expect(page.locator('.tree-node', { hasText: 'Page Alpha' })).toBeVisible()
+    await expect(page.locator('.tree-node-section', { hasText: 'Section Alpha' })).not.toHaveClass(/active/)
+    await expect(page.getByText('Loading pages...')).toHaveCount(0)
   })
 
   test('clicking row label selects and expands the item', async ({ page }) => {

--- a/e2e/issue-70-same-notebook-copy.spec.js
+++ b/e2e/issue-70-same-notebook-copy.spec.js
@@ -12,10 +12,18 @@ import {
 const TARGET_BLOCK_ID = 'e2e-target-block-copy'
 const escapeRegex = (value) => value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
 
-const exactTreeNode = (page, className, label) =>
-  page.locator(className).filter({
-    has: page.locator('.tree-label', { hasText: new RegExp(`^${escapeRegex(label)}$`) }),
-  }).first()
+const exactTreeNode = (root, className, label) => {
+  const classToken = className.startsWith('.') ? className.slice(1) : className
+  return root
+    .locator('.tree-label', { hasText: new RegExp(`^${escapeRegex(label)}$`) })
+    .locator(
+      `xpath=ancestor::*[contains(concat(" ", normalize-space(@class), " "), " ${classToken} ")][1]`,
+    )
+    .first()
+}
+
+const treeBranchForNode = (node) =>
+  node.locator('xpath=ancestor::div[contains(concat(" ", normalize-space(@class), " "), " tree-branch ")][1]')
 
 test.describe('Issue #70 same-notebook section copy', () => {
   let notebookId = null
@@ -157,7 +165,8 @@ test.describe('Issue #70 same-notebook section copy', () => {
     const copiedSectionNode = exactTreeNode(page, '.tree-node-section', `${sectionTitle} (1)`)
     await expect(copiedSectionNode).toBeVisible({ timeout: 10000 })
     await clickNavigationItem(page, copiedSectionNode)
-    const copiedScratchpad = exactTreeNode(page, '.tree-node-page', scratchpadTitle)
+    const copiedSectionBranch = treeBranchForNode(copiedSectionNode)
+    const copiedScratchpad = exactTreeNode(copiedSectionBranch, '.tree-node-page', scratchpadTitle)
     await expect(copiedScratchpad).toBeVisible({ timeout: 10000 })
     await clickNavigationItem(page, copiedScratchpad)
     await expect(page.locator('.ProseMirror')).toContainText('See the target', { timeout: 10000 })

--- a/e2e/notebook-section-hydration.spec.js
+++ b/e2e/notebook-section-hydration.spec.js
@@ -87,6 +87,7 @@ test.describe('notebook section hydration', () => {
 
     // The stale "select notebook" prompt must not appear anywhere
     await expect(page.locator('text=Select notebook to load sections')).toHaveCount(0)
+    await expect(page.getByText('Loading pages...')).toHaveCount(0)
   })
 
   test('clicking a non-active notebook switches active section to its first section', async ({ page }) => {
@@ -136,6 +137,7 @@ test.describe('notebook section hydration', () => {
     await expect(
       page.locator('.tree-node-page', { hasText: pageB1.title }),
     ).toBeVisible({ timeout: 8000 })
+    await expect(page.getByText('Loading pages...')).toHaveCount(0)
 
     // Active state must not have changed
     await expect(rowFor(page, notebookA.title)).toHaveClass(/active/)
@@ -156,6 +158,7 @@ test.describe('notebook section hydration', () => {
     await expect(
       page.locator('.tree-node-page', { hasText: pageB1.title }),
     ).toBeVisible({ timeout: 8000 })
+    await expect(page.getByText('Loading pages...')).toHaveCount(0)
 
     // Section B-Two must still be active
     await expect(page.locator('.tree-node-section', { hasText: 'Section B-Two' })).toHaveClass(/active/)

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -150,8 +150,9 @@ function App() {
 
   const {
     trackers,
-    pagesBySection,
+    sectionPageCache,
     loadSectionPagesMeta,
+    loadedTrackerSectionId,
     activeTrackerId,
     setActiveTrackerId,
     activeTracker,
@@ -177,10 +178,20 @@ function App() {
     flushAllPendingSaves,
   } = useTrackers(userId, activeSectionId)
 
+  const { session: trackerSession, sessionKey, bumpSessionNonce } = useTrackerSession({
+    activeTrackerId,
+    activeTracker,
+    dataLoading,
+    settingsMode,
+    settingsContentVersion,
+    templateContentRef,
+    hydrateContentWithSignedUrls,
+  })
+
   const {
     navIntentRef,
     hashBlockRef,
-    isNavigating,
+    pendingTarget,
     selectNavigationTarget,
     handleInternalHashNavigate,
     clearBlockAnchorIfPresent,
@@ -191,6 +202,8 @@ function App() {
     trackers,
     sectionsLoading,
     dataLoading,
+    loadedTrackerSectionId,
+    editorReady: trackerSession.status === 'ready',
     activeNotebookId,
     activeSectionId,
     activeTrackerId,
@@ -361,16 +374,6 @@ function App() {
   }
 
   const uploadImageRef = useRef(null)
-
-  const { session: trackerSession, sessionKey, bumpSessionNonce } = useTrackerSession({
-    activeTrackerId,
-    activeTracker,
-    dataLoading,
-    settingsMode,
-    settingsContentVersion,
-    templateContentRef,
-    hydrateContentWithSignedUrls,
-  })
 
   const { editor, suppressFocusRef } = useEditorSetup({
     authSession: session,
@@ -574,7 +577,31 @@ function App() {
 
   const isSettingsHub = settingsMode === 'hub'
   const isTemplateEditing = settingsMode === 'daily-template'
-  const hasEditorTarget = Boolean(activeTracker) || isNavigating
+  const activeSectionPending =
+    Boolean(activeSectionId) && loadedTrackerSectionId !== activeSectionId
+  const isSamePageBlockAnchor =
+    Boolean(pendingTarget?.blockId) &&
+    pendingTarget.notebookId === activeNotebookId &&
+    pendingTarget.sectionId === activeSectionId &&
+    pendingTarget.pageId === activeTrackerId
+  const navigationRequiresEditorTransition = Boolean(
+    pendingTarget &&
+      !isSamePageBlockAnchor &&
+      (pendingTarget.notebookId !== activeNotebookId ||
+        pendingTarget.sectionId !== activeSectionId ||
+        pendingTarget.pageId !== activeTrackerId),
+  )
+  const editorTransitioning =
+    navigationRequiresEditorTransition ||
+    dataLoading ||
+    activeSectionPending ||
+    trackerSession.status === 'loading'
+  const hasEditorTarget =
+    Boolean(activeTracker) ||
+    Boolean(activeTrackerId) ||
+    navigationRequiresEditorTransition ||
+    dataLoading ||
+    activeSectionPending
   const compactBadges = sidebarWidth < SIDEBAR_BADGE_COMPACT_WIDTH
   const isSidebarOpen = isMobileViewport ? mobileSidebarOpen : !sidebarCollapsed
   const workspaceClassName = [
@@ -668,7 +695,7 @@ function App() {
           notebooks={notebooks}
           sections={sections}
           trackers={trackers}
-          pagesBySection={pagesBySection}
+          sectionPageCache={sectionPageCache}
           activeNotebookId={activeNotebookId}
           activeSectionId={activeSectionId}
           activeTrackerId={activeTrackerId}
@@ -739,13 +766,14 @@ function App() {
             <EditorPanel
               key={sessionKey}
               editor={editor}
-              editorLocked={trackerSession.status !== 'ready'}
+              editorLocked={trackerSession.status !== 'ready' || editorTransitioning}
               title={titleDraft}
               onTitleChange={(value) => handleTitleChange(value, editor)}
               onDelete={deleteTracker}
               saveStatus={saveStatus}
               onImageUpload={finalUploadImageAndInsert}
               hasTracker={hasEditorTarget}
+              editorTransitioning={editorTransitioning}
               message={message}
               notebookId={activeNotebookId}
               sectionId={activeSectionId}

--- a/src/components/EditorPanel.jsx
+++ b/src/components/EditorPanel.jsx
@@ -35,6 +35,7 @@ function EditorPanel({
   saveStatus,
   onImageUpload,
   hasTracker,
+  editorTransitioning = false,
   message,
   notebookId,
   sectionId,
@@ -738,6 +739,7 @@ function EditorPanel({
         onDelete={onDelete}
         saveStatus={saveStatus}
         hasTracker={hasTracker}
+        editorTransitioning={editorTransitioning}
         message={message}
         titleReadOnly={titleReadOnly}
         editorLocked={editorLocked}

--- a/src/components/app/NavigationTree.jsx
+++ b/src/components/app/NavigationTree.jsx
@@ -4,14 +4,14 @@ import StarterKit from '@tiptap/starter-kit'
 import { supabase } from '../../lib/supabase'
 import { resizeAndEncode } from '../../utils/imageResize'
 import PasteRecipeModal from '../editor/PasteRecipeModal'
-import { getSectionPages } from '../../utils/sectionPages'
+import { SECTION_PAGE_STATUS, getSectionPageEntry } from '../../utils/sectionPages'
 
 function NavigationTree({
   className = '',
   notebooks,
   sections,
   trackers,
-  pagesBySection = {},
+  sectionPageCache = {},
   activeNotebookId,
   activeSectionId,
   activeTrackerId,
@@ -284,11 +284,15 @@ function NavigationTree({
                       notebookSections.map((section) => {
                         const sectionActive = section.id === activeSectionId
                         const sectionExpanded = expandedSections.has(section.id)
-                        const sectionPages = sectionActive
-                          ? trackers
-                          : getSectionPages(pagesBySection, section.id)
-                        const pagesLoading = (sectionActive && loading) ||
-                          (!sectionActive && pagesBySection[section.id] === null)
+                        const sectionPageEntry = getSectionPageEntry(sectionPageCache, section.id)
+                        const sectionPages = sectionPageEntry.pages
+                        const pagesLoading =
+                          (sectionActive && loading && sectionPageEntry.status !== SECTION_PAGE_STATUS.LOADED) ||
+                          sectionPageEntry.status === SECTION_PAGE_STATUS.LOADING
+                        const showPageSkeleton = pagesLoading && sectionPages.length === 0
+                        const showEmptyPages =
+                          sectionPageEntry.status === SECTION_PAGE_STATUS.LOADED &&
+                          sectionPages.length === 0
 
                         return (
                           <div key={section.id} className="tree-branch">
@@ -321,9 +325,16 @@ function NavigationTree({
 
                             {sectionExpanded ? (
                               <div className="tree-children tree-children-pages" role="group">
-                                {pagesLoading ? (
-                                  <p className="subtle tree-empty">Loading pages...</p>
-                                ) : sectionPages.length === 0 ? (
+                                {showPageSkeleton ? (
+                                  <div
+                                    className="tree-page-skeleton"
+                                    role="status"
+                                    aria-label="Loading pages"
+                                  >
+                                    <span />
+                                    <span />
+                                  </div>
+                                ) : showEmptyPages ? (
                                   <p className="subtle tree-empty">No pages yet.</p>
                                 ) : (
                                   sectionPages.map((tracker) => (

--- a/src/components/editor/EditorHeader.jsx
+++ b/src/components/editor/EditorHeader.jsx
@@ -4,6 +4,7 @@ function EditorHeader({
   onDelete,
   saveStatus,
   hasTracker,
+  editorTransitioning,
   message,
   titleReadOnly,
   editorLocked,
@@ -38,8 +39,9 @@ function EditorHeader({
         )}
       </div>
       <div className="status-row">
-        <span className="subtle">{hasTracker ? saveStatus : 'No tracker selected'}</span>
-        {editorLocked && hasTracker && <span className="subtle">Switching...</span>}
+        <span className="subtle">
+          {editorTransitioning ? 'Switching...' : hasTracker ? saveStatus : 'No tracker selected'}
+        </span>
         {message && <span className="message-inline">{message}</span>}
       </div>
     </div>

--- a/src/hooks/useNavigation.js
+++ b/src/hooks/useNavigation.js
@@ -21,6 +21,8 @@ export const useNavigation = ({
   trackers,
   sectionsLoading,
   dataLoading,
+  loadedTrackerSectionId,
+  editorReady = true,
   activeNotebookId,
   activeSectionId,
   activeTrackerId,
@@ -193,6 +195,7 @@ export const useNavigation = ({
       activeTrackerId,
       sectionsLoading,
       dataLoading,
+      loadedTrackerSectionId,
     })
 
     if (step.type === 'wait') return
@@ -223,6 +226,7 @@ export const useNavigation = ({
       clearPendingTarget()
       return
     }
+    if (!editorReady) return
 
     requestAnimationFrame(() => {
       const found = scrollToBlock(pendingTarget.blockId)
@@ -239,6 +243,8 @@ export const useNavigation = ({
     activeTrackerId,
     sectionsLoading,
     dataLoading,
+    loadedTrackerSectionId,
+    editorReady,
     setActiveNotebookId,
     setActiveSectionId,
     setActiveTrackerId,
@@ -294,12 +300,13 @@ export const useNavigation = ({
       savedSelection?.sectionId === activeSectionId &&
       savedSelection.pageId &&
       !activeTrackerId &&
-      (dataLoading || trackers.length > 0)
+      (dataLoading || loadedTrackerSectionId !== activeSectionId || trackers.length > 0)
     ) {
       return
     }
     if (activeNotebookId && sectionsLoading) return
     if (activeSectionId && dataLoading) return
+    if (activeSectionId && loadedTrackerSectionId !== activeSectionId) return
     saveSelection(activeNotebookId, activeSectionId, activeTrackerId)
     if (savedSelectionRef) {
       savedSelectionRef.current = {
@@ -318,6 +325,7 @@ export const useNavigation = ({
     activeTrackerId,
     sectionsLoading,
     dataLoading,
+    loadedTrackerSectionId,
     sections.length,
     trackers.length,
   ])

--- a/src/hooks/useSectionPageCache.js
+++ b/src/hooks/useSectionPageCache.js
@@ -1,0 +1,110 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { supabase } from '../lib/supabase'
+import { runSupabaseQueryWithRetry } from '../utils/supabaseRetry'
+import {
+  SECTION_PAGE_STATUS,
+  getSectionPageEntry,
+  removeSectionPage,
+  setSectionPagesError,
+  setSectionPagesLoaded,
+  setSectionPagesLoading,
+  setSectionTrackerPage,
+  updateSectionPage,
+  upsertSectionPage,
+} from '../utils/sectionPages'
+
+export function useSectionPageCache(userId) {
+  const [sectionPageCache, setSectionPageCache] = useState({})
+  const cacheRef = useRef(sectionPageCache)
+  const inFlightBySectionRef = useRef({})
+  const userIdRef = useRef(userId)
+
+  useEffect(() => {
+    cacheRef.current = sectionPageCache
+  }, [sectionPageCache])
+
+  useEffect(() => {
+    userIdRef.current = userId
+    if (userId) return
+    inFlightBySectionRef.current = {}
+    setSectionPageCache({})
+  }, [userId])
+
+  const seedSectionPages = useCallback((sectionId, pages) => {
+    if (!sectionId) return
+    setSectionPageCache((prev) => setSectionPagesLoaded(prev, sectionId, pages ?? []))
+  }, [])
+
+  const markSectionPagesLoading = useCallback((sectionId) => {
+    if (!sectionId) return
+    setSectionPageCache((prev) => setSectionPagesLoading(prev, sectionId))
+  }, [])
+
+  const markSectionPagesError = useCallback((sectionId, error) => {
+    if (!sectionId) return
+    setSectionPageCache((prev) => setSectionPagesError(prev, sectionId, error))
+  }, [])
+
+  const loadSectionPagesMeta = useCallback(
+    async (sectionId, { force = false } = {}) => {
+      if (!userId || !sectionId) return
+
+      const current = getSectionPageEntry(cacheRef.current, sectionId)
+      if (!force && current.status === SECTION_PAGE_STATUS.LOADED) return
+      if (!force && current.status === SECTION_PAGE_STATUS.LOADING) return
+      if (inFlightBySectionRef.current[sectionId]) return
+
+      inFlightBySectionRef.current[sectionId] = true
+      markSectionPagesLoading(sectionId)
+
+      const { data, error } = await runSupabaseQueryWithRetry(() =>
+        supabase
+          .from('pages')
+          .select('id, title, section_id, sort_order, is_tracker_page')
+          .eq('section_id', sectionId)
+          .order('sort_order', { ascending: true, nullsLast: true }),
+      )
+
+      delete inFlightBySectionRef.current[sectionId]
+      if (userIdRef.current !== userId) return
+
+      if (error) {
+        markSectionPagesError(sectionId, error.message)
+        return
+      }
+
+      seedSectionPages(sectionId, data ?? [])
+    },
+    [markSectionPagesError, markSectionPagesLoading, seedSectionPages, userId],
+  )
+
+  const upsertCachedPage = useCallback((sectionId, page) => {
+    if (!sectionId || !page) return
+    setSectionPageCache((prev) => upsertSectionPage(prev, sectionId, page))
+  }, [])
+
+  const updateCachedPage = useCallback((sectionId, pageId, changes) => {
+    if (!sectionId || !pageId) return
+    setSectionPageCache((prev) => updateSectionPage(prev, sectionId, pageId, changes))
+  }, [])
+
+  const removeCachedPage = useCallback((sectionId, pageId) => {
+    if (!sectionId || !pageId) return
+    setSectionPageCache((prev) => removeSectionPage(prev, sectionId, pageId))
+  }, [])
+
+  const markCachedTrackerPage = useCallback((sectionId, pageId) => {
+    if (!sectionId || !pageId) return
+    setSectionPageCache((prev) => setSectionTrackerPage(prev, sectionId, pageId))
+  }, [])
+
+  return {
+    sectionPageCache,
+    loadSectionPagesMeta,
+    seedSectionPages,
+    upsertCachedPage,
+    updateCachedPage,
+    removeCachedPage,
+    markCachedTrackerPage,
+  }
+}

--- a/src/hooks/useTrackers.js
+++ b/src/hooks/useTrackers.js
@@ -7,10 +7,11 @@ import { readPageDraft, writePageDraft, clearPageDraft } from '../utils/localDra
 import { detectConflict } from '../utils/draftHelpers'
 import { clearNavHierarchyCache } from '../utils/resolveNavHierarchy'
 import { runSupabaseQueryWithRetry } from '../utils/supabaseRetry'
+import { useSectionPageCache } from './useSectionPageCache'
 
 export const useTrackers = (userId, activeSectionId) => {
   const [trackers, setTrackers] = useState([])
-  const [pagesBySection, setPagesBySection] = useState({})
+  const [loadedTrackerSectionId, setLoadedTrackerSectionId] = useState(null)
   const [activeTrackerId, setActiveTrackerId] = useState(null)
   const [dataLoading, setDataLoading] = useState(false)
   const [trackerPageSaving, setTrackerPageSaving] = useState(false)
@@ -36,6 +37,15 @@ export const useTrackers = (userId, activeSectionId) => {
 
   const draftWriteTimersByTrackerRef = useRef({})
   const latestDraftKeyByTrackerRef = useRef({})
+  const {
+    sectionPageCache,
+    loadSectionPagesMeta,
+    seedSectionPages,
+    upsertCachedPage,
+    updateCachedPage,
+    removeCachedPage,
+    markCachedTrackerPage,
+  } = useSectionPageCache(userId)
 
   const activeTrackerServer = trackers.find((tracker) => tracker.id === activeTrackerId) ?? null
   const activeTracker = useMemo(() => {
@@ -94,7 +104,7 @@ export const useTrackers = (userId, activeSectionId) => {
   useEffect(() => {
     if (userId) return
     setTrackers([])
-    setPagesBySection({})
+    setLoadedTrackerSectionId(null)
     setActiveTrackerId(null)
     setDataLoading(false)
     setTrackerPageSaving(false)
@@ -111,57 +121,6 @@ export const useTrackers = (userId, activeSectionId) => {
     draftWriteTimersByTrackerRef.current = {}
     latestDraftKeyByTrackerRef.current = {}
   }, [userId])
-
-  // Fetch light page metadata (no content) for a section on first expand.
-  // Results are cached in pagesBySection so subsequent expands are instant.
-  const loadSectionPagesMeta = useCallback(async (sectionId) => {
-    if (!userId || !sectionId) return
-    setPagesBySection((prev) => {
-      if (prev[sectionId]) return prev
-      return prev
-    })
-    // Check synchronously whether we already have data for this section.
-    // We can't read state inside a callback reliably, so we set a sentinel
-    // and let the updater decide.
-    setPagesBySection((prev) => {
-      if (prev[sectionId] !== undefined) return prev
-      // Mark as loading with null so a second call before the fetch
-      // completes does not fire a duplicate request.
-      return { ...prev, [sectionId]: null }
-    })
-  }, [userId])
-
-  // Perform the actual fetch whenever pagesBySection gains a null sentinel.
-  useEffect(() => {
-    const pending = Object.entries(pagesBySection)
-      .filter(([, v]) => v === null)
-      .map(([id]) => id)
-
-    if (pending.length === 0 || !userId) return
-
-    const fetchMeta = async (sectionId) => {
-      const { data, error } = await runSupabaseQueryWithRetry(() =>
-        supabase
-          .from('pages')
-          .select('id, title, section_id, sort_order, is_tracker_page')
-          .eq('section_id', sectionId)
-          .order('sort_order', { ascending: true, nullsLast: true }),
-      )
-      if (error) {
-        setPagesBySection((prev) => {
-          const next = { ...prev }
-          delete next[sectionId]
-          return next
-        })
-        return
-      }
-      setPagesBySection((prev) => ({ ...prev, [sectionId]: data ?? [] }))
-    }
-
-    for (const sectionId of pending) {
-      fetchMeta(sectionId)
-    }
-  }, [pagesBySection, userId])
 
   // Immediately write any debounced localStorage drafts for all trackers.
   const flushAllPendingDrafts = useCallback(() => {
@@ -299,15 +258,8 @@ export const useTrackers = (userId, activeSectionId) => {
         prev.map((item) => (item.id === trackerId ? { ...item, ...payload } : item)),
       )
       if (typeof payload.title === 'string') {
-        setPagesBySection((prev) => {
-          const sectionId = trackersRef.current.find((t) => t.id === trackerId)?.section_id
-          const existing = sectionId ? prev[sectionId] : null
-          if (!existing) return prev
-          return {
-            ...prev,
-            [sectionId]: existing.map((p) => (p.id === trackerId ? { ...p, title: payload.title } : p)),
-          }
-        })
+        const sectionId = trackersRef.current.find((t) => t.id === trackerId)?.section_id
+        updateCachedPage(sectionId, trackerId, { title: payload.title })
       }
 
       if (trackerId === activeTrackerRef.current?.id) {
@@ -331,7 +283,7 @@ export const useTrackers = (userId, activeSectionId) => {
 
       recomputeHasPendingSaves()
     },
-    [maybeClearLocalDraft, recomputeHasPendingSaves],
+    [maybeClearLocalDraft, recomputeHasPendingSaves, updateCachedPage],
   )
 
   // Flush all pending saves (both localStorage drafts and Supabase writes) immediately.
@@ -387,25 +339,30 @@ export const useTrackers = (userId, activeSectionId) => {
         return
       }
 
-      setTrackers(data ?? [])
+      const nextTrackers = data ?? []
+      setTrackers(nextTrackers)
+      setLoadedTrackerSectionId(sectionId)
+      seedSectionPages(sectionId, nextTrackers)
       setActiveTrackerId((prev) => {
-        if (prev && data?.some((item) => item.id === prev)) return prev
-        return data?.[0]?.id ?? null
+        if (prev && nextTrackers.some((item) => item.id === prev)) return prev
+        return nextTrackers[0]?.id ?? null
       })
       setDataLoading(false)
     },
-    [userId],
+    [seedSectionPages, userId],
   )
 
   useEffect(() => {
     if (!activeSectionId) {
       loadRequestIdRef.current += 1
       setTrackers([])
+      setLoadedTrackerSectionId(null)
       setActiveTrackerId(null)
       setDataLoading(false)
       return
     }
     setTrackers([])
+    setLoadedTrackerSectionId(null)
     setActiveTrackerId(null)
     loadTrackers(activeSectionId)
   }, [activeSectionId, loadTrackers])
@@ -520,13 +477,9 @@ export const useTrackers = (userId, activeSectionId) => {
       return
     }
 
-    setTrackers((prev) => [...prev, { ...data, sort_order: nextSortOrder }])
-    setPagesBySection((prev) => {
-      const existing = prev[sectionId]
-      if (existing === undefined || existing === null) return prev
-      const meta = { id: data.id, title: data.title, section_id: sectionId, sort_order: nextSortOrder, is_tracker_page: false }
-      return { ...prev, [sectionId]: [...existing, meta] }
-    })
+    const created = { ...data, sort_order: nextSortOrder }
+    setTrackers((prev) => [...prev, created])
+    upsertCachedPage(sectionId, created)
     setActiveTrackerId(data.id)
   }
 
@@ -556,13 +509,9 @@ export const useTrackers = (userId, activeSectionId) => {
       return null
     }
 
-    setTrackers((prev) => [...prev, { ...data, sort_order: nextSortOrder }])
-    setPagesBySection((prev) => {
-      const existing = prev[sectionId]
-      if (existing === undefined || existing === null) return prev
-      const meta = { id: data.id, title: pageTitle, section_id: sectionId, sort_order: nextSortOrder, is_tracker_page: false }
-      return { ...prev, [sectionId]: [...existing, meta] }
-    })
+    const created = { ...data, sort_order: nextSortOrder }
+    setTrackers((prev) => [...prev, created])
+    upsertCachedPage(sectionId, created)
     setActiveTrackerId(data.id)
     return data
   }
@@ -575,14 +524,7 @@ export const useTrackers = (userId, activeSectionId) => {
         sort_order: index + 1,
       }))
       setTrackers(reordered)
-      setPagesBySection((prev) => {
-        if (!activeSectionId || !prev[activeSectionId]) return prev
-        const orderMap = Object.fromEntries(reordered.map((item) => [item.id, item.sort_order]))
-        const updated = prev[activeSectionId].map((p) =>
-          orderMap[p.id] !== undefined ? { ...p, sort_order: orderMap[p.id] } : p,
-        )
-        return { ...prev, [activeSectionId]: updated }
-      })
+      seedSectionPages(activeSectionId, reordered)
       const updates = reordered.map((item) =>
         supabase.from('pages').update({ sort_order: item.sort_order }).eq('id', item.id),
       )
@@ -592,7 +534,7 @@ export const useTrackers = (userId, activeSectionId) => {
         setMessage(error.message)
       }
     },
-    [userId, activeSectionId],
+    [activeSectionId, seedSectionPages, userId],
   )
 
   const setTrackerPage = useCallback(
@@ -610,12 +552,7 @@ export const useTrackers = (userId, activeSectionId) => {
           is_tracker_page: item.id === pageId,
         })),
       )
-      setPagesBySection((prev) => {
-        const existing = prev[activeSectionId]
-        if (!existing) return prev
-        const updated = existing.map((p) => ({ ...p, is_tracker_page: p.id === pageId }))
-        return { ...prev, [activeSectionId]: updated }
-      })
+      markCachedTrackerPage(activeSectionId, pageId)
 
       const { error: clearError } = await supabase
         .from('pages')
@@ -627,6 +564,7 @@ export const useTrackers = (userId, activeSectionId) => {
       if (clearError) {
         setTrackers(currentTrackers)
         setMessage(clearError.message)
+        seedSectionPages(activeSectionId, currentTrackers)
         setTrackerPageSaving(false)
         return
       }
@@ -651,7 +589,7 @@ export const useTrackers = (userId, activeSectionId) => {
 
       setTrackerPageSaving(false)
     },
-    [userId, activeSectionId, loadTrackers],
+    [userId, activeSectionId, loadTrackers, markCachedTrackerPage, seedSectionPages],
   )
 
   const deleteTracker = async (trackerToDelete = null) => {
@@ -685,12 +623,7 @@ export const useTrackers = (userId, activeSectionId) => {
     clearNavHierarchyCache()
     const nextTrackers = trackers.filter((item) => item.id !== tracker.id)
     setTrackers(nextTrackers)
-    setPagesBySection((prev) => {
-      const sectionId = tracker.section_id ?? activeSectionId
-      const existing = prev[sectionId]
-      if (!existing) return prev
-      return { ...prev, [sectionId]: existing.filter((p) => p.id !== tracker.id) }
-    })
+    removeCachedPage(tracker.section_id ?? activeSectionId, tracker.id)
     delete pendingTitleByTrackerRef.current[tracker.id]
     clearPageDraft(tracker.id)
     setActiveTrackerId((prev) => (prev === tracker.id ? nextTrackers[0]?.id ?? null : prev))
@@ -716,8 +649,9 @@ export const useTrackers = (userId, activeSectionId) => {
 
   return {
     trackers,
-    pagesBySection,
+    sectionPageCache,
     loadSectionPagesMeta,
+    loadedTrackerSectionId,
     activeTrackerId,
     setActiveTrackerId,
     activeTracker,

--- a/src/styles/layout.css
+++ b/src/styles/layout.css
@@ -283,6 +283,25 @@
   font-size: 0.82rem;
 }
 
+.tree-page-skeleton {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  padding: 0.25rem 0.55rem 0.3rem 1.55rem;
+}
+
+.tree-page-skeleton span {
+  display: block;
+  width: min(9rem, 72%);
+  height: 0.65rem;
+  border-radius: var(--radius-sm);
+  background: var(--surface-raised);
+}
+
+.tree-page-skeleton span:nth-child(2) {
+  width: min(7rem, 58%);
+}
+
 .tree-node {
   width: 100%;
   min-width: 0;

--- a/src/utils/__tests__/navigationTarget.test.js
+++ b/src/utils/__tests__/navigationTarget.test.js
@@ -88,6 +88,7 @@ describe('getNavigationApplyStep', () => {
       activeNotebookId: 'nb-2',
       activeSectionId: 'sec-2',
       activeTrackerId: 'pg-1',
+      loadedTrackerSectionId: 'sec-2',
     })).toEqual({ type: 'page', id: 'pg-2' })
   })
 
@@ -100,6 +101,33 @@ describe('getNavigationApplyStep', () => {
       activeNotebookId: 'nb-2',
       activeSectionId: 'sec-2',
       dataLoading: true,
+      loadedTrackerSectionId: 'sec-2',
     })).toEqual({ type: 'wait' })
+  })
+
+  it('waits for the target section page data instead of using stale trackers', () => {
+    expect(getNavigationApplyStep({
+      target: { notebookId: 'nb-2', sectionId: 'sec-2', pageId: 'pg-2' },
+      notebooks,
+      sections,
+      trackers: [{ id: 'pg-1', section_id: 'sec-1' }],
+      activeNotebookId: 'nb-2',
+      activeSectionId: 'sec-2',
+      activeTrackerId: 'pg-1',
+      dataLoading: false,
+      loadedTrackerSectionId: 'sec-1',
+    })).toEqual({ type: 'wait' })
+  })
+
+  it('treats a page as missing only after the target section has loaded', () => {
+    expect(getNavigationApplyStep({
+      target: { notebookId: 'nb-2', sectionId: 'sec-2', pageId: 'pg-missing' },
+      notebooks,
+      sections,
+      trackers,
+      activeNotebookId: 'nb-2',
+      activeSectionId: 'sec-2',
+      loadedTrackerSectionId: 'sec-2',
+    })).toEqual({ type: 'missing' })
   })
 })

--- a/src/utils/__tests__/sectionPages.test.js
+++ b/src/utils/__tests__/sectionPages.test.js
@@ -1,5 +1,15 @@
 import { describe, it, expect } from 'vitest'
-import { getSectionPages } from '../sectionPages'
+import {
+  SECTION_PAGE_STATUS,
+  getSectionPageEntry,
+  getSectionPages,
+  removeSectionPage,
+  setSectionPagesLoaded,
+  setSectionPagesLoading,
+  setSectionTrackerPage,
+  updateSectionPage,
+  upsertSectionPage,
+} from '../sectionPages'
 
 const makePages = () => [
   { id: 'p1', title: 'Alpha', section_id: 's1', sort_order: 2, is_tracker_page: false },
@@ -9,8 +19,8 @@ const makePages = () => [
 
 describe('getSectionPages', () => {
   it('returns pages for a known section sorted ascending by sort_order', () => {
-    const pagesBySection = { s1: [makePages()[0], makePages()[1]] }
-    const result = getSectionPages(pagesBySection, 's1')
+    const sectionPageCache = setSectionPagesLoaded({}, 's1', [makePages()[0], makePages()[1]])
+    const result = getSectionPages(sectionPageCache, 's1')
     expect(result.map((p) => p.id)).toEqual(['p2', 'p1'])
   })
 
@@ -23,21 +33,19 @@ describe('getSectionPages', () => {
   })
 
   it('returns a single page without error', () => {
-    const pagesBySection = { s2: [makePages()[2]] }
-    const result = getSectionPages(pagesBySection, 's2')
+    const sectionPageCache = setSectionPagesLoaded({}, 's2', [makePages()[2]])
+    const result = getSectionPages(sectionPageCache, 's2')
     expect(result).toHaveLength(1)
     expect(result[0].id).toBe('p3')
   })
 
   it('sorts null sort_order to the end', () => {
-    const pagesBySection = {
-      s1: [
-        { id: 'pA', sort_order: null },
-        { id: 'pB', sort_order: 1 },
-        { id: 'pC', sort_order: 3 },
-      ],
-    }
-    const result = getSectionPages(pagesBySection, 's1')
+    const sectionPageCache = setSectionPagesLoaded({}, 's1', [
+      { id: 'pA', section_id: 's1', sort_order: null },
+      { id: 'pB', section_id: 's1', sort_order: 1 },
+      { id: 'pC', section_id: 's1', sort_order: 3 },
+    ])
+    const result = getSectionPages(sectionPageCache, 's1')
     expect(result.map((p) => p.id)).toEqual(['pB', 'pC', 'pA'])
   })
 
@@ -46,8 +54,42 @@ describe('getSectionPages', () => {
       { id: 'p2', sort_order: 2 },
       { id: 'p1', sort_order: 1 },
     ]
-    const pagesBySection = { s1: source }
-    getSectionPages(pagesBySection, 's1')
+    const sectionPageCache = setSectionPagesLoaded({}, 's1', source)
+    getSectionPages(sectionPageCache, 's1')
     expect(source[0].id).toBe('p2')
+  })
+
+  it('distinguishes idle, loading, and loaded-empty sections', () => {
+    expect(getSectionPageEntry({}, 's1').status).toBe(SECTION_PAGE_STATUS.IDLE)
+
+    const loading = setSectionPagesLoading({}, 's1')
+    expect(getSectionPageEntry(loading, 's1').status).toBe(SECTION_PAGE_STATUS.LOADING)
+
+    const loaded = setSectionPagesLoaded({}, 's1', [])
+    const entry = getSectionPageEntry(loaded, 's1')
+    expect(entry.status).toBe(SECTION_PAGE_STATUS.LOADED)
+    expect(entry.pages).toEqual([])
+  })
+
+  it('patches loaded page metadata without touching unknown sections', () => {
+    const loaded = setSectionPagesLoaded({}, 's1', [makePages()[0]])
+    const updated = updateSectionPage(loaded, 's1', 'p1', { title: 'Renamed' })
+    expect(getSectionPages(updated, 's1')[0].title).toBe('Renamed')
+
+    expect(updateSectionPage({}, 's1', 'p1', { title: 'Ignored' })).toEqual({})
+  })
+
+  it('upserts, removes, and marks tracker page metadata', () => {
+    let cache = setSectionPagesLoaded({}, 's1', [])
+    cache = upsertSectionPage(cache, 's1', makePages()[0])
+    cache = upsertSectionPage(cache, 's1', makePages()[1])
+    expect(getSectionPages(cache, 's1').map((page) => page.id)).toEqual(['p2', 'p1'])
+
+    cache = setSectionTrackerPage(cache, 's1', 'p1')
+    expect(getSectionPages(cache, 's1').find((page) => page.id === 'p1').is_tracker_page).toBe(true)
+    expect(getSectionPages(cache, 's1').find((page) => page.id === 'p2').is_tracker_page).toBe(false)
+
+    cache = removeSectionPage(cache, 's1', 'p1')
+    expect(getSectionPages(cache, 's1').map((page) => page.id)).toEqual(['p2'])
   })
 })

--- a/src/utils/navigationTarget.js
+++ b/src/utils/navigationTarget.js
@@ -39,6 +39,7 @@ export const getNavigationApplyStep = ({
   activeTrackerId = null,
   sectionsLoading = false,
   dataLoading = false,
+  loadedTrackerSectionId = null,
 }) => {
   if (!target?.notebookId) return { type: 'done' }
 
@@ -62,6 +63,10 @@ export const getNavigationApplyStep = ({
   }
 
   if (!target.pageId) return { type: 'done' }
+
+  if (loadedTrackerSectionId !== target.sectionId) {
+    return { type: 'wait' }
+  }
 
   if (!trackers.some((item) => item.id === target.pageId && item.section_id === target.sectionId)) {
     if (trackers.length === 0) return { type: 'wait' }

--- a/src/utils/sectionPages.js
+++ b/src/utils/sectionPages.js
@@ -1,17 +1,122 @@
-/**
- * Returns a sorted copy of the pages cached for a given section.
- * Pages with a null/undefined sort_order sort to the end.
- *
- * @param {Record<string, Array>} pagesBySection - keyed by section ID
- * @param {string} sectionId
- * @returns {Array}
- */
-export function getSectionPages(pagesBySection, sectionId) {
-  const pages = pagesBySection[sectionId]
-  if (!pages || pages.length === 0) return []
+export const SECTION_PAGE_STATUS = {
+  IDLE: 'idle',
+  LOADING: 'loading',
+  LOADED: 'loaded',
+  ERROR: 'error',
+}
+
+export function toSectionPageMeta(page) {
+  return {
+    id: page.id,
+    title: page.title,
+    section_id: page.section_id,
+    sort_order: page.sort_order ?? null,
+    is_tracker_page: Boolean(page.is_tracker_page),
+  }
+}
+
+export function sortSectionPages(pages = []) {
   return [...pages].sort((a, b) => {
     const aOrder = a.sort_order ?? Infinity
     const bOrder = b.sort_order ?? Infinity
     return aOrder - bOrder
   })
+}
+
+export function makeSectionPageEntry(status, pages = [], error = null) {
+  return {
+    status,
+    pages: sortSectionPages(pages.map(toSectionPageMeta)),
+    error,
+  }
+}
+
+export function getSectionPageEntry(sectionPageCache = {}, sectionId) {
+  const entry = sectionPageCache[sectionId]
+  if (Array.isArray(entry)) {
+    return makeSectionPageEntry(SECTION_PAGE_STATUS.LOADED, entry)
+  }
+  if (!entry) {
+    return makeSectionPageEntry(SECTION_PAGE_STATUS.IDLE)
+  }
+  return makeSectionPageEntry(
+    entry.status ?? SECTION_PAGE_STATUS.IDLE,
+    entry.pages ?? [],
+    entry.error ?? null,
+  )
+}
+
+/**
+ * Returns a sorted copy of the pages cached for a given section.
+ * Pages with a null/undefined sort_order sort to the end.
+ */
+export function getSectionPages(sectionPageCache, sectionId) {
+  return getSectionPageEntry(sectionPageCache, sectionId).pages
+}
+
+export function areSectionPagesLoaded(sectionPageCache, sectionId) {
+  return getSectionPageEntry(sectionPageCache, sectionId).status === SECTION_PAGE_STATUS.LOADED
+}
+
+export function setSectionPagesLoading(sectionPageCache, sectionId) {
+  const current = getSectionPageEntry(sectionPageCache, sectionId)
+  return {
+    ...sectionPageCache,
+    [sectionId]: makeSectionPageEntry(SECTION_PAGE_STATUS.LOADING, current.pages),
+  }
+}
+
+export function setSectionPagesLoaded(sectionPageCache, sectionId, pages) {
+  return {
+    ...sectionPageCache,
+    [sectionId]: makeSectionPageEntry(SECTION_PAGE_STATUS.LOADED, pages),
+  }
+}
+
+export function setSectionPagesError(sectionPageCache, sectionId, error) {
+  const current = getSectionPageEntry(sectionPageCache, sectionId)
+  return {
+    ...sectionPageCache,
+    [sectionId]: makeSectionPageEntry(SECTION_PAGE_STATUS.ERROR, current.pages, error),
+  }
+}
+
+export function upsertSectionPage(sectionPageCache, sectionId, page) {
+  const current = getSectionPageEntry(sectionPageCache, sectionId)
+  if (current.status !== SECTION_PAGE_STATUS.LOADED) return sectionPageCache
+  const meta = toSectionPageMeta({ ...page, section_id: page.section_id ?? sectionId })
+  const found = current.pages.some((item) => item.id === meta.id)
+  const pages = found
+    ? current.pages.map((item) => (item.id === meta.id ? { ...item, ...meta } : item))
+    : [...current.pages, meta]
+  return setSectionPagesLoaded(sectionPageCache, sectionId, pages)
+}
+
+export function updateSectionPage(sectionPageCache, sectionId, pageId, changes) {
+  const current = getSectionPageEntry(sectionPageCache, sectionId)
+  if (current.status !== SECTION_PAGE_STATUS.LOADED) return sectionPageCache
+  const pages = current.pages.map((page) =>
+    page.id === pageId ? toSectionPageMeta({ ...page, ...changes }) : page,
+  )
+  return setSectionPagesLoaded(sectionPageCache, sectionId, pages)
+}
+
+export function removeSectionPage(sectionPageCache, sectionId, pageId) {
+  const current = getSectionPageEntry(sectionPageCache, sectionId)
+  if (current.status !== SECTION_PAGE_STATUS.LOADED) return sectionPageCache
+  return setSectionPagesLoaded(
+    sectionPageCache,
+    sectionId,
+    current.pages.filter((page) => page.id !== pageId),
+  )
+}
+
+export function setSectionTrackerPage(sectionPageCache, sectionId, pageId) {
+  const current = getSectionPageEntry(sectionPageCache, sectionId)
+  if (current.status !== SECTION_PAGE_STATUS.LOADED) return sectionPageCache
+  const pages = current.pages.map((page) => ({
+    ...page,
+    is_tracker_page: page.id === pageId,
+  }))
+  return setSectionPagesLoaded(sectionPageCache, sectionId, pages)
 }


### PR DESCRIPTION
## Summary

Extracts section-page fetching and caching into a dedicated `useSectionPageCache` hook, upgrades the cache to track per-section load status, and fixes the navigation step-machine to wait until the correct section's pages are fully loaded before attempting deep-link scroll.

## Changes

**New**
- `src/hooks/useSectionPageCache.js` — standalone hook owning all section page fetch/cache lifecycle; replaces the inline logic that lived in `useTrackers`

**Expanded**
- `src/utils/sectionPages.js` — adds `SECTION_PAGE_STATUS` enum, typed entry shape, and pure mutation helpers (`setSectionPagesLoaded`, `setSectionPagesLoading`, `setSectionPagesError`, `upsertSectionPage`, `updateSectionPage`, `removeSectionPage`, `setSectionTrackerPage`, `areSectionPagesLoaded`)
- `src/utils/navigationTarget.js` — `getNavigationApplyStep` now accepts `loadedTrackerSectionId` and returns `wait` until it matches the target section
- `src/hooks/useNavigation.js` — threads `loadedTrackerSectionId` and `editorReady` through the step-machine; guards `scrollToBlock` on `editorReady` to prevent premature deep-link scroll

**Simplified**
- `src/hooks/useTrackers.js` — page cache logic removed; delegates to `useSectionPageCache`
- `src/App.jsx`, `src/components/app/NavigationTree.jsx`, `src/components/editor/EditorHeader.jsx`, `src/components/EditorPanel.jsx` — wiring updates for the new hook and props

**Tests**
- `src/utils/__tests__/sectionPages.test.js` — coverage for new status helpers and entry shape
- `src/utils/__tests__/navigationTarget.test.js` — cases for `loadedTrackerSectionId` wait logic

**E2E**
- `e2e/notebook-section-hydration.spec.js`, `e2e/issue-114-chevron-toggle.spec.js`, `e2e/issue-70-same-notebook-copy.spec.js` — updated for the new loading behavior

## Files Changed

| File | Change |
|---|---|
| `src/hooks/useSectionPageCache.js` | Added |
| `src/utils/sectionPages.js` | Modified |
| `src/utils/navigationTarget.js` | Modified |
| `src/hooks/useNavigation.js` | Modified |
| `src/hooks/useTrackers.js` | Modified |
| `src/App.jsx` | Modified |
| `src/components/app/NavigationTree.jsx` | Modified |
| `src/components/editor/EditorHeader.jsx` | Modified |
| `src/components/EditorPanel.jsx` | Modified |
| `src/styles/layout.css` | Modified |
| `src/utils/__tests__/sectionPages.test.js` | Modified |
| `src/utils/__tests__/navigationTarget.test.js` | Modified |
| `e2e/notebook-section-hydration.spec.js` | Modified |
| `e2e/issue-114-chevron-toggle.spec.js` | Modified |
| `e2e/issue-70-same-notebook-copy.spec.js` | Modified |

## Testing

- [ ] Unit tests pass (`npm run test:unit`)
- [ ] E2E tests pass on CI (section hydration, chevron toggle, same-notebook copy)
- [ ] Deep-link navigation lands on the correct block after section load completes
- [ ] No regression on notebook expand / section expand page listing

## Related Issues

Follows #137 (navigation target step-machine) and #136 (lazy-per-section page cache)