### PR TITLE
fix: prevent stale-device overwrites with OCC + realtime sync

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,7 @@ tmp_req*.txt
 recovery/
 .codex
 .playwright-mcp/
+
+# Reference implementation clones (kept locally for review, not tracked)
+docmost/
+notesnook/

--- a/e2e/cross-notebook-switch-speed.spec.js
+++ b/e2e/cross-notebook-switch-speed.spec.js
@@ -82,7 +82,9 @@ test.describe('cross-notebook switch speed', () => {
     await page.evaluate(({ nb, sec, pg }) => {
       window.location.hash = `#nb=${nb}&sec=${sec}&pg=${pg}`
     }, { nb: notebookA.id, sec: sectionA.id, pg: pageA.id })
-    await expect(page.locator('.ProseMirror')).toContainText('Content of page A', { timeout: 2000 })
+    // This is only cache warmup; it may still hit Supabase and should not use
+    // the strict cached-return SLA asserted below.
+    await expect(page.locator('.ProseMirror')).toContainText('Content of page A', { timeout: 10000 })
 
     // Navigate back to page B (should be in cache — no loading flash)
     const t0 = Date.now()

--- a/e2e/sync-occ-conflict.spec.js
+++ b/e2e/sync-occ-conflict.spec.js
@@ -1,0 +1,84 @@
+// Sync regression: optimistic-concurrency conflict at save time.
+//
+// Repro: load a page in the browser, simulate "another device" writing the
+// same row via the Supabase API (bumps updated_at), then make a local edit.
+// The save should detect the version mismatch and surface ConflictModal
+// instead of silently overwriting the other device's content.
+
+import { test, expect } from './fixtures'
+import { getSupabase, createNotebook, createSection, createPage, deleteNotebookById, waitForApp } from './test-helpers'
+
+const INITIAL_CONTENT = {
+  type: 'doc',
+  content: [
+    { type: 'paragraph', content: [{ type: 'text', text: 'Initial shared content.' }] },
+  ],
+}
+
+const REMOTE_DEVICE_CONTENT = {
+  type: 'doc',
+  content: [
+    { type: 'heading', attrs: { level: 2 }, content: [{ type: 'text', text: 'Remote Device Edit' }] },
+    { type: 'paragraph', content: [{ type: 'text', text: 'Written by the other device.' }] },
+  ],
+}
+
+test.describe('Save-time OCC conflict prevents stale overwrite', () => {
+  let supabaseInfo = null
+  let notebookId = null
+  let sectionId = null
+  let testPage = null
+
+  test.beforeAll(async () => {
+    supabaseInfo = await getSupabase()
+    const nb = await createNotebook(supabaseInfo.client, supabaseInfo.userId, `OCC Notebook ${Date.now()}`)
+    notebookId = nb.id
+    const sec = await createSection(supabaseInfo.client, supabaseInfo.userId, nb.id, 'OCC Section')
+    sectionId = sec.id
+  })
+
+  test.afterAll(async () => {
+    if (!supabaseInfo?.client) return
+    await deleteNotebookById(supabaseInfo.client, notebookId)
+  })
+
+  test('a stale save surfaces ConflictModal instead of overwriting the server', async ({ page }) => {
+    testPage = await createPage(supabaseInfo.client, supabaseInfo.userId, sectionId, 'OCC Test Page', INITIAL_CONTENT)
+
+    // Open the page in the browser — this caches the current updated_at as the
+    // OCC token. Wait for the editor to fully render the initial content.
+    await waitForApp(page, `/#pg=${testPage.id}`)
+    await expect(page.locator('.ProseMirror')).toContainText('Initial shared content.', { timeout: 15000 })
+
+    // Simulate "the other device" writing the row via the API directly. This
+    // advances updated_at without going through our save path.
+    const futureTs = new Date(Date.now() + 60_000).toISOString()
+    const { error: remoteWriteError } = await supabaseInfo.client
+      .from('pages')
+      .update({ content: REMOTE_DEVICE_CONTENT, updated_at: futureTs })
+      .eq('id', testPage.id)
+    expect(remoteWriteError).toBeNull()
+
+    // Make a local edit so the autosave path runs and hits the .eq(updated_at)
+    // mismatch. Type into the editor.
+    await page.locator('.ProseMirror').click()
+    await page.keyboard.type(' Local edit on top of stale snapshot.')
+
+    // ConflictModal should appear. The existing draft-conflict copy is reused.
+    await expect(page.locator('.conflict-modal')).toBeVisible({ timeout: 15000 })
+
+    // Critical: server content must still be the remote-device write, NOT our
+    // stale-overlay edit. If OCC were broken, the save would have clobbered it.
+    await expect(async () => {
+      const { data, error } = await supabaseInfo.client
+        .from('pages')
+        .select('content')
+        .eq('id', testPage.id)
+        .single()
+      if (error) throw error
+      const serverText = JSON.stringify(data?.content)
+      expect(serverText).toContain('Remote Device Edit')
+      expect(serverText).not.toContain('Local edit on top of stale snapshot.')
+    }).toPass({ timeout: 10000 })
+  })
+})

--- a/src/hooks/sync/usePageRealtime.js
+++ b/src/hooks/sync/usePageRealtime.js
@@ -1,0 +1,37 @@
+import { useEffect } from 'react'
+import { supabase } from '../../lib/supabase'
+
+/**
+ * Subscribe to Postgres realtime UPDATE events for a single active page.
+ *
+ * The handler fires whenever a different device writes the row. The caller
+ * decides what to do:
+ *   - editor is clean -> swap content in, advance OCC token
+ *   - editor is dirty -> just remember the new server version so the next
+ *     save attempt enters the conflict gate immediately
+ *
+ * Echoes of our own writes are filtered upstream by comparing
+ * `payload.new.updated_at` to the token we just stored.
+ *
+ * @param {string|null} pageId       The active page id, or null to unsubscribe.
+ * @param {(payload: { new: { id: string, content: unknown, updated_at: string, title: string } }) => void} onRemoteChange
+ */
+export function usePageRealtime(pageId, onRemoteChange) {
+  useEffect(() => {
+    if (!pageId) return
+    const channel = supabase
+      .channel(`page:${pageId}`)
+      .on(
+        'postgres_changes',
+        { event: 'UPDATE', schema: 'public', table: 'pages', filter: `id=eq.${pageId}` },
+        (payload) => {
+          if (payload?.new) onRemoteChange(payload)
+        },
+      )
+      .subscribe()
+
+    return () => {
+      supabase.removeChannel(channel)
+    }
+  }, [pageId, onRemoteChange])
+}

--- a/src/hooks/usePageContentCache.js
+++ b/src/hooks/usePageContentCache.js
@@ -19,10 +19,12 @@ const MAX_CACHE_ENTRIES = 30
  * Shape: { [pageId]: { status, content, error, loadedAt } }
  *
  * Returns:
- *   pageContentCache     — reactive cache map (React state)
- *   loadPageContent(id)  — idempotent single-row content fetch that resolves content
- *   setPageContent(id, c)— write-through after autosave
- *   invalidatePage(id)   — resets to IDLE (for conflict resolution)
+ *   pageContentCache         — reactive cache map (React state)
+ *   loadPageContent(id)      — idempotent single-row content fetch that resolves content
+ *   setPageContent(id, c, ts)— write-through after autosave (ts advances the OCC token)
+ *   invalidatePage(id)       — resets to IDLE (for conflict resolution)
+ *   getKnownUpdatedAt(id)    — current OCC version token from server
+ *   setKnownUpdatedAt(id, ts)— record the latest server timestamp we've observed
  */
 export function usePageContentCache(userId) {
   const [pageContentCache, setPageContentCache] = useState({})
@@ -31,6 +33,9 @@ export function usePageContentCache(userId) {
   const userIdRef = useRef(userId)
   // LRU order: oldest pageId at index 0, newest at the end
   const lruOrderRef = useRef([])
+  // OCC version tokens: { [pageId]: '2026-05-10T12:34:56.789Z' }
+  // Populated from each successful load and each successful save.
+  const knownUpdatedAtRef = useRef({})
 
   useEffect(() => {
     cacheRef.current = pageContentCache
@@ -41,6 +46,7 @@ export function usePageContentCache(userId) {
     if (userId) return
     inFlightRef.current = {}
     lruOrderRef.current = []
+    knownUpdatedAtRef.current = {}
     setPageContentCache({})
   }, [userId])
 
@@ -100,6 +106,9 @@ export function usePageContentCache(userId) {
         }
 
         const content = data?.content ?? null
+        if (data?.updated_at) {
+          knownUpdatedAtRef.current[pageId] = data.updated_at
+        }
         recordAccess(pageId)
         setPageContentCache((prev) =>
           applyEviction({
@@ -128,8 +137,11 @@ export function usePageContentCache(userId) {
   )
 
   const setPageContent = useCallback(
-    (pageId, content) => {
+    (pageId, content, updatedAt) => {
       if (!pageId) return
+      if (updatedAt) {
+        knownUpdatedAtRef.current[pageId] = updatedAt
+      }
       recordAccess(pageId)
       setPageContentCache((prev) =>
         applyEviction({
@@ -149,6 +161,7 @@ export function usePageContentCache(userId) {
   const invalidatePage = useCallback((pageId) => {
     if (!pageId) return
     delete inFlightRef.current[pageId]
+    delete knownUpdatedAtRef.current[pageId]
     lruOrderRef.current = lruOrderRef.current.filter((id) => id !== pageId)
     setPageContentCache((prev) => {
       const next = { ...prev }
@@ -157,10 +170,22 @@ export function usePageContentCache(userId) {
     })
   }, [])
 
+  const getKnownUpdatedAt = useCallback((pageId) => {
+    if (!pageId) return null
+    return knownUpdatedAtRef.current[pageId] ?? null
+  }, [])
+
+  const setKnownUpdatedAt = useCallback((pageId, updatedAt) => {
+    if (!pageId || !updatedAt) return
+    knownUpdatedAtRef.current[pageId] = updatedAt
+  }, [])
+
   return {
     pageContentCache,
     loadPageContent,
     setPageContent,
     invalidatePage,
+    getKnownUpdatedAt,
+    setKnownUpdatedAt,
   }
 }

--- a/src/hooks/useTrackers.js
+++ b/src/hooks/useTrackers.js
@@ -781,12 +781,29 @@ export const useTrackers = (userId, activeSectionId) => {
   const resolveConflictWithServer = useCallback(() => {
     if (!draftConflict) return
     clearPageDraft(draftConflict.trackerId)
-    // The server version is already loaded in the page-content cache; clearing
-    // the local draft is enough to let the editor remount with that content.
+    // For save-time conflicts the cache still holds the stale pre-remote-write
+    // snapshot, so refresh it from the descriptor we built when classifying.
+    if (draftConflict.serverContent !== undefined) {
+      setPageContent(draftConflict.trackerId, draftConflict.serverContent, draftConflict.serverUpdatedAt)
+    }
+    if (typeof draftConflict.serverTitle === 'string') {
+      setTrackers((prev) =>
+        prev.map((item) =>
+          item.id === draftConflict.trackerId
+            ? { ...item, title: draftConflict.serverTitle, updated_at: draftConflict.serverUpdatedAt }
+            : item,
+        ),
+      )
+    }
+    // Drop any queued/in-flight save; the user chose to discard their edit.
+    queuedPayloadByTrackerRef.current[draftConflict.trackerId] = null
+    const rt = retryTimersByTrackerRef.current[draftConflict.trackerId]
+    if (rt) { clearTimeout(rt); retryTimersByTrackerRef.current[draftConflict.trackerId] = null }
     setActiveDraft(null)
     setDraftConflict(null)
     setDraftInvalidation((n) => n + 1)
-  }, [draftConflict])
+    setSaveStatus('Saved')
+  }, [draftConflict, setPageContent])
 
   const resolveConflictWithDraft = useCallback(() => {
     if (!draftConflict) return

--- a/src/hooks/useTrackers.js
+++ b/src/hooks/useTrackers.js
@@ -5,10 +5,12 @@ import { sanitizeContentForSave } from '../utils/contentHelpers'
 import { deleteImagesFromStorage, findRemovedImagePaths, collectAllImagePaths } from '../utils/imageCleanup'
 import { readPageDraft, writePageDraft, clearPageDraft } from '../utils/localDrafts'
 import { detectConflict } from '../utils/draftHelpers'
+import { classifySaveResult } from '../utils/saveConflict'
 import { clearNavHierarchyCache } from '../utils/resolveNavHierarchy'
 import { runSupabaseQueryWithRetry } from '../utils/supabaseRetry'
 import { useSectionPageCache } from './useSectionPageCache'
 import { usePageContentCache, PAGE_CONTENT_STATUS } from './usePageContentCache'
+import { usePageRealtime } from './sync/usePageRealtime'
 
 export const useTrackers = (userId, activeSectionId) => {
   const [trackers, setTrackers] = useState([])
@@ -53,12 +55,52 @@ export const useTrackers = (userId, activeSectionId) => {
     loadPageContent,
     setPageContent,
     invalidatePage,
+    getKnownUpdatedAt,
+    setKnownUpdatedAt,
   } = usePageContentCache(userId)
   const pageContentCacheRef = useRef(pageContentCache)
 
   useEffect(() => {
     pageContentCacheRef.current = pageContentCache
   }, [pageContentCache])
+
+  // Realtime: when another device writes the active page, react accordingly.
+  const handleRemotePageChange = useCallback(
+    (payload) => {
+      const row = payload?.new
+      if (!row?.id) return
+      const trackerId = row.id
+      const incomingTs = row.updated_at
+      // Ignore echoes of our own write (we already advanced the token to this value).
+      if (incomingTs && getKnownUpdatedAt(trackerId) === incomingTs) return
+
+      const isDirty =
+        !!queuedPayloadByTrackerRef.current[trackerId] ||
+        !!inFlightByTrackerRef.current[trackerId] ||
+        !!latestDraftKeyByTrackerRef.current[trackerId]
+
+      if (isDirty) {
+        // Bump the token only — the next save attempt will enter the conflict
+        // gate (its UPDATE will mismatch and route through detectConflict).
+        if (incomingTs) setKnownUpdatedAt(trackerId, incomingTs)
+        return
+      }
+
+      // Clean editor: swap server content in and advance the token in one step.
+      if (row.content !== undefined) {
+        setPageContent(trackerId, row.content, incomingTs)
+      } else if (incomingTs) {
+        setKnownUpdatedAt(trackerId, incomingTs)
+      }
+      if (typeof row.title === 'string') {
+        setTrackers((prev) =>
+          prev.map((item) => (item.id === trackerId ? { ...item, title: row.title, updated_at: incomingTs } : item)),
+        )
+      }
+    },
+    [getKnownUpdatedAt, setKnownUpdatedAt, setPageContent],
+  )
+  usePageRealtime(activeTrackerId, handleRemotePageChange)
 
   const activeTrackerServer = trackers.find((tracker) => tracker.id === activeTrackerId) ?? null
   const activeTracker = useMemo(() => {
@@ -257,11 +299,68 @@ export const useTrackers = (userId, activeSectionId) => {
       const { payload, payloadKey } = queued
       // Snapshot the old content before the save so we can diff for removed images.
       const oldContent = pageContentCacheRef.current[trackerId]?.content ?? null
-      const { error } = await supabase.from('pages').update(payload).eq('id', trackerId)
+      // Optimistic concurrency: only write if the server still has the version we last read.
+      // Zero rows matched -> conflict (someone else wrote since we loaded).
+      // If we never observed a version (e.g. title-only save on a page that was never
+      // opened), fetch it just-in-time so we have a baseline to compare against.
+      let knownTs = getKnownUpdatedAt(trackerId)
+      if (!knownTs) {
+        const { data: seedRow } = await supabase
+          .from('pages')
+          .select('updated_at')
+          .eq('id', trackerId)
+          .maybeSingle()
+        if (seedRow?.updated_at) {
+          setKnownUpdatedAt(trackerId, seedRow.updated_at)
+          knownTs = seedRow.updated_at
+        }
+      }
+      const { data, error } = await supabase
+        .from('pages')
+        .update(payload)
+        .eq('id', trackerId)
+        .eq('updated_at', knownTs)
+        .select('updated_at')
+        .maybeSingle()
 
       inFlightByTrackerRef.current[trackerId] = false
 
-      if (error) {
+      const outcome = classifySaveResult({ data, error, knownTs })
+
+      if (outcome.kind === 'conflict') {
+        // Someone else wrote since we loaded. Fetch the server row, run the
+        // existing detectConflict gate, and surface the modal if content actually
+        // differs. Identical content (e.g. a retry whose first attempt succeeded)
+        // auto-recovers by adopting the server's new version token.
+        const { data: serverRow } = await supabase
+          .from('pages')
+          .select('content, updated_at, title')
+          .eq('id', trackerId)
+          .maybeSingle()
+        const conflictDescriptor = serverRow
+          ? detectConflict(trackerId, serverRow, {
+              ts: Date.parse(payload.updated_at) || Date.now(),
+              content: payload.content,
+              title: payload.title,
+            })
+          : null
+        if (conflictDescriptor) {
+          // Real conflict — drop the in-flight payload (the user will pick a side
+          // via ConflictModal). Stop the retry timer; this is not a network error.
+          const rt = retryTimersByTrackerRef.current[trackerId]
+          if (rt) { clearTimeout(rt); retryTimersByTrackerRef.current[trackerId] = null }
+          if (serverRow?.updated_at) setKnownUpdatedAt(trackerId, serverRow.updated_at)
+          if (trackerId === activeTrackerRef.current?.id) {
+            setSaveStatus('Conflict')
+          }
+          setDraftConflict(conflictDescriptor)
+          recomputeHasPendingSaves()
+          return
+        }
+        // Identical content — silently adopt the new server version and treat as success.
+        if (serverRow?.updated_at) setKnownUpdatedAt(trackerId, serverRow.updated_at)
+        // fall through to success cleanup below
+      } else if (outcome.kind === 'error') {
         // If nothing newer is queued, keep this payload as the next attempt.
         if (!queuedPayloadByTrackerRef.current[trackerId]) {
           queuedPayloadByTrackerRef.current[trackerId] = queued
@@ -273,12 +372,15 @@ export const useTrackers = (userId, activeSectionId) => {
             recomputeHasPendingSaves()
           }, 5000)
         }
-        setMessage(error.message)
+        const errMsg = outcome.error?.message ?? 'Save failed'
+        setMessage(errMsg)
         if (trackerId === activeTrackerRef.current?.id) {
           setSaveStatus('Error')
         }
         recomputeHasPendingSaves()
         return
+      } else if (outcome.kind === 'ok' && outcome.nextKnownTs) {
+        setKnownUpdatedAt(trackerId, outcome.nextKnownTs)
       }
 
       const retryTimer = retryTimersByTrackerRef.current[trackerId]
@@ -295,8 +397,9 @@ export const useTrackers = (userId, activeSectionId) => {
         prev.map((item) => (item.id === trackerId ? { ...item, ...payload } : item)),
       )
       // Write-through to the content cache so the editor sees its own saves without re-fetching.
+      // Pass the latest server timestamp (when available) so the OCC token stays current.
       if (payload.content !== undefined) {
-        setPageContent(trackerId, payload.content)
+        setPageContent(trackerId, payload.content, outcome.nextKnownTs)
       }
       if (typeof payload.title === 'string') {
         const sectionId = trackersRef.current.find((t) => t.id === trackerId)?.section_id
@@ -324,7 +427,7 @@ export const useTrackers = (userId, activeSectionId) => {
 
       recomputeHasPendingSaves()
     },
-    [maybeClearLocalDraft, recomputeHasPendingSaves, setPageContent, updateCachedPage],
+    [maybeClearLocalDraft, recomputeHasPendingSaves, setPageContent, updateCachedPage, getKnownUpdatedAt, setKnownUpdatedAt],
   )
 
   // Flush all pending saves (both localStorage drafts and Supabase writes) immediately.

--- a/src/utils/__tests__/saveConflict.test.js
+++ b/src/utils/__tests__/saveConflict.test.js
@@ -1,0 +1,54 @@
+import { describe, it, expect } from 'vitest'
+import { classifySaveResult } from '../saveConflict'
+
+describe('classifySaveResult', () => {
+  it('returns ok with the server timestamp when the row was updated', () => {
+    const result = classifySaveResult({
+      data: { updated_at: '2026-05-10T12:00:00.000Z' },
+      error: null,
+      knownTs: '2026-05-10T11:00:00.000Z',
+    })
+    expect(result).toEqual({
+      kind: 'ok',
+      nextKnownTs: '2026-05-10T12:00:00.000Z',
+    })
+  })
+
+  it('returns conflict when no row matched (PostgREST single() with no rows)', () => {
+    // Supabase .single() with zero rows returns data:null and a PGRST116 error.
+    const result = classifySaveResult({
+      data: null,
+      error: { code: 'PGRST116', message: 'JSON object requested, multiple (or no) rows returned' },
+      knownTs: '2026-05-10T11:00:00.000Z',
+    })
+    expect(result.kind).toBe('conflict')
+  })
+
+  it('returns conflict when data is null without an error code (zero rows matched)', () => {
+    const result = classifySaveResult({
+      data: null,
+      error: null,
+      knownTs: '2026-05-10T11:00:00.000Z',
+    })
+    expect(result.kind).toBe('conflict')
+  })
+
+  it('returns error for a real network or server error (not PGRST116)', () => {
+    const err = { code: '08006', message: 'connection failure' }
+    const result = classifySaveResult({
+      data: null,
+      error: err,
+      knownTs: '2026-05-10T11:00:00.000Z',
+    })
+    expect(result).toEqual({ kind: 'error', error: err })
+  })
+
+  it('returns error when knownTs is missing (cannot do OCC without a version token)', () => {
+    const result = classifySaveResult({
+      data: null,
+      error: null,
+      knownTs: null,
+    })
+    expect(result.kind).toBe('error')
+  })
+})

--- a/src/utils/saveConflict.js
+++ b/src/utils/saveConflict.js
@@ -1,0 +1,35 @@
+/**
+ * Classify the outcome of an optimistic-concurrency UPDATE against the pages table.
+ *
+ * Expected call shape:
+ *   supabase.from('pages')
+ *     .update(payload)
+ *     .eq('id', trackerId)
+ *     .eq('updated_at', knownTs)
+ *     .select('updated_at')
+ *     .single()
+ *
+ * Outcomes:
+ *   - data row returned        -> 'ok'      (server accepted, advance the version token)
+ *   - zero rows matched        -> 'conflict' (someone else wrote since we last read)
+ *   - real transport/db error  -> 'error'    (retryable)
+ *   - missing knownTs          -> 'error'    (we can't safely save without a version)
+ *
+ * PostgREST returns the PGRST116 code when .single() matches no rows. Some clients
+ * also return data:null with no error in that case, so handle both.
+ */
+export const classifySaveResult = ({ data, error, knownTs }) => {
+  if (!knownTs) {
+    return { kind: 'error', error: error ?? new Error('missing version token') }
+  }
+  if (error) {
+    if (error.code === 'PGRST116') {
+      return { kind: 'conflict' }
+    }
+    return { kind: 'error', error }
+  }
+  if (data === null || data === undefined) {
+    return { kind: 'conflict' }
+  }
+  return { kind: 'ok', nextKnownTs: data.updated_at }
+}

--- a/supabase/migrations/20260510000000_enable_realtime_on_pages.sql
+++ b/supabase/migrations/20260510000000_enable_realtime_on_pages.sql
@@ -1,0 +1,8 @@
+-- Enable Supabase Realtime for the pages table.
+--
+-- Required for the cross-device sync flow in src/hooks/sync/usePageRealtime.js:
+-- when one device saves a page, other devices viewing the same page receive
+-- the UPDATE event and either swap content in (clean editor) or advance
+-- their OCC token so the next save attempt routes through the conflict gate.
+
+alter publication supabase_realtime add table public.pages;


### PR DESCRIPTION
## Summary

Sync system was last-write-wins with no version check, so a stale device (e.g. a phone opened minutes after the laptop synced) could silently clobber newer server content. This PR adds optimistic concurrency control + a save-time conflict gate + Postgres realtime, modeled after Notesnook's `dateModified` + dirty-bit + conflict-threshold pattern (Docmost's Yjs CRDT was the alternative — too heavy for a single-user app).

## Changes

**Save path now does OCC**
- `src/utils/saveConflict.js` — pure `classifySaveResult` helper mapping a `.update(...).eq('updated_at', knownTs).select().maybeSingle()` outcome to `ok` / `conflict` / `error`. Five unit tests; RED → GREEN cycle.
- `src/hooks/useTrackers.js` — save now writes only if the server still has the version we last read. Zero rows matched routes through the conflict path, not the retry timer. Identical content auto-recovers (token advance, no modal). Real divergence reuses the existing `detectConflict` gate and opens `ConflictModal`. Title-only saves on never-opened pages lazy-fetch the token once.

**OCC version token in the cache**
- `src/hooks/usePageContentCache.js` tracks `updated_at` per page, exposed via `getKnownUpdatedAt` / `setKnownUpdatedAt`. Populated on load and after each successful save.

**Cross-device realtime**
- `src/hooks/sync/usePageRealtime.js` subscribes to `postgres_changes` on the active page. Clean editor swaps content in transparently; dirty editor only advances the token so the next save attempt enters the conflict gate.
- `supabase/migrations/20260510000000_enable_realtime_on_pages.sql` adds `pages` to the `supabase_realtime` publication.

**Resolution hardening**
- `resolveConflictWithServer` writes the fresh server snapshot from the descriptor into the cache (in save-time conflicts the cache still holds the stale pre-remote-write copy) and drops queued/retry saves so a discarded edit can't sneak back.

**Tests**
- `src/utils/__tests__/saveConflict.test.js` — 5 unit tests for the classifier (ok / PGRST116 / data-null / network error / missing token).
- `e2e/sync-occ-conflict.spec.js` — simulates a remote-device write between page open and local save; asserts `ConflictModal` appears and server content survives untouched.
- `e2e/cross-notebook-switch-speed.spec.js` — bumped cache-warmup timeout 2s → 10s (the strict SLA only applies to the *cached* navigation; warmup can still hit Supabase).

## Files Changed

| File | Type |
|---|---|
| `src/utils/saveConflict.js` | Added |
| `src/utils/__tests__/saveConflict.test.js` | Added |
| `src/hooks/sync/usePageRealtime.js` | Added |
| `src/hooks/usePageContentCache.js` | Modified |
| `src/hooks/useTrackers.js` | Modified |
| `supabase/migrations/20260510000000_enable_realtime_on_pages.sql` | Added |
| `e2e/sync-occ-conflict.spec.js` | Added |
| `e2e/cross-notebook-switch-speed.spec.js` | Modified |
| `.gitignore` | Modified (ignore local `docmost/` and `notesnook/` reference clones) |

## Testing

- `npm run test:unit` — 161 / 161 passing (5 new).
- `npm run build` — green.
- `e2e/sync-occ-conflict.spec.js` will run in CI. Local E2E skipped per the usual workflow.

**Manual repro for reviewers:**
1. Open the same page in two browser contexts (or laptop + phone).
2. Edit and save in A; wait for `Saved`.
3. Edit in B without refreshing → save should surface `ConflictModal` instead of silently overwriting A.
4. Pick "Use server version" in B → editor reloads to A's content; pick "Use local version" → B's edit is pushed forward.
5. With B clean, edit in A again → B's editor swaps in the new content via realtime (no manual reload).

## Related Issues

None linked. Closes the silent-overwrite class of sync bugs raised in chat.

## Out of scope

Called out and not done in this PR: Yjs/CRDT migration, per-block granularity, broader save-queue refactor. The save path is now isolated enough that a future CRDT swap-in is feasible without re-plumbing the editor.