### PR TITLE
Fix AI daily tracker content loading

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -156,6 +156,7 @@ function App() {
     setActiveTrackerId,
     activeTracker,
     sectionTrackerPage,
+    loadTrackerContent,
     titleDraft,
     saveStatus,
     hasPendingSaves,
@@ -779,6 +780,7 @@ function App() {
               onNavigateHash={handleInternalHashNavigate}
               allTrackers={trackers}
               trackerSourcePage={sectionTrackerPage}
+              loadTrackerContent={loadTrackerContent}
               onSetTrackerPage={setTrackerPage}
               trackerPageSaving={trackerPageSaving}
               userId={userId}

--- a/src/components/EditorPanel.jsx
+++ b/src/components/EditorPanel.jsx
@@ -43,6 +43,7 @@ function EditorPanel({
   onNavigateHash,
   allTrackers,
   trackerSourcePage = null,
+  loadTrackerContent = null,
   onSetTrackerPage = null,
   trackerPageSaving = false,
   userId,
@@ -230,11 +231,22 @@ function EditorPanel({
         return
       }
 
+      let trackerContent = null
+      if (sourceTrackerPage.id === trackerId) {
+        trackerContent = editor.getJSON()
+      } else if (loadTrackerContent) {
+        trackerContent = await loadTrackerContent(sourceTrackerPage.id)
+      }
+
+      if (!trackerContent || typeof trackerContent !== 'object') {
+        throw new Error('Tracker page content could not be loaded.')
+      }
+
       const trackerPages = [
         {
           title: sourceTrackerPage.title,
           pageId: sourceTrackerPage.id,
-          content: sourceTrackerPage.content || { type: 'doc', content: [] },
+          content: trackerContent,
         },
       ]
       const trackerPagesForModel = trackerPages.map((page) => ({

--- a/src/hooks/usePageContentCache.js
+++ b/src/hooks/usePageContentCache.js
@@ -20,7 +20,7 @@ const MAX_CACHE_ENTRIES = 30
  *
  * Returns:
  *   pageContentCache     — reactive cache map (React state)
- *   loadPageContent(id)  — idempotent single-row content fetch
+ *   loadPageContent(id)  — idempotent single-row content fetch that resolves content
  *   setPageContent(id, c)— write-through after autosave
  *   invalidatePage(id)   — resets to IDLE (for conflict resolution)
  */
@@ -62,54 +62,67 @@ export function usePageContentCache(userId) {
 
   const loadPageContent = useCallback(
     async (pageId) => {
-      if (!userId || !pageId) return
+      if (!userId || !pageId) return null
       const current = cacheRef.current[pageId]
-      if (current?.status === PAGE_CONTENT_STATUS.LOADING) return
-      if (current?.status === PAGE_CONTENT_STATUS.LOADED) return
-      if (inFlightRef.current[pageId]) return
+      if (current?.status === PAGE_CONTENT_STATUS.LOADING && inFlightRef.current[pageId]) {
+        return inFlightRef.current[pageId]
+      }
+      if (current?.status === PAGE_CONTENT_STATUS.LOADED) return current.content ?? null
+      if (inFlightRef.current[pageId]) return inFlightRef.current[pageId]
 
-      inFlightRef.current[pageId] = true
-      setPageContentCache((prev) => ({
-        ...prev,
-        [pageId]: {
-          status: PAGE_CONTENT_STATUS.LOADING,
-          content: prev[pageId]?.content ?? null,
-          error: null,
-          loadedAt: null,
-        },
-      }))
-
-      const { data, error } = await runSupabaseQueryWithRetry(() =>
-        supabase
-          .from('pages')
-          .select('content, updated_at')
-          .eq('id', pageId)
-          .single(),
-      )
-
-      delete inFlightRef.current[pageId]
-      if (userIdRef.current !== userId) return
-
-      if (error) {
+      const request = (async () => {
         setPageContentCache((prev) => ({
           ...prev,
-          [pageId]: { status: PAGE_CONTENT_STATUS.ERROR, content: null, error: error.message, loadedAt: null },
-        }))
-        return
-      }
-
-      recordAccess(pageId)
-      setPageContentCache((prev) =>
-        applyEviction({
-          ...prev,
           [pageId]: {
-            status: PAGE_CONTENT_STATUS.LOADED,
-            content: data?.content ?? null,
+            status: PAGE_CONTENT_STATUS.LOADING,
+            content: prev[pageId]?.content ?? null,
             error: null,
-            loadedAt: Date.now(),
+            loadedAt: null,
           },
-        }),
-      )
+        }))
+
+        const { data, error } = await runSupabaseQueryWithRetry(() =>
+          supabase
+            .from('pages')
+            .select('content, updated_at')
+            .eq('id', pageId)
+            .single(),
+        )
+
+        if (userIdRef.current !== userId) return null
+
+        if (error) {
+          setPageContentCache((prev) => ({
+            ...prev,
+            [pageId]: { status: PAGE_CONTENT_STATUS.ERROR, content: null, error: error.message, loadedAt: null },
+          }))
+          throw new Error(error.message)
+        }
+
+        const content = data?.content ?? null
+        recordAccess(pageId)
+        setPageContentCache((prev) =>
+          applyEviction({
+            ...prev,
+            [pageId]: {
+              status: PAGE_CONTENT_STATUS.LOADED,
+              content,
+              error: null,
+              loadedAt: Date.now(),
+            },
+          }),
+        )
+        return content
+      })()
+
+      inFlightRef.current[pageId] = request
+      try {
+        return await request
+      } finally {
+        if (inFlightRef.current[pageId] === request) {
+          delete inFlightRef.current[pageId]
+        }
+      }
     },
     [userId, recordAccess, applyEviction],
   )

--- a/src/hooks/useTrackers.js
+++ b/src/hooks/useTrackers.js
@@ -695,6 +695,18 @@ export const useTrackers = (userId, activeSectionId) => {
 
   const sectionTrackerPage = trackers.find((item) => item.is_tracker_page) ?? null
 
+  const loadTrackerContent = useCallback(
+    async (pageId) => {
+      if (!pageId) return null
+      const entry = pageContentCacheRef.current[pageId]
+      if (entry?.status === PAGE_CONTENT_STATUS.LOADED) {
+        return entry.content ?? null
+      }
+      return loadPageContent(pageId)
+    },
+    [loadPageContent],
+  )
+
   return {
     trackers,
     sectionPageCache,
@@ -722,6 +734,7 @@ export const useTrackers = (userId, activeSectionId) => {
     activeTrackerRef,
     draftConflictRef,
     sectionTrackerPage,
+    loadTrackerContent,
     draftConflict,
     resolveConflictWithServer,
     resolveConflictWithDraft,


### PR DESCRIPTION
## Summary
- resolve AI Daily tracker content from the page content cache instead of page metadata
- use the active editor document when the tracker page is currently open
- make page content loading awaitable so AI Daily can fetch tracker content before invoking the edge function

## Testing
- npm run build
- npm run test:unit -- src/hooks/__tests__/usePageContentCache.test.js