### PR TITLE
fix: stop suppressing synthetic click on mobile toolbar buttons

### DIFF
--- a/e2e/toolbar-expand-toggle.spec.js
+++ b/e2e/toolbar-expand-toggle.spec.js
@@ -1,0 +1,137 @@
+/**
+ * E2E regression tests for the mobile toolbar expand/collapse toggle.
+ *
+ * Bug we are guarding against: ToolButton used to attach a non-passive,
+ * capture-phase `touchstart` listener that called `preventDefault()`. On
+ * Android Chrome, canceling touchstart suppresses the synthetic `click`
+ * that would otherwise follow touchend — so the expand toggle (and every
+ * other tool button) intermittently never received its click on real
+ * devices. The toolbar would get stuck open or refuse to expand at all.
+ *
+ * These tests run only against the Mobile Chrome project, which exercises
+ * the touch event path. Playwright's `.tap()` dispatches the full
+ * touchstart → touchend → mousedown → click sequence, matching real
+ * device behavior closely enough to catch the regression.
+ */
+
+import { test, expect } from './fixtures'
+import {
+  getSupabase,
+  createNotebook,
+  createSection,
+  createPage,
+  deleteNotebookById,
+  waitForApp,
+} from './test-helpers'
+
+const buildSeedContent = () => ({
+  type: 'doc',
+  content: [
+    {
+      type: 'paragraph',
+      attrs: { id: 'p-toggle-1' },
+      content: [{ type: 'text', text: 'Toolbar toggle test line one' }],
+    },
+    {
+      type: 'paragraph',
+      attrs: { id: 'p-toggle-2' },
+      content: [{ type: 'text', text: 'Toolbar toggle test line two' }],
+    },
+  ],
+})
+
+let seedIds = {}
+const seedLabel = `TB-TOGGLE-${Date.now()}`
+
+test.beforeAll(async () => {
+  const { client, userId } = await getSupabase()
+  const notebook = await createNotebook(client, userId, `${seedLabel} Notebook`)
+  const section = await createSection(client, userId, notebook.id, `${seedLabel} Section`, 0)
+  const page = await createPage(
+    client,
+    userId,
+    section.id,
+    `${seedLabel} Page`,
+    buildSeedContent(),
+    0,
+  )
+  seedIds = { notebook, section, page }
+})
+
+test.afterAll(async () => {
+  const { client } = await getSupabase()
+  await deleteNotebookById(client, seedIds.notebook?.id)
+})
+
+test(
+  'mobile expand toggle flips state on a single tap',
+  async ({ page, isMobile }) => {
+    test.skip(!isMobile, 'Mobile-only test')
+
+    const hash = `#nb=${seedIds.notebook.id}&sec=${seedIds.section.id}&pg=${seedIds.page.id}`
+    await waitForApp(page, hash, { expectedText: 'Toolbar toggle test line one' })
+
+    const expandToggle = page.getByTestId('toolbar-expand-toggle')
+    await expect(expandToggle).toBeVisible()
+
+    // Starts collapsed on touch devices.
+    await expect(expandToggle).toHaveAttribute('aria-label', 'Expand toolbar')
+    await expect(page.locator('.toolbar')).toHaveClass(/toolbar-collapsed/)
+
+    // One tap should flip the state.
+    await expandToggle.tap()
+    await expect(expandToggle).toHaveAttribute('aria-label', 'Collapse toolbar')
+    await expect(page.locator('.toolbar')).not.toHaveClass(/toolbar-collapsed/)
+
+    // Tapping again should flip back — this was the "stuck open" case.
+    await expandToggle.tap()
+    await expect(expandToggle).toHaveAttribute('aria-label', 'Expand toolbar')
+    await expect(page.locator('.toolbar')).toHaveClass(/toolbar-collapsed/)
+  },
+)
+
+test(
+  'tapping a command button preserves editor selection and applies the command',
+  async ({ page, isMobile }) => {
+    test.skip(!isMobile, 'Mobile-only test')
+
+    const hash = `#nb=${seedIds.notebook.id}&sec=${seedIds.section.id}&pg=${seedIds.page.id}`
+    await waitForApp(page, hash, { expectedText: 'Toolbar toggle test line one' })
+
+    // Place cursor inside the first paragraph and select the word "toggle".
+    const firstPara = page.locator('#p-toggle-1')
+    await firstPara.click()
+    await page.waitForTimeout(100)
+
+    // Select a word programmatically through Tiptap; tapping the toolbar
+    // button must not collapse this selection.
+    await page.evaluate(() => {
+      const para = document.querySelector('#p-toggle-1')
+      if (!para) return
+      const text = para.firstChild
+      if (!text) return
+      const start = para.textContent.indexOf('toggle')
+      const end = start + 'toggle'.length
+      const range = document.createRange()
+      range.setStart(text, start)
+      range.setEnd(text, end)
+      const sel = window.getSelection()
+      sel.removeAllRanges()
+      sel.addRange(range)
+    })
+
+    const selectionBefore = await page.evaluate(() => window.getSelection()?.toString())
+    expect(selectionBefore).toBe('toggle')
+
+    // Tap the Bold button (in toolbar-core, always visible on touch).
+    const boldButton = page.getByRole('button', { name: 'Bold' })
+    await boldButton.tap()
+
+    // The bold command should have applied — the selected word is now wrapped.
+    await expect(page.locator('#p-toggle-1 strong')).toHaveText('toggle')
+
+    // And the editor should still hold the same selection (didn't collapse).
+    const selectionAfter = await page.evaluate(() => window.getSelection()?.toString())
+    expect(selectionAfter).toBe('toggle')
+  },
+)

--- a/src/components/editor/ToolButton.jsx
+++ b/src/components/editor/ToolButton.jsx
@@ -1,18 +1,22 @@
 import { useEffect, useRef } from 'react'
+import { attachToolButtonTouchGuard } from '../../utils/toolButtonTouchGuard'
 
 // Shared toolbar button.
 //
-// Why this exists: on mobile, tapping a plain <button> inside a contenteditable
-// toolbar makes the browser pull focus off the editor before the click handler
-// runs. That collapses the text selection (so toggleItalic ends up a no-op)
-// and dismisses the on-screen keyboard. Pattern mirrors notesnook's
-// packages/editor/src/toolbar/components/tool-button.tsx:
+// Pieces that keep the editor selection alive when a button is tapped:
+//   1. tabIndex={-1}             keep the button out of the focus order
+//   2. mousedown preventDefault  block focus transfer to the button. mousedown
+//                                also fires on touch (via the touch→mouse
+//                                compatibility sequence) before the synthetic
+//                                click, so a single capture-phase mousedown
+//                                handler covers both pointer and touch.
+//   3. plain onClick             runs the editor command (chain().focus().toggleX().run())
 //
-//   1. tabIndex={-1}            keep the button out of the focus order
-//   2. onMouseDown preventDefault    stop focus transfer on touch
-//   3. capture-phase native listener belt-and-braces in case anything
-//                                    synthesizes its own pointer handling
-//   4. plain onClick runs the editor command (chain().focus().toggleX().run())
+// Do NOT add a touchstart preventDefault here. On Android Chrome, canceling
+// touchstart suppresses the synthetic click that would otherwise follow
+// touchend — which silently breaks every button that activates via onClick
+// (most visibly the toolbar expand/collapse toggle). See
+// src/utils/toolButtonTouchGuard.js for the canonical guard and its tests.
 function ToolButton({
   active = false,
   disabled = false,
@@ -30,15 +34,7 @@ function ToolButton({
   const ref = buttonRef ?? localRef
 
   useEffect(() => {
-    const el = ref.current
-    if (!el || !isTouchOnly) return undefined
-    const onDown = (e) => { e.preventDefault() }
-    el.addEventListener('mousedown', onDown, { capture: true, passive: false })
-    el.addEventListener('touchstart', onDown, { capture: true, passive: false })
-    return () => {
-      el.removeEventListener('mousedown', onDown, { capture: true })
-      el.removeEventListener('touchstart', onDown, { capture: true })
-    }
+    return attachToolButtonTouchGuard(ref.current, { isTouchOnly })
   }, [isTouchOnly, ref])
 
   const composedClassName = `toolbar-btn${active ? ' active' : ''}${className ? ` ${className}` : ''}`

--- a/src/utils/__tests__/toolButtonTouchGuard.test.js
+++ b/src/utils/__tests__/toolButtonTouchGuard.test.js
@@ -1,0 +1,84 @@
+import { describe, it, expect, vi } from 'vitest'
+import { attachToolButtonTouchGuard } from '../toolButtonTouchGuard'
+
+// Focus-preservation guard for toolbar buttons.
+//
+// Why this exists: tapping a <button> while a contenteditable has focus
+// transfers focus to the button. That collapses the editor selection
+// (so toggleBold/Italic/... ends up a no-op) and on touch devices dismisses
+// the on-screen keyboard.
+//
+// Mitigation: preventDefault on `mousedown` only. mousedown fires on touch
+// too (via the touch→mouse compatibility sequence), so a single handler
+// covers both mouse and touch.
+//
+// CRITICAL: we must NOT preventDefault `touchstart`. On Android Chrome,
+// canceling touchstart suppresses the synthetic click that follows
+// touchend, which silently breaks every tool button that activates via
+// onClick — most notably the toolbar expand/collapse toggle.
+// This util exists to make that invariant testable.
+
+function makeEl() {
+  // Node's EventTarget + Event are enough to verify addEventListener wiring.
+  // No jsdom needed.
+  return new EventTarget()
+}
+
+function dispatch(el, type, { cancelable = true } = {}) {
+  const ev = new Event(type, { cancelable })
+  el.dispatchEvent(ev)
+  return ev
+}
+
+describe('attachToolButtonTouchGuard', () => {
+  it('calls preventDefault on mousedown when isTouchOnly is true', () => {
+    const el = makeEl()
+    attachToolButtonTouchGuard(el, { isTouchOnly: true })
+    const ev = dispatch(el, 'mousedown')
+    expect(ev.defaultPrevented).toBe(true)
+  })
+
+  it('does NOT call preventDefault on touchstart (regression guard for Android click suppression)', () => {
+    const el = makeEl()
+    attachToolButtonTouchGuard(el, { isTouchOnly: true })
+    const ev = dispatch(el, 'touchstart')
+    expect(ev.defaultPrevented).toBe(false)
+  })
+
+  it('attaches no listeners when isTouchOnly is false', () => {
+    const el = makeEl()
+    attachToolButtonTouchGuard(el, { isTouchOnly: false })
+    const md = dispatch(el, 'mousedown')
+    const ts = dispatch(el, 'touchstart')
+    expect(md.defaultPrevented).toBe(false)
+    expect(ts.defaultPrevented).toBe(false)
+  })
+
+  it('returns a no-op cleanup when el is null', () => {
+    const cleanup = attachToolButtonTouchGuard(null, { isTouchOnly: true })
+    expect(typeof cleanup).toBe('function')
+    expect(() => cleanup()).not.toThrow()
+  })
+
+  it('cleanup removes the mousedown listener', () => {
+    const el = makeEl()
+    const cleanup = attachToolButtonTouchGuard(el, { isTouchOnly: true })
+    cleanup()
+    const ev = dispatch(el, 'mousedown')
+    expect(ev.defaultPrevented).toBe(false)
+  })
+
+  it('uses capture-phase listener (runs before bubble-phase listeners)', () => {
+    const el = makeEl()
+    const order = []
+    // bubble-phase listener attached BEFORE the guard, but capture runs first
+    el.addEventListener('mousedown', () => order.push('bubble'))
+    attachToolButtonTouchGuard(el, { isTouchOnly: true })
+    el.addEventListener('mousedown', (e) => {
+      order.push(e.defaultPrevented ? 'bubble-after-guard:prevented' : 'bubble-after-guard:not-prevented')
+    })
+    dispatch(el, 'mousedown')
+    // capture handler should have set defaultPrevented before bubble listeners run
+    expect(order).toContain('bubble-after-guard:prevented')
+  })
+})

--- a/src/utils/toolButtonTouchGuard.js
+++ b/src/utils/toolButtonTouchGuard.js
@@ -1,0 +1,29 @@
+// Focus-preservation guard for toolbar buttons inside a contenteditable.
+//
+// Why this exists: tapping a <button> while a contenteditable has focus
+// transfers focus to the button. That collapses the editor selection
+// (so toggleBold/toggleItalic/... ends up a no-op) and on touch devices
+// dismisses the on-screen keyboard.
+//
+// Mitigation: preventDefault on `mousedown` only. mousedown also fires on
+// touch (via the touch→mouse compatibility sequence) before the synthetic
+// click, so a single capture-phase mousedown handler blocks the focus
+// transfer for both pointer and touch.
+//
+// Do NOT also preventDefault `touchstart`. On Android Chrome, canceling
+// touchstart suppresses the synthetic click that would otherwise follow
+// touchend, which silently breaks every tool button that activates via
+// onClick (most visibly the toolbar expand/collapse toggle). We hit this
+// regression once; this util is the single place that invariant lives.
+//
+// Matches the proven pattern in notesnook's tool-button (mousedown-only,
+// no touchstart listener).
+
+export function attachToolButtonTouchGuard(el, { isTouchOnly } = {}) {
+  if (!el || !isTouchOnly) return () => {}
+  const onDown = (e) => { e.preventDefault() }
+  el.addEventListener('mousedown', onDown, { capture: true, passive: false })
+  return () => {
+    el.removeEventListener('mousedown', onDown, { capture: true })
+  }
+}


### PR DESCRIPTION
## Summary

On the deployed PWA on Android Chrome, the mobile toolbar expand/collapse toggle required many taps to respond and then got stuck. Live CDP debugging on a real Pixel 10 proved the root cause: `ToolButton` was attaching a capture-phase, non-passive `touchstart` listener that called `preventDefault()`. On Android Chrome, canceling `touchstart` suppresses the synthetic `click` that follows `touchend` — so any tool button that activates via `onClick` (most visibly the expand-toggle) silently lost its click most of the time. Chrome's scroll-active intervention occasionally dropped the `preventDefault`, which is why the toggle "randomly" worked. Follow-up to #143.

## Changes

- **Remove the touchstart preventDefault** from `ToolButton.jsx`. `mousedown` preventDefault alone is enough — it also fires on touch via the touch→mouse compatibility sequence, before the synthetic click — so we keep the editor selection alive without breaking taps. Matches the actual notesnook pattern (and docmost's bubble menu, which does no pointer/touch preventDefault at all).
- **Extract** the focus-guard into `src/utils/toolButtonTouchGuard.js` so the "do NOT preventDefault touchstart" invariant has a single home with an explicit regression test.
- **Update the comment** in `ToolButton.jsx` to describe what the code actually does instead of incorrectly claiming to mirror notesnook.
- **Unit tests** (`src/utils/__tests__/toolButtonTouchGuard.test.js`) — 6 cases including an explicit "touchstart MUST NOT be preventDefault'd" regression guard.
- **E2E tests** (`e2e/toolbar-expand-toggle.spec.js`, Mobile Chrome project only) — single-tap flip-state in both directions; plus a regression test that tapping Bold preserves the editor selection and applies the formatting.

## Files Changed

| File | Type |
|---|---|
| `src/components/editor/ToolButton.jsx` | Modified |
| `src/utils/toolButtonTouchGuard.js` | Added |
| `src/utils/__tests__/toolButtonTouchGuard.test.js` | Added |
| `e2e/toolbar-expand-toggle.spec.js` | Added |

## Testing

- Unit suite: `npm run test:unit` — 177/177 passing locally, including 6 new tests.
- E2E suite: spec discovers correctly under both `Desktop Chrome` and `Mobile Chrome` projects; tests gate themselves to mobile via `test.skip(!isMobile, ...)`. CI will run them on the Mobile Chrome project.
- Manual device verification: a live Chrome DevTools Protocol session attached to the deployed PWA on a Pixel 10 confirmed the bug pre-fix (`[BUBBLE touchstart] defPrev(after-react)=true`, no `click` events on the toggle). Re-verify post-deploy with the same probe.

## Related Issues

None. Follow-up regression to #143 (mobile toolbar expand toggle + scroll-on-resize + OCC baseline).