### PR TITLE
fix: mobile toolbar expand toggle, scroll-on-resize, and OCC baseline

### DIFF
--- a/src/components/editor/Toolbar.jsx
+++ b/src/components/editor/Toolbar.jsx
@@ -507,7 +507,7 @@ function Toolbar({
   }, [isTouchOnly, toolbarRef])
 
   // When the toolbar expands on mobile, scroll so the cursor stays visible above it.
-  useKeepCursorVisible({ enabled: isTouchOnly, editor, toolbarExpanded, toolbarRef })
+  useKeepCursorVisible({ enabled: isTouchOnly, editor, toolbarExpanded, toolbarRef, editorPanelRef })
 
   // Outside click and escape handlers for pickers
   useEffect(() => {

--- a/src/hooks/useKeepCursorVisible.js
+++ b/src/hooks/useKeepCursorVisible.js
@@ -1,63 +1,91 @@
 import { useEffect } from 'react'
-import { computeScrollDelta } from '../utils/cursorVisibility'
+import {
+  computeScrollAdjustment,
+  pickScrollSurface,
+} from '../utils/scrollIntoViewWithToolbar'
 
 /**
- * When the mobile toolbar expands, scroll so the cursor stays visible above it.
+ * Keep the cursor / current selection visible whenever the mobile toolbar
+ * changes height (expand or collapse).
  *
- * Trigger: `toolbarExpanded` transitioning to true.
- * Method: measure cursor rect (window.getSelection, fallback to coordsAtPos),
- * measure toolbar top edge via getBoundingClientRect, then scrollBy the delta.
+ * Ported from Notesnook's keep-in-view pattern
+ * (packages/editor/src/extensions/keep-in-view/keep-in-view.ts):
+ *   - measure the current selection rect via ProseMirror's coordsAtPos
+ *     (falls back to window.getSelection when the contenteditable owns focus)
+ *   - use the toolbar's top edge as the bottom of the safe zone
+ *   - scrollBy a bidirectional signed delta so the cursor lands inside the
+ *     visible band, regardless of whether the editor currently has focus
  *
- * Ported from Notesnook's keep-in-view pattern:
- * packages/editor/src/extensions/keep-in-view/keep-in-view.ts
- * Their approach: detect toolbar via DOM querySelector, add 60px buffer,
- * walk up DOM for scroll container, scrollBy with smooth behavior.
+ * Runs on every transition of `toolbarExpanded` so collapse also recenters.
  *
- * @param {{ enabled: boolean, editor: object, toolbarExpanded: boolean, toolbarRef: React.RefObject, padding: number }} opts
+ * @param {{ enabled: boolean, editor: object, toolbarExpanded: boolean, toolbarRef: React.RefObject, editorPanelRef?: React.RefObject, padding?: number }} opts
  */
-export function useKeepCursorVisible({ enabled, editor, toolbarExpanded, toolbarRef, padding = 16 }) {
+export function useKeepCursorVisible({
+  enabled,
+  editor,
+  toolbarExpanded,
+  toolbarRef,
+  editorPanelRef,
+  padding = 16,
+}) {
   useEffect(() => {
     if (!enabled) return
-    if (!toolbarExpanded) return
     if (!editor) return
     if (!toolbarRef?.current) return
-    if (!window.visualViewport) return
 
     let rafId = null
 
     const run = () => {
       rafId = null
-      if (!editor.view.hasFocus()) return
+      const toolbarEl = toolbarRef.current
+      if (!toolbarEl) return
 
-      // Get cursor rect — prefer native selection for accuracy
+      // Prefer the native selection rect when the editor has focus — it's
+      // pixel-accurate. Fall back to ProseMirror's coordsAtPos so we still
+      // scroll when the user tapped the toggle without focusing the editor.
+      let cursorTop = null
       let cursorBottom = null
-      const sel = window.getSelection()
-      if (sel && sel.rangeCount > 0) {
-        const rect = sel.getRangeAt(0).getBoundingClientRect()
-        if (rect.height > 0) cursorBottom = rect.bottom
+
+      if (editor.view?.hasFocus?.()) {
+        const sel = window.getSelection()
+        if (sel && sel.rangeCount > 0) {
+          const rect = sel.getRangeAt(0).getBoundingClientRect()
+          if (rect.height > 0) {
+            cursorTop = rect.top
+            cursorBottom = rect.bottom
+          }
+        }
       }
 
-      // Fall back to ProseMirror's coordsAtPos when native rect is zero-sized
       if (cursorBottom === null) {
-        const { head } = editor.state.selection
-        const coords = editor.view.coordsAtPos(head)
-        cursorBottom = coords.bottom
+        try {
+          const { head } = editor.state.selection
+          const coords = editor.view.coordsAtPos(head)
+          cursorTop = coords.top
+          cursorBottom = coords.bottom
+        } catch {
+          return
+        }
       }
 
-      if (cursorBottom === null) return
+      const toolbarTop = toolbarEl.getBoundingClientRect().top
+      const surface = pickScrollSurface(editorPanelRef?.current ?? null)
+      const surfaceRect = surface.getRect()
 
-      const toolbarTop = toolbarRef.current.getBoundingClientRect().top
-      const safeBottom = toolbarTop - padding
+      const delta = computeScrollAdjustment({
+        cursorTop,
+        cursorBottom,
+        safeTop: surfaceRect.top,
+        safeBottom: toolbarTop,
+        padding,
+      })
 
-      const delta = computeScrollDelta({ cursorBottom, safeBottom })
-      if (delta > 0) {
-        window.scrollBy({ top: delta, behavior: 'smooth' })
-      }
+      if (delta !== 0) surface.scrollBy({ top: delta })
     }
 
-    // Two rAFs: first lets the CSS expand animation start and the
-    // ResizeObserver write the new --toolbar-height, second reads
-    // the settled toolbar rect.
+    // Two rAFs: first lets the CSS expand/collapse animation start and the
+    // ResizeObserver write the new --toolbar-height; second reads the
+    // settled toolbar rect.
     rafId = requestAnimationFrame(() => {
       rafId = requestAnimationFrame(run)
     })
@@ -65,5 +93,5 @@ export function useKeepCursorVisible({ enabled, editor, toolbarExpanded, toolbar
     return () => {
       if (rafId !== null) cancelAnimationFrame(rafId)
     }
-  }, [enabled, editor, toolbarExpanded, toolbarRef, padding])
+  }, [enabled, editor, toolbarExpanded, toolbarRef, editorPanelRef, padding])
 }

--- a/src/hooks/useTrackers.js
+++ b/src/hooks/useTrackers.js
@@ -80,9 +80,9 @@ export const useTrackers = (userId, activeSectionId) => {
         !!latestDraftKeyByTrackerRef.current[trackerId]
 
       if (isDirty) {
-        // Bump the token only — the next save attempt will enter the conflict
-        // gate (its UPDATE will mismatch and route through detectConflict).
-        if (incomingTs) setKnownUpdatedAt(trackerId, incomingTs)
+        // Keep the old version token. The pending save must compare against the
+        // version we loaded before editing so a remote write becomes an OCC conflict
+        // instead of becoming the new baseline for a stale local overwrite.
         return
       }
 
@@ -301,20 +301,11 @@ export const useTrackers = (userId, activeSectionId) => {
       const oldContent = pageContentCacheRef.current[trackerId]?.content ?? null
       // Optimistic concurrency: only write if the server still has the version we last read.
       // Zero rows matched -> conflict (someone else wrote since we loaded).
-      // If we never observed a version (e.g. title-only save on a page that was never
-      // opened), fetch it just-in-time so we have a baseline to compare against.
+      // If we never observed a version, do not fetch one at save time. A fresh
+      // fetch could adopt another device's newer timestamp and turn a stale local
+      // write into an accepted overwrite. Loaded/created pages seed this token
+      // from server metadata before edits are allowed.
       let knownTs = getKnownUpdatedAt(trackerId)
-      if (!knownTs) {
-        const { data: seedRow } = await supabase
-          .from('pages')
-          .select('updated_at')
-          .eq('id', trackerId)
-          .maybeSingle()
-        if (seedRow?.updated_at) {
-          setKnownUpdatedAt(trackerId, seedRow.updated_at)
-          knownTs = seedRow.updated_at
-        }
-      }
       const { data, error } = await supabase
         .from('pages')
         .update(payload)
@@ -484,6 +475,9 @@ export const useTrackers = (userId, activeSectionId) => {
       }
 
       const nextTrackers = data ?? []
+      nextTrackers.forEach((page) => {
+        if (page?.id && page?.updated_at) setKnownUpdatedAt(page.id, page.updated_at)
+      })
       setTrackers(nextTrackers)
       setLoadedTrackerSectionId(sectionId)
       seedSectionPages(sectionId, nextTrackers)
@@ -493,7 +487,7 @@ export const useTrackers = (userId, activeSectionId) => {
       })
       setDataLoading(false)
     },
-    [seedSectionPages, userId],
+    [seedSectionPages, setKnownUpdatedAt, userId],
   )
 
   useEffect(() => {
@@ -625,7 +619,7 @@ export const useTrackers = (userId, activeSectionId) => {
     setTrackers((prev) => [...prev, created])
     upsertCachedPage(sectionId, created)
     // Seed the content cache so the editor can mount immediately without a round-trip.
-    setPageContent(data.id, EMPTY_DOC)
+    setPageContent(data.id, EMPTY_DOC, data.updated_at)
     setActiveTrackerId(data.id)
   }
 
@@ -659,7 +653,7 @@ export const useTrackers = (userId, activeSectionId) => {
     setTrackers((prev) => [...prev, created])
     upsertCachedPage(sectionId, created)
     // Seed the content cache so the editor can mount immediately without a round-trip.
-    setPageContent(data.id, content)
+    setPageContent(data.id, content, data.updated_at)
     setActiveTrackerId(data.id)
     return data
   }

--- a/src/stores/__tests__/editorUIStore.test.js
+++ b/src/stores/__tests__/editorUIStore.test.js
@@ -1,0 +1,42 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { useEditorUIStore } from '../editorUIStore'
+
+const reset = () => {
+  useEditorUIStore.setState({ toolbarExpanded: false })
+}
+
+describe('useEditorUIStore - setToolbarExpanded', () => {
+  beforeEach(reset)
+
+  it('accepts a boolean value', () => {
+    useEditorUIStore.getState().setToolbarExpanded(true)
+    expect(useEditorUIStore.getState().toolbarExpanded).toBe(true)
+
+    useEditorUIStore.getState().setToolbarExpanded(false)
+    expect(useEditorUIStore.getState().toolbarExpanded).toBe(false)
+  })
+
+  it('accepts a functional updater that toggles the value', () => {
+    useEditorUIStore.setState({ toolbarExpanded: false })
+    useEditorUIStore.getState().setToolbarExpanded((prev) => !prev)
+    expect(useEditorUIStore.getState().toolbarExpanded).toBe(true)
+
+    useEditorUIStore.getState().setToolbarExpanded((prev) => !prev)
+    expect(useEditorUIStore.getState().toolbarExpanded).toBe(false)
+  })
+
+  it('does not store the updater function itself as the state value', () => {
+    useEditorUIStore.getState().setToolbarExpanded((prev) => !prev)
+    expect(typeof useEditorUIStore.getState().toolbarExpanded).toBe('boolean')
+  })
+
+  it('passes the current value into the functional updater', () => {
+    useEditorUIStore.setState({ toolbarExpanded: true })
+    let received
+    useEditorUIStore.getState().setToolbarExpanded((prev) => {
+      received = prev
+      return prev
+    })
+    expect(received).toBe(true)
+  })
+})

--- a/src/stores/editorUIStore.js
+++ b/src/stores/editorUIStore.js
@@ -4,7 +4,9 @@ import { isTouchOnlyDevice } from '../utils/device'
 export const useEditorUIStore = create((set) => ({
   // Toolbar layout
   toolbarExpanded: !isTouchOnlyDevice(),
-  setToolbarExpanded: (v) => set({ toolbarExpanded: v }),
+  setToolbarExpanded: (v) => set((state) => ({
+    toolbarExpanded: typeof v === 'function' ? v(state.toolbarExpanded) : v,
+  })),
 
   // Find bar
   findOpen: false,

--- a/src/utils/__tests__/scrollIntoViewWithToolbar.test.js
+++ b/src/utils/__tests__/scrollIntoViewWithToolbar.test.js
@@ -1,0 +1,93 @@
+import { describe, it, expect } from 'vitest'
+import { computeScrollAdjustment } from '../scrollIntoViewWithToolbar'
+
+// Bidirectional scroll math used to keep the cursor in the visible band
+// between the top of a scroll surface and a bottom obstruction such as the
+// mobile toolbar's top edge,
+// minus a padding so we don't sit flush against either edge.
+//
+// Inputs:
+//   cursorTop, cursorBottom — cursor rect in viewport (or container) coordinates
+//   safeTop                 — y of the visible area's top edge
+//   safeBottom              — y of the visible area's bottom edge
+//   padding                 — extra breathing room from each edge
+//
+// Returns a signed delta to feed scrollBy:
+//   positive → scroll down (cursor is below safe zone — bring it up into view)
+//   negative → scroll up   (cursor is above safe zone — bring it down into view)
+//   0        → cursor is inside the safe zone
+describe('computeScrollAdjustment', () => {
+  it('returns 0 when the cursor is comfortably inside the safe zone', () => {
+    expect(
+      computeScrollAdjustment({
+        cursorTop: 300,
+        cursorBottom: 320,
+        safeTop: 100,
+        safeBottom: 700,
+        padding: 16,
+      }),
+    ).toBe(0)
+  })
+
+  it('returns a positive delta when the cursor is below the safe zone', () => {
+    // cursorBottom 800; safeBottom - padding = 700 - 16 = 684 → scroll down 116
+    expect(
+      computeScrollAdjustment({
+        cursorTop: 780,
+        cursorBottom: 800,
+        safeTop: 100,
+        safeBottom: 700,
+        padding: 16,
+      }),
+    ).toBe(116)
+  })
+
+  it('returns a negative delta when the cursor is above the safe zone (hidden by toolbar)', () => {
+    // cursorTop 60; safeTop + padding = 100 + 16 = 116 → scroll up 56
+    expect(
+      computeScrollAdjustment({
+        cursorTop: 60,
+        cursorBottom: 80,
+        safeTop: 100,
+        safeBottom: 700,
+        padding: 16,
+      }),
+    ).toBe(-56)
+  })
+
+  it('returns 0 when cursor sits exactly at the safe zone edges', () => {
+    expect(
+      computeScrollAdjustment({
+        cursorTop: 116,
+        cursorBottom: 684,
+        safeTop: 100,
+        safeBottom: 700,
+        padding: 16,
+      }),
+    ).toBe(0)
+  })
+
+  it('defaults padding to 0 when omitted', () => {
+    expect(
+      computeScrollAdjustment({
+        cursorTop: 90,
+        cursorBottom: 110,
+        safeTop: 100,
+        safeBottom: 700,
+      }),
+    ).toBe(-10)
+  })
+
+  it('prefers the "above" branch when the cursor is taller than the safe zone (degenerate viewport)', () => {
+    // Very narrow safe zone; both checks could fire. Above-branch wins so we
+    // scroll up to expose the start of the selection.
+    const delta = computeScrollAdjustment({
+      cursorTop: 50,
+      cursorBottom: 800,
+      safeTop: 100,
+      safeBottom: 700,
+      padding: 16,
+    })
+    expect(delta).toBeLessThan(0)
+  })
+})

--- a/src/utils/scrollIntoViewWithToolbar.js
+++ b/src/utils/scrollIntoViewWithToolbar.js
@@ -1,0 +1,63 @@
+/**
+ * Bidirectional scroll math for keeping a cursor / element inside the visible
+ * band between a top boundary and a bottom boundary such as a mobile toolbar's
+ * top edge.
+ *
+ * Ported from Notesnook's keep-in-view extension
+ * (packages/editor/src/extensions/keep-in-view/keep-in-view.ts):
+ * threshold check from both edges, single scrollBy with the signed delta.
+ *
+ * Positive return → scrollBy down (cursor is below the safe zone).
+ * Negative return → scrollBy up   (cursor is above the safe zone, hidden by toolbar).
+ * Zero return     → cursor is already inside the safe zone.
+ *
+ * @param {{ cursorTop: number, cursorBottom: number, safeTop: number, safeBottom: number, padding?: number }} params
+ */
+export function computeScrollAdjustment({
+  cursorTop,
+  cursorBottom,
+  safeTop,
+  safeBottom,
+  padding = 0,
+}) {
+  const topEdge = safeTop + padding
+  const bottomEdge = safeBottom - padding
+
+  if (cursorTop < topEdge) {
+    return cursorTop - topEdge
+  }
+  if (cursorBottom > bottomEdge) {
+    return cursorBottom - bottomEdge
+  }
+  return 0
+}
+
+/**
+ * Pick the appropriate scroll surface for a given element/container pair.
+ * Mirrors the find-bar logic in Toolbar.jsx — prefer the editor panel when it
+ * is an actual scroll container, otherwise fall back to the window.
+ *
+ * @param {HTMLElement | null | undefined} container
+ * @returns {{ scrollBy: (opts: { top: number }) => void, getRect: () => { top: number, bottom: number } }}
+ */
+export function pickScrollSurface(container) {
+  const isScrollContainer =
+    container &&
+    container.scrollHeight > container.clientHeight &&
+    typeof window !== 'undefined' &&
+    getComputedStyle(container).overflowY !== 'visible'
+
+  if (isScrollContainer) {
+    return {
+      scrollBy: ({ top }) => container.scrollBy({ top, behavior: 'instant' }),
+      getRect: () => {
+        const rect = container.getBoundingClientRect()
+        return { top: rect.top, bottom: rect.bottom }
+      },
+    }
+  }
+  return {
+    scrollBy: ({ top }) => window.scrollBy({ top, behavior: 'instant' }),
+    getRect: () => ({ top: 0, bottom: window.innerHeight }),
+  }
+}


### PR DESCRIPTION
## Summary

Two independent fixes:

1. **Mobile toolbar expand toggle was dead** — tapping ▾ did nothing and the icon never flipped. Plus the companion UX where, even when it had been working, expanding the toolbar would visually cover the content the user was editing.
2. **Stale-device OCC overwrite still possible** despite #142 — two remaining paths could rebaseline `knownUpdatedAt` to a newer remote timestamp before a pending local save, turning a stale write into an accepted overwrite.

## Changes

**Toolbar (commit 1)**
- `src/stores/editorUIStore.js` — `setToolbarExpanded` now unwraps functional updaters (`prev => !prev`), matching `useState`. PR #134's Zustand refactor stored the updater function itself as the state value, which is why the toggle froze.
- `src/hooks/useKeepCursorVisible.js` — rewritten:
  - dropped the `editor.view.hasFocus()` early-return so the scroll runs whether or not the contenteditable owns focus (mobile users tap the toggle without focusing the editor)
  - runs on both expand and collapse
  - uses a signed bidirectional delta so the cursor lands in the visible band whether it was hidden above the safe zone or pushed below it
  - picks the correct scroll surface (editor panel container vs `window`)
- `src/utils/scrollIntoViewWithToolbar.js` *(new)* — shared `computeScrollAdjustment` and `pickScrollSurface` utilities, ported from Notesnook's `keep-in-view` extension.
- `src/components/editor/Toolbar.jsx` — pass `editorPanelRef` through to the hook.
- New unit tests: `src/stores/__tests__/editorUIStore.test.js`, `src/utils/__tests__/scrollIntoViewWithToolbar.test.js`.

**OCC tightening (commit 2)**
- `src/hooks/useTrackers.js` — close two rebaseline holes:
  - realtime tick on a dirty page no longer bumps `knownUpdatedAt` to the incoming timestamp; the pending save now correctly hits the conflict gate
  - removed the just-in-time `updated_at` fetch in the save path (title-only saves on never-opened pages); baselines are seeded from the list query on load and from create responses instead

## Files Changed

- Modified: `src/stores/editorUIStore.js`, `src/hooks/useKeepCursorVisible.js`, `src/components/editor/Toolbar.jsx`, `src/hooks/useTrackers.js`
- Added: `src/utils/scrollIntoViewWithToolbar.js`, `src/utils/__tests__/scrollIntoViewWithToolbar.test.js`, `src/stores/__tests__/editorUIStore.test.js`

## Testing

- `npm run test:unit` — 171 tests pass (10 new).
- `npm run build` — clean.

Manual mobile checks needed:
- [ ] Tap expand toggle on phone → toolbar opens; icon flips ▾→▴. Tap again → collapses.
- [ ] Tap expand while cursor is near top of page → page scrolls so cursor is no longer hidden behind the now-taller toolbar.
- [ ] Tap expand while cursor is near bottom → cursor remains visible.
- [ ] Two-device sync: edit page A on phone (don't save), edit page A on desktop and save, then continue typing on phone → phone save hits conflict gate instead of overwriting desktop's write.

## Related

- Builds on #142 (OCC + realtime sync)
- Fixes a regression introduced in #134 (Zustand store refactor) and #141 (Toolbar picker extraction kept the broken call site)

## References

- Notesnook `packages/editor/src/extensions/keep-in-view/keep-in-view.ts` — bidirectional scroll pattern adopted in `useKeepCursorVisible`.