### PR TITLE
refactor: rebuild editor toolbar around a tool registry

### DIFF
--- a/src/components/editor/Toolbar.jsx
+++ b/src/components/editor/Toolbar.jsx
@@ -1,29 +1,12 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
-import { TextSelection } from '@tiptap/pm/state'
-import { mixColors } from '../../utils/colorUtils'
-import { serializeDocForExport } from '../../lib/serializeDocForExport'
-import { findInDocPluginKey } from '../../extensions/findInDoc'
-import { toggleLineStrike } from '../../extensions/keyboard/toggleLineStrike'
+import { useEffect, useMemo, useRef } from 'react'
 import { useKeepCursorVisible } from '../../hooks/useKeepCursorVisible'
 import { useEditorUIStore } from '../../stores/editorUIStore'
 import FindBar from './FindBar'
 import ToolButton from './ToolButton'
-import HighlightPicker from './toolbar/HighlightPicker'
-import ShadingPicker from './toolbar/ShadingPicker'
-import TablePicker from './toolbar/TablePicker'
-import AiDailyPicker from './toolbar/AiDailyPicker'
-import MoreMenu from './toolbar/MoreMenu'
-import {
-  BoldIcon, ItalicIcon, UnderlineIcon, StrikethroughIcon,
-  HighlightIcon,
-  BulletListIcon, OrderedListIcon, TaskListIcon,
-  AlignLeftIcon, AlignCenterIcon, AlignRightIcon,
-  LinkIcon, UnlinkIcon, ImageIcon,
-  TableIcon, AddRowIcon, AddColIcon, DeleteTableIcon, ShadingIcon,
-  UndoIcon, RedoIcon,
-  SearchIcon, ExportIcon, CopyIcon, MoreIcon, AiIcon,
-  IndentIcon, OutdentIcon,
-} from './ToolbarIcons'
+import { ToolbarContext } from './toolbar/ToolbarContext'
+import ToolbarGroup from './toolbar/ToolbarGroup'
+import { CORE_GROUPS, EXTRA_GROUPS } from './toolbar/tools'
+import { useFindBar } from './toolbar/useFindBar'
 
 function Toolbar({
   editor,
@@ -44,451 +27,23 @@ function Toolbar({
   handleSetTrackerFromToolbar,
   contextMenuItems,
 }) {
-  const {
-    toolbarExpanded, setToolbarExpanded,
-    findOpen, setFindOpen,
-    findQuery, setFindQuery,
-    findStatus, setFindStatus,
-    aiInsertOpen, setAiInsertOpen,
-    aiInsertLoading,
-    aiLoading,
-    aiDailyDate, setAiDailyDate,
-    inTable,
-    highlightColor, setHighlightColor,
-    shadingColor, setShadingColor,
-    copyLabel, setCopyLabel,
-  } = useEditorUIStore()
+  const toolbarExpanded = useEditorUIStore((s) => s.toolbarExpanded)
+  const setToolbarExpanded = useEditorUIStore((s) => s.setToolbarExpanded)
+  const findOpen = useEditorUIStore((s) => s.findOpen)
+  const findQuery = useEditorUIStore((s) => s.findQuery)
+  const findStatus = useEditorUIStore((s) => s.findStatus)
 
-  // Refs local to Toolbar
-  const fileInputRef = useRef(null)
-  const shadingInputRef = useRef(null)
   const findInputRef = useRef(null)
-  const highlightButtonRef = useRef(null)
-  const highlightPickerRef = useRef(null)
-  const shadingButtonRef = useRef(null)
-  const shadingPickerRef = useRef(null)
-  const tableButtonRef = useRef(null)
-  const tablePickerRef = useRef(null)
-  const aiDailyButtonRef = useRef(null)
-  const aiDailyPickerRef = useRef(null)
-  const moreMenuRef = useRef(null)
 
-  // Purely local UI state (not shared, no need for store)
-  const [highlightPickerOpen, setHighlightPickerOpen] = useState(false)
-  const [shadingPickerOpen, setShadingPickerOpen] = useState(false)
-  const [tablePickerOpen, setTablePickerOpen] = useState(false)
-  const [tableSize, setTableSize] = useState({ rows: 2, cols: 2 })
-  const [aiDailyPickerOpen, setAiDailyPickerOpen] = useState(false)
-  const [moreMenuOpen, setMoreMenuOpen] = useState(false)
+  const { openFind, closeFind, handleFindQueryChange, handleFindNext, handleFindPrev } =
+    useFindBar({ editor, hasTracker, controlsDisabled, editorPanelRef, findInputRef })
 
-  // Idiomatic Tiptap chain. Selection preservation on touch is handled at the
-  // ToolButton layer (preventDefault on mousedown), so always include .focus().
-  const cmd = useCallback(() => editor?.chain().focus() ?? null, [editor])
+  // Mobile cursor visibility when the toolbar lifts.
+  useKeepCursorVisible({ enabled: isTouchOnly, editor, toolbarExpanded, toolbarRef, editorPanelRef })
 
-  const isInList = editor?.isActive('bulletList') || editor?.isActive('orderedList') || editor?.isActive('taskList')
-
-  // --- Find handlers ---
-
-  const openFind = useCallback(() => {
-    if (!editor || !hasTracker) return
-    setFindOpen(true)
-    requestAnimationFrame(() => {
-      findInputRef.current?.focus()
-      findInputRef.current?.select()
-    })
-  }, [editor, hasTracker, setFindOpen])
-
-  const closeFind = useCallback(() => {
-    setFindOpen(false)
-    setFindQuery('')
-    editor?.commands?.clearFind?.()
-    if (!editor || controlsDisabled) return
-    requestAnimationFrame(() => {
-      editor.chain().focus().run()
-    })
-  }, [editor, controlsDisabled, setFindOpen, setFindQuery])
-
-  const handleFindQueryChange = (value) => {
-    setFindQuery(value)
-    editor?.commands?.setFindQuery?.(value)
-  }
-
-  const scrollMatchIntoView = useCallback(() => {
-    if (!editor) return
-    requestAnimationFrame(() => {
-      const container = editorPanelRef?.current
-      if (!container) return
-      const { view } = editor
-      const { from } = view.state.selection
-      const coords = view.coordsAtPos(from)
-      const containerRect = container.getBoundingClientRect()
-      const toolbarEl = container.querySelector('.toolbar')
-      const bottomPadding = 50
-
-      const isScrollContainer =
-        container.scrollHeight > container.clientHeight &&
-        getComputedStyle(container).overflowY !== 'visible'
-
-      if (isScrollContainer) {
-        const toolbarBottom = toolbarEl ? toolbarEl.getBoundingClientRect().bottom : containerRect.top
-        if (coords.top < toolbarBottom) {
-          container.scrollBy({ top: -(toolbarBottom - coords.top + 20), behavior: 'instant' })
-        } else if (coords.bottom > containerRect.bottom - bottomPadding) {
-          container.scrollBy({ top: coords.bottom - containerRect.bottom + bottomPadding + 20, behavior: 'instant' })
-        }
-      } else {
-        const toolbarBottom = toolbarEl ? toolbarEl.getBoundingClientRect().bottom : 0
-        if (coords.top < toolbarBottom) {
-          window.scrollBy({ top: -(toolbarBottom - coords.top + 20), behavior: 'instant' })
-        } else if (coords.bottom > window.innerHeight - bottomPadding) {
-          window.scrollBy({ top: coords.bottom - window.innerHeight + bottomPadding + 20, behavior: 'instant' })
-        }
-      }
-    })
-  }, [editor, editorPanelRef])
-
-  const handleFindNext = () => {
-    editor?.commands?.findNext?.()
-    scrollMatchIntoView()
-  }
-
-  const handleFindPrev = () => {
-    editor?.commands?.findPrev?.()
-    scrollMatchIntoView()
-  }
-
-  // Wire openFind/closeFind into editor storage so the extension can trigger them
+  // Publish toolbar height as CSS custom property for mobile padding offsets.
   useEffect(() => {
-    if (!editor) return undefined
-    const findStorage = editor.storage.findInDoc
-    if (!findStorage) return undefined
-    findStorage.open = openFind
-    findStorage.close = closeFind
-    return () => {
-      if (editor.storage?.findInDoc) {
-        editor.storage.findInDoc.open = null
-        editor.storage.findInDoc.close = null
-      }
-    }
-  }, [editor, openFind, closeFind])
-
-  // Sync find plugin state → store
-  useEffect(() => {
-    if (!editor) return undefined
-    const syncFindState = () => {
-      const pluginState = findInDocPluginKey.getState(editor.state)
-      if (!pluginState) return
-      setFindStatus(pluginState)
-      setFindQuery(pluginState.query || '')
-    }
-    syncFindState()
-    editor.on('transaction', syncFindState)
-    return () => editor.off('transaction', syncFindState)
-  }, [editor, setFindStatus, setFindQuery])
-
-  // --- Selection sync helpers for indent/outdent ---
-
-  const syncSelectionFromDom = useCallback(() => {
-    if (!editor || editor.isDestroyed || editor.view.hasFocus()) return
-    const selection = window.getSelection?.()
-    const anchorNode = selection?.anchorNode
-    const focusNode = selection?.focusNode
-    if (!selection || selection.rangeCount === 0 || !anchorNode || !focusNode) return
-    const root = editor.view.dom
-    const anchorElement =
-      anchorNode.nodeType === Node.ELEMENT_NODE ? anchorNode : anchorNode.parentElement
-    const focusElement =
-      focusNode.nodeType === Node.ELEMENT_NODE ? focusNode : focusNode.parentElement
-    const selectionInEditor =
-      (anchorElement && root.contains(anchorElement)) ||
-      (focusElement && root.contains(focusElement))
-    if (!selectionInEditor) return
-    try {
-      const anchorPos = editor.view.posAtDOM(anchorNode, selection.anchorOffset)
-      const headPos = editor.view.posAtDOM(focusNode, selection.focusOffset)
-      const nextSelection = TextSelection.create(editor.state.doc, anchorPos, headPos)
-      if (nextSelection.eq(editor.state.selection)) return
-      editor.view.dispatch(editor.state.tr.setSelection(nextSelection))
-    } catch {
-      // Ignore DOM-to-state selection sync failures
-    }
-  }, [editor])
-
-  const getListItemInfo = useCallback(() => {
-    if (!editor) return null
-    const { $from } = editor.state.selection
-    const itemTypeName = editor.isActive('taskList') || editor.isActive('taskItem') ? 'taskItem' : 'listItem'
-    let itemDepth = null
-    for (let depth = $from.depth; depth > 0; depth -= 1) {
-      const node = $from.node(depth)
-      if (node.type?.name === 'listItem' || node.type?.name === 'taskItem') {
-        itemDepth = depth
-        break
-      }
-    }
-    if (!itemDepth) return null
-    const listDepth = itemDepth - 1
-    const index = $from.index(listDepth)
-    const listParentDepth = listDepth - 1
-    const listParent = listParentDepth > 0 ? $from.node(listParentDepth) : null
-    const isNested = listParent?.type?.name === 'listItem' || listParent?.type?.name === 'taskItem'
-    return { itemTypeName, itemDepth, listDepth, index, isNested }
-  }, [editor])
-
-  const handleIndent = useCallback(() => {
-    if (!editor) return
-    syncSelectionFromDom()
-    const info = getListItemInfo()
-    if (!info || info.index === 0) return
-    editor.chain().focus().sinkListItem(info.itemTypeName).run()
-  }, [editor, getListItemInfo, syncSelectionFromDom])
-
-  const handleOutdent = useCallback(() => {
-    if (!editor) return
-    syncSelectionFromDom()
-    const info = getListItemInfo()
-    if (!info || !info.isNested) return
-    editor.chain().focus().liftListItem(info.itemTypeName).run()
-  }, [editor, getListItemInfo, syncSelectionFromDom])
-
-  // --- Editor command handlers ---
-
-  const handleSetLink = () => {
-    if (!editor) return
-    const previousUrl = editor.getAttributes('link').href
-    const url = window.prompt('Paste a link URL', previousUrl || '')
-    if (url === null) return
-    if (url === '') {
-      editor.chain().focus().unsetLink().run()
-      return
-    }
-    editor.chain().focus().extendMarkRange('link').setLink({ href: url }).run()
-  }
-
-  const handleSetTextAlign = (alignment) => {
-    cmd()?.setTextAlign(alignment).run()
-  }
-
-  const handleExportText = () => {
-    if (!editor || !hasTracker) return
-    const rawTitle = title?.trim() || 'Untitled'
-    const safeTitle = rawTitle.replace(/[\\/:*?"<>|]+/g, '').trim() || 'Untitled'
-    const doc = editor.getJSON()
-    const text = serializeDocForExport(doc, rawTitle)
-    const blob = new Blob([text], { type: 'text/plain;charset=utf-8' })
-    const url = URL.createObjectURL(blob)
-    const link = document.createElement('a')
-    link.href = url
-    link.download = `${safeTitle}.txt`
-    document.body.appendChild(link)
-    link.click()
-    link.remove()
-    URL.revokeObjectURL(url)
-  }
-
-  const handleCopyText = async () => {
-    if (!editor || !hasTracker) return
-    const rawTitle = title?.trim() || 'Untitled'
-    const doc = editor.getJSON()
-    const text = serializeDocForExport(doc, rawTitle)
-    try {
-      await navigator.clipboard.writeText(text)
-      setCopyLabel('Copied!')
-      setTimeout(() => setCopyLabel('Copy'), 2000)
-    } catch {
-      window.alert('Failed to copy to clipboard.')
-    }
-  }
-
-  const handlePickImage = () => {
-    fileInputRef.current?.click()
-  }
-
-  const handleFileChange = (event) => {
-    const file = event.target.files?.[0]
-    if (file) {
-      onImageUpload?.(file)
-    }
-    event.target.value = ''
-  }
-
-  const handleInsertTable = (rows, cols) => {
-    if (!editor) return
-    cmd()?.insertTable({ rows, cols, withHeaderRow: false }).run()
-  }
-
-  const handleApplyHighlight = () => {
-    if (!editor) return
-    if (!highlightColor) {
-      cmd()?.unsetHighlight().run()
-      return
-    }
-    cmd()?.setHighlight({ color: highlightColor }).run()
-  }
-
-  const handlePickHighlight = (color) => {
-    if (!editor) return
-    if (!color) {
-      setHighlightColor(null)
-      cmd()?.unsetHighlight().run()
-    } else {
-      setHighlightColor(color)
-      cmd()?.setHighlight({ color }).run()
-    }
-  }
-
-  const handleApplyShading = () => {
-    if (!editor) return
-    if (!shadingColor) {
-      cmd()?.setCellAttribute('backgroundColor', null).run()
-      return
-    }
-    cmd()?.setCellAttribute('backgroundColor', shadingColor).run()
-  }
-
-  const handlePickShading = (color) => {
-    if (!editor) return
-    if (!color) {
-      setShadingColor(null)
-      cmd()?.setCellAttribute('backgroundColor', null).run()
-    } else {
-      setShadingColor(color)
-      cmd()?.setCellAttribute('backgroundColor', color).run()
-    }
-  }
-
-  const openCustomShading = () => {
-    shadingInputRef.current?.click()
-  }
-
-  const handleCustomShading = (event) => {
-    const color = event.target.value
-    if (!color) return
-    handlePickShading(color)
-  }
-
-  // AI Daily date navigation
-  const handleAiDailyPrevDay = () => {
-    setAiDailyDate((prev) => {
-      const next = new Date(prev)
-      next.setDate(next.getDate() - 1)
-      return next
-    })
-  }
-
-  const handleAiDailyNextDay = () => {
-    setAiDailyDate((prev) => {
-      const next = new Date(prev)
-      next.setDate(next.getDate() + 1)
-      return next
-    })
-  }
-
-  const handleAiDailyDateChange = (dateString) => {
-    const parsed = new Date(dateString + 'T00:00:00')
-    if (!isNaN(parsed.getTime())) {
-      setAiDailyDate(parsed)
-    }
-  }
-
-  const handleCopyLinkFromToolbar = async () => {
-    if (!toolbarDeepLinkHash) return
-    await navigator.clipboard.writeText(toolbarDeepLinkHash)
-  }
-
-  // --- Color data (theme palette for shading/highlight pickers) ---
-
-  const themeBaseColors = useMemo(
-    () => [
-      { label: 'White', value: '#ffffff' },
-      { label: 'Black', value: '#000000' },
-      { label: 'Dark Blue-Gray', value: '#1f2937' },
-      { label: 'Dark Blue', value: '#1e3a8a' },
-      { label: 'Medium Blue', value: '#2563eb' },
-      { label: 'Red', value: '#ef4444' },
-      { label: 'Dark Red', value: '#7f1d1d' },
-      { label: 'Orange', value: '#f97316' },
-      { label: 'Gold/Yellow', value: '#f59e0b' },
-      { label: 'Green', value: '#16a34a' },
-    ],
-    [],
-  )
-
-  const themeRows = useMemo(() => {
-    const lightSteps = [0.2, 0.4, 0.6, 0.8]
-    return [
-      themeBaseColors.map((color) => color.value),
-      ...lightSteps.map((amount) =>
-        themeBaseColors.map((color) => {
-          const base = color.value.toLowerCase()
-          if (base === '#ffffff') return mixColors(base, '#000000', amount)
-          return mixColors(base, '#ffffff', amount)
-        }),
-      ),
-    ]
-  }, [themeBaseColors])
-
-  const standardColors = useMemo(
-    () => [
-      '#7f1d1d', '#ef4444', '#f97316', '#f59e0b', '#22c55e',
-      '#0f766e', '#3b82f6', '#1e3a8a', '#0f172a', '#7c3aed',
-    ],
-    [],
-  )
-
-  const highlightColors = useMemo(
-    () => [
-      [
-        { label: 'Yellow', value: '#fef08a' },
-        { label: 'Green', value: '#86efac' },
-        { label: 'Cyan', value: '#67e8f9' },
-        { label: 'Magenta', value: '#f0abfc' },
-        { label: 'Blue', value: '#93c5fd' },
-      ],
-      [
-        { label: 'Red', value: '#fca5a5' },
-        { label: 'Dark Navy', value: '#0f172a' },
-        { label: 'Teal', value: '#0d9488' },
-        { label: 'Dark Green', value: '#166534' },
-        { label: 'Purple', value: '#7c3aed' },
-      ],
-      [
-        { label: 'Dark Maroon', value: '#7f1d1d' },
-        { label: 'Olive', value: '#a16207' },
-        { label: 'Gray', value: '#6b7280' },
-        { label: 'Light Gray', value: '#d1d5db' },
-        { label: 'Black', value: '#000000' },
-      ],
-      [
-        { label: 'Light Yellow', value: '#fef9c3' },
-        { label: 'Light Green', value: '#dcfce7' },
-        { label: 'Light Cyan', value: '#cffafe' },
-        { label: 'Pink', value: '#fbcfe8' },
-        { label: 'Light Blue', value: '#dbeafe' },
-      ],
-      [
-        { label: 'Orange', value: '#fdba74' },
-        { label: 'Medium Light Green', value: '#bbf7d0' },
-        { label: 'Medium Cyan', value: '#99f6e4' },
-        { label: 'Lavender', value: '#e9d5ff' },
-        { label: 'Bright Cyan', value: '#22d3ee' },
-      ],
-      [
-        { label: 'Light Orange', value: '#fed7aa' },
-        { label: 'Pale Green', value: '#ecfccb' },
-        { label: 'Pale Teal', value: '#ccfbf1' },
-        { label: 'Pale Lavender', value: '#f3e8ff' },
-        { label: 'Pale Blue', value: '#e0f2fe' },
-      ],
-    ],
-    [],
-  )
-
-  // --- Lifecycle effects ---
-
-  // Publish toolbar height as CSS custom property for mobile padding
-  useEffect(() => {
-    if (!isTouchOnly || !toolbarRef?.current) return
+    if (!isTouchOnly || !toolbarRef?.current) return undefined
     const el = toolbarRef.current
     const publishHeight = () => {
       const height = Math.ceil(el.getBoundingClientRect().height)
@@ -506,497 +61,77 @@ function Toolbar({
     }
   }, [isTouchOnly, toolbarRef])
 
-  // When the toolbar expands on mobile, scroll so the cursor stays visible above it.
-  useKeepCursorVisible({ enabled: isTouchOnly, editor, toolbarExpanded, toolbarRef, editorPanelRef })
-
-  // Outside click and escape handlers for pickers
-  useEffect(() => {
-    const handleOutsideClick = (event) => {
-      if (tablePickerOpen) {
-        const picker = tablePickerRef.current
-        const button = tableButtonRef.current
-        if (picker?.contains(event.target) || button?.contains(event.target)) return
-        setTablePickerOpen(false)
-      }
-      if (highlightPickerOpen) {
-        const picker = highlightPickerRef.current
-        const button = highlightButtonRef.current
-        if (picker?.contains(event.target) || button?.contains(event.target)) return
-        setHighlightPickerOpen(false)
-      }
-      if (shadingPickerOpen) {
-        const picker = shadingPickerRef.current
-        const button = shadingButtonRef.current
-        if (picker?.contains(event.target) || button?.contains(event.target)) return
-        setShadingPickerOpen(false)
-      }
-      if (aiDailyPickerOpen) {
-        const picker = aiDailyPickerRef.current
-        const button = aiDailyButtonRef.current
-        if (picker?.contains(event.target) || button?.contains(event.target)) return
-        setAiDailyPickerOpen(false)
-      }
-      if (moreMenuOpen && moreMenuRef.current && !moreMenuRef.current.contains(event.target)) {
-        setMoreMenuOpen(false)
-      }
-    }
-
-    const handleKeyDown = (event) => {
-      if (event.key === 'Escape') {
-        setTablePickerOpen(false)
-        setHighlightPickerOpen(false)
-        setShadingPickerOpen(false)
-        setAiDailyPickerOpen(false)
-        setMoreMenuOpen(false)
-      }
-    }
-
-    document.addEventListener('mousedown', handleOutsideClick)
-    document.addEventListener('keydown', handleKeyDown)
-    return () => {
-      document.removeEventListener('mousedown', handleOutsideClick)
-      document.removeEventListener('keydown', handleKeyDown)
-    }
-  }, [tablePickerOpen, highlightPickerOpen, shadingPickerOpen, aiDailyPickerOpen, moreMenuOpen])
-
-  const closeTablePicker = useCallback(() => setTablePickerOpen(false), [])
-
-  const onInsertTable = (rows, cols) => {
-    handleInsertTable(rows, cols)
-    closeTablePicker()
-  }
-
-  const onPickHighlight = (color) => {
-    handlePickHighlight(color)
-    setHighlightPickerOpen(false)
-  }
-
-  const onPickShading = (color) => {
-    handlePickShading(color)
-    setShadingPickerOpen(false)
-  }
-
-  const onCopyLinkFromToolbar = async () => {
-    await handleCopyLinkFromToolbar()
-    setMoreMenuOpen(false)
-  }
-
-  const onSetTrackerFromToolbar = async () => {
-    await handleSetTrackerFromToolbar()
-    setMoreMenuOpen(false)
-  }
-
-  // ToolButton helpers — every toolbar button uses the wrapper that
-  // preserves the editor selection on touch.
-  const tb = (props) => (
-    <ToolButton
-      isTouchOnly={isTouchOnly}
-      disabled={!hasTracker}
-      {...props}
-    />
+  const ctxValue = useMemo(
+    () => ({
+      isTouchOnly,
+      hasTracker,
+      controlsDisabled,
+      editorPanelRef,
+      title,
+      onImageUpload,
+      onAiDailyGenerate,
+      showAiDaily,
+      showAiInsert,
+      toolbarDeepLinkHash,
+      isCurrentPageTracker,
+      trackerPageSaving,
+      onSetTrackerPage,
+      handleSetTrackerFromToolbar,
+      contextMenuItems,
+      openFind,
+    }),
+    [
+      isTouchOnly, hasTracker, controlsDisabled, editorPanelRef, title,
+      onImageUpload, onAiDailyGenerate, showAiDaily, showAiInsert,
+      toolbarDeepLinkHash, isCurrentPageTracker, trackerPageSaving,
+      onSetTrackerPage, handleSetTrackerFromToolbar, contextMenuItems,
+      openFind,
+    ],
   )
 
   return (
-    <div
-      ref={toolbarRef}
-      className={`toolbar${controlsDisabled ? ' disabled' : ''}${isTouchOnly && !toolbarExpanded ? ' toolbar-collapsed' : ''}`}
-      data-expanded={!isTouchOnly || toolbarExpanded ? 'true' : 'false'}
-    >
-      <div className="toolbar-core">
-        {/* Text formatting group */}
-        <div className="toolbar-group">
-          {tb({
-            active: editor?.isActive('bold'),
-            onActivate: () => cmd()?.toggleBold().run(),
-            title: 'Bold',
-            children: <BoldIcon />,
-          })}
-          {tb({
-            active: editor?.isActive('italic'),
-            onActivate: () => cmd()?.toggleItalic().run(),
-            title: 'Italic',
-            children: <ItalicIcon />,
-          })}
-          {tb({
-            active: editor?.isActive('heading', { level: 1 }),
-            onActivate: () => cmd()?.toggleHeading({ level: 1 }).run(),
-            title: 'Heading 1',
-            children: <span className="toolbar-btn-label">H1</span>,
-          })}
-          {tb({
-            active: editor?.isActive('bulletList'),
-            onActivate: () => cmd()?.toggleBulletList().run(),
-            title: 'Bullet list',
-            children: <BulletListIcon />,
-          })}
+    <ToolbarContext.Provider value={ctxValue}>
+      <div
+        ref={toolbarRef}
+        className={`toolbar${controlsDisabled ? ' disabled' : ''}${isTouchOnly && !toolbarExpanded ? ' toolbar-collapsed' : ''}`}
+        data-expanded={!isTouchOnly || toolbarExpanded ? 'true' : 'false'}
+      >
+        <div className="toolbar-core">
+          {CORE_GROUPS.map((group) => (
+            <ToolbarGroup key={group.id} group={group} editor={editor} />
+          ))}
           {isTouchOnly && (
-            <>
-              {tb({
-                disabled: !hasTracker || !isInList,
-                onActivate: handleOutdent,
-                title: 'Outdent',
-                ariaLabel: 'Outdent list item',
-                testId: 'toolbar-outdent',
-                children: <OutdentIcon />,
-              })}
-              {tb({
-                disabled: !hasTracker || !isInList,
-                onActivate: handleIndent,
-                title: 'Indent',
-                ariaLabel: 'Indent list item',
-                testId: 'toolbar-indent',
-                children: <IndentIcon />,
-              })}
-            </>
+            <ToolButton
+              isTouchOnly={isTouchOnly}
+              className="toolbar-expand-toggle"
+              onActivate={() => setToolbarExpanded((prev) => !prev)}
+              ariaLabel={toolbarExpanded ? 'Collapse toolbar' : 'Expand toolbar'}
+              testId="toolbar-expand-toggle"
+            >
+              {toolbarExpanded ? '▴' : '▾'}
+            </ToolButton>
           )}
         </div>
 
-        {/* Link + Undo group */}
-        <div className="toolbar-group">
-          {tb({
-            onActivate: handleSetLink,
-            title: 'Link',
-            ariaLabel: 'Insert link',
-            children: <LinkIcon />,
-          })}
-          {tb({
-            onActivate: () => cmd()?.undo().run(),
-            title: 'Undo',
-            testId: 'toolbar-undo',
-            children: <UndoIcon />,
-          })}
+        <div className="toolbar-extra">
+          {EXTRA_GROUPS.map((group) => (
+            <ToolbarGroup key={group.id} group={group} editor={editor} />
+          ))}
         </div>
 
-        {/* Mobile expand toggle */}
-        {isTouchOnly && (
-          <ToolButton
-            isTouchOnly={isTouchOnly}
-            className="toolbar-expand-toggle"
-            onActivate={() => setToolbarExpanded((prev) => !prev)}
-            ariaLabel={toolbarExpanded ? 'Collapse toolbar' : 'Expand toolbar'}
-            testId="toolbar-expand-toggle"
-          >
-            {toolbarExpanded ? '▴' : '▾'}
-          </ToolButton>
+        {findOpen && hasTracker && (
+          <FindBar
+            inputRef={findInputRef}
+            findQuery={findQuery}
+            findStatus={findStatus}
+            onFindQueryChange={handleFindQueryChange}
+            onFindPrev={handleFindPrev}
+            onFindNext={handleFindNext}
+            onClose={closeFind}
+          />
         )}
       </div>
-
-      <div className="toolbar-extra">
-        {/* Extended text formatting */}
-        <div className="toolbar-group">
-          {tb({
-            active: editor?.isActive('underline'),
-            onActivate: () => cmd()?.toggleUnderline().run(),
-            title: 'Underline',
-            children: <UnderlineIcon />,
-          })}
-          {tb({
-            active: editor?.isActive('strike'),
-            onActivate: () => editor && toggleLineStrike(editor),
-            title: 'Strikethrough',
-            ariaLabel: 'Toggle strikethrough',
-            testId: 'toolbar-strikethrough',
-            children: <StrikethroughIcon />,
-          })}
-          <div className="highlight-control" ref={highlightButtonRef}>
-            {tb({
-              active: editor?.isActive('highlight'),
-              onActivate: handleApplyHighlight,
-              title: 'Highlight',
-              children: (
-                <>
-                  <HighlightIcon />
-                  <span
-                    className="toolbar-color-bar"
-                    style={{ backgroundColor: highlightColor ?? 'transparent' }}
-                  />
-                </>
-              ),
-            })}
-            {tb({
-              className: 'toolbar-btn-caret',
-              onActivate: () => setHighlightPickerOpen((prev) => !prev),
-              ariaLabel: 'Highlight colors',
-              children: '▾',
-            })}
-            {highlightPickerOpen && (
-              <HighlightPicker
-                pickerRef={highlightPickerRef}
-                colors={highlightColors}
-                onPick={onPickHighlight}
-              />
-            )}
-          </div>
-          <input
-            type="color"
-            aria-label="Text color"
-            className="toolbar-color-input"
-            onChange={(event) => cmd()?.setColor(event.target.value).run()}
-            disabled={!hasTracker}
-          />
-        </div>
-
-        {/* Headings + Lists */}
-        <div className="toolbar-group">
-          {tb({
-            active: editor?.isActive('heading', { level: 2 }),
-            onActivate: () => cmd()?.toggleHeading({ level: 2 }).run(),
-            title: 'Heading 2',
-            children: <span className="toolbar-btn-label">H2</span>,
-          })}
-          {tb({
-            active: editor?.isActive('orderedList'),
-            onActivate: () => cmd()?.toggleOrderedList().run(),
-            title: 'Numbered list',
-            children: <OrderedListIcon />,
-          })}
-          {tb({
-            active: editor?.isActive('taskList'),
-            onActivate: () => cmd()?.toggleTaskList().run(),
-            title: 'Task list',
-            children: <TaskListIcon />,
-          })}
-        </div>
-
-        {/* Alignment */}
-        <div className="toolbar-group">
-          {tb({
-            active: editor?.isActive({ textAlign: 'left' }),
-            onActivate: () => handleSetTextAlign('left'),
-            title: 'Align left',
-            children: <AlignLeftIcon />,
-          })}
-          {tb({
-            active: editor?.isActive({ textAlign: 'center' }),
-            onActivate: () => handleSetTextAlign('center'),
-            title: 'Align center',
-            children: <AlignCenterIcon />,
-          })}
-          {tb({
-            active: editor?.isActive({ textAlign: 'right' }),
-            onActivate: () => handleSetTextAlign('right'),
-            title: 'Align right',
-            children: <AlignRightIcon />,
-          })}
-        </div>
-
-        <div className="toolbar-separator" />
-
-        {/* Insert group */}
-        <div className="toolbar-group">
-          {tb({
-            onActivate: () => cmd()?.unsetLink().run(),
-            title: 'Unlink',
-            ariaLabel: 'Remove link',
-            children: <UnlinkIcon />,
-          })}
-          {tb({
-            onActivate: handlePickImage,
-            title: 'Image',
-            ariaLabel: 'Insert image',
-            children: <ImageIcon />,
-          })}
-          <input
-            ref={fileInputRef}
-            type="file"
-            accept="image/*"
-            onChange={handleFileChange}
-            className="file-input"
-          />
-          <div className="table-picker-wrap">
-            {tb({
-              buttonRef: tableButtonRef,
-              onActivate: () => setTablePickerOpen((prev) => !prev),
-              title: 'Table',
-              ariaLabel: 'Insert table',
-              children: <TableIcon />,
-            })}
-            {tablePickerOpen && (
-              <TablePicker
-                pickerRef={tablePickerRef}
-                size={tableSize}
-                setSize={setTableSize}
-                onInsert={onInsertTable}
-                onClose={closeTablePicker}
-              />
-            )}
-          </div>
-          {tb({
-            onActivate: () => cmd()?.addRowAfter().run(),
-            title: 'Add row',
-            children: <AddRowIcon />,
-          })}
-          {tb({
-            onActivate: () => cmd()?.addColumnAfter().run(),
-            title: 'Add column',
-            children: <AddColIcon />,
-          })}
-          {inTable && (
-            <div className="shading-control" ref={shadingButtonRef}>
-              {tb({
-                active: !!shadingColor,
-                onActivate: handleApplyShading,
-                title: 'Shading',
-                ariaLabel: 'Cell shading',
-                children: <ShadingIcon />,
-              })}
-              {tb({
-                className: 'toolbar-btn-caret',
-                onActivate: () => setShadingPickerOpen((prev) => !prev),
-                ariaLabel: 'Shading colors',
-                children: '▾',
-              })}
-              {shadingPickerOpen && (
-                <ShadingPicker
-                  pickerRef={shadingPickerRef}
-                  themeRows={themeRows}
-                  standardColors={standardColors}
-                  shadingColor={shadingColor}
-                  customInputRef={shadingInputRef}
-                  onPick={onPickShading}
-                  onOpenCustom={openCustomShading}
-                  onCustomChange={handleCustomShading}
-                />
-              )}
-            </div>
-          )}
-          {tb({
-            onActivate: () => cmd()?.deleteTable().run(),
-            title: 'Delete table',
-            children: <DeleteTableIcon />,
-          })}
-        </div>
-
-        <div className="toolbar-separator" />
-
-        {/* Undo/Redo + utilities */}
-        <div className="toolbar-group">
-          {tb({
-            onActivate: () => cmd()?.redo().run(),
-            title: 'Redo',
-            children: <RedoIcon />,
-          })}
-          {tb({
-            onActivate: handleExportText,
-            title: 'Export',
-            children: <ExportIcon />,
-          })}
-          {tb({
-            onActivate: handleCopyText,
-            title: copyLabel,
-            ariaLabel: 'Copy text',
-            children: <CopyIcon />,
-          })}
-        </div>
-
-        {/* AI group */}
-        {showAiDaily && (
-          <div className="toolbar-group">
-            <div className="ai-daily-control" ref={aiDailyButtonRef}>
-              {tb({
-                disabled: !hasTracker || aiLoading || aiInsertLoading,
-                className: 'toolbar-btn-ai',
-                onActivate: onAiDailyGenerate,
-                title: aiLoading ? 'Generating...' : 'AI Daily',
-                ariaLabel: 'AI Daily',
-                children: (
-                  <>
-                    <AiIcon />
-                    <span className="toolbar-btn-label toolbar-btn-ai-label">
-                      {aiLoading ? '...' : 'AI'}
-                    </span>
-                  </>
-                ),
-              })}
-              {tb({
-                disabled: !hasTracker || aiLoading || aiInsertLoading,
-                className: 'toolbar-btn-caret',
-                onActivate: () => setAiDailyPickerOpen((prev) => !prev),
-                ariaLabel: 'Pick date for AI Daily',
-                children: '▾',
-              })}
-              {aiDailyPickerOpen && (
-                <AiDailyPicker
-                  pickerRef={aiDailyPickerRef}
-                  date={aiDailyDate}
-                  onPrevDay={handleAiDailyPrevDay}
-                  onNextDay={handleAiDailyNextDay}
-                  onDateChange={handleAiDailyDateChange}
-                />
-              )}
-            </div>
-            {showAiInsert && tb({
-              disabled: !hasTracker || aiLoading || aiInsertLoading,
-              className: 'toolbar-btn-ai',
-              onActivate: () => {
-                setAiDailyPickerOpen(false)
-                setAiInsertOpen(true)
-              },
-              title: aiInsertLoading ? 'Inserting...' : 'AI Insert',
-              ariaLabel: 'AI Insert',
-              children: (
-                <>
-                  <AiIcon />
-                  <span className="toolbar-btn-label toolbar-btn-ai-label">
-                    {aiInsertLoading ? '...' : '⊕'}
-                  </span>
-                </>
-              ),
-            })}
-          </div>
-        )}
-
-        {/* Search + More */}
-        <div className="toolbar-group">
-          {tb({
-            onActivate: openFind,
-            title: 'Find',
-            ariaLabel: 'Find in page',
-            children: <SearchIcon />,
-          })}
-          <div className="more-menu-wrap" ref={moreMenuRef}>
-            {tb({
-              onActivate: () => setMoreMenuOpen((prev) => !prev),
-              title: 'More',
-              ariaLabel: 'More actions',
-              children: <MoreIcon />,
-            })}
-            {moreMenuOpen && (
-              <MoreMenu
-                onClose={() => setMoreMenuOpen(false)}
-                onCopyLink={onCopyLinkFromToolbar}
-                copyLinkDisabled={!toolbarDeepLinkHash}
-                onSetTrackerPage={onSetTrackerFromToolbar}
-                setTrackerLabel={
-                  isCurrentPageTracker
-                    ? 'This page is the tracker page'
-                    : trackerPageSaving
-                    ? 'Setting tracker page...'
-                    : 'Set this page as tracker'
-                }
-                setTrackerDisabled={
-                  !hasTracker || isCurrentPageTracker || trackerPageSaving || !onSetTrackerPage
-                }
-                inTable={inTable}
-                contextMenuItems={contextMenuItems}
-              />
-            )}
-          </div>
-        </div>
-      </div>
-
-      {findOpen && hasTracker && (
-        <FindBar
-          inputRef={findInputRef}
-          findQuery={findQuery}
-          findStatus={findStatus}
-          onFindQueryChange={handleFindQueryChange}
-          onFindPrev={handleFindPrev}
-          onFindNext={handleFindNext}
-          onClose={closeFind}
-        />
-      )}
-    </div>
+    </ToolbarContext.Provider>
   )
 }
 

--- a/src/components/editor/toolbar/ToolbarContext.js
+++ b/src/components/editor/toolbar/ToolbarContext.js
@@ -1,0 +1,33 @@
+import { createContext, useContext } from 'react'
+
+/**
+ * Parent-owned values that individual toolbar tools need. Tools read from
+ * context instead of having ~10 single-use props threaded through Toolbar.
+ *
+ * Shape:
+ *   isTouchOnly:                bool — mobile / touch device flag
+ *   hasTracker:                 bool — disables tools that need a doc
+ *   controlsDisabled:           bool — broader disabled state
+ *   editorPanelRef:             ref  — editor scroll container (for find scroll)
+ *   title:                      str  — used for export filename + copy header
+ *   onImageUpload:              fn   — invoked by the image tool
+ *   onAiDailyGenerate:          fn   — invoked by the AI Daily tool
+ *   showAiDaily:                bool — gates AI group visibility
+ *   showAiInsert:               bool — gates the AI Insert button
+ *   toolbarDeepLinkHash:        str  — for the More menu's copy-link
+ *   isCurrentPageTracker:       bool — More menu label state
+ *   trackerPageSaving:          bool — More menu label state
+ *   onSetTrackerPage:           fn   — More menu enable predicate
+ *   handleSetTrackerFromToolbar fn   — More menu action
+ *   contextMenuItems:           arr  — extra in-table items for More menu
+ *   openFind:                   fn   — provided by useFindBar
+ */
+export const ToolbarContext = createContext(null)
+
+export function useToolbarContext() {
+  const ctx = useContext(ToolbarContext)
+  if (!ctx) {
+    throw new Error('useToolbarContext must be used inside <ToolbarContext.Provider>')
+  }
+  return ctx
+}

--- a/src/components/editor/toolbar/ToolbarGroup.jsx
+++ b/src/components/editor/toolbar/ToolbarGroup.jsx
@@ -1,0 +1,34 @@
+import { TOOL_DEFINITIONS } from './tools'
+import { useToolbarContext } from './ToolbarContext'
+
+/**
+ * Renders a single toolbar group: either a separator, or a row of tools.
+ * Mobile-only tools are filtered out on desktop. Groups with a `visible(ctx)`
+ * predicate that returns false are skipped entirely.
+ */
+function ToolbarGroup({ group, editor }) {
+  const ctx = useToolbarContext()
+
+  if (group.separator) return <div className="toolbar-separator" />
+  if (group.visible && !group.visible(ctx)) return null
+
+  const toolIds = group.tools.filter((id) => {
+    const def = TOOL_DEFINITIONS[id]
+    if (!def) return false
+    if (def.mobileOnly && !ctx.isTouchOnly) return false
+    return true
+  })
+
+  if (toolIds.length === 0) return null
+
+  return (
+    <div className="toolbar-group">
+      {toolIds.map((id) => {
+        const { Component } = TOOL_DEFINITIONS[id]
+        return <Component key={id} editor={editor} />
+      })}
+    </div>
+  )
+}
+
+export default ToolbarGroup

--- a/src/components/editor/toolbar/__tests__/tools.test.js
+++ b/src/components/editor/toolbar/__tests__/tools.test.js
@@ -1,0 +1,38 @@
+import { describe, it, expect } from 'vitest'
+import { TOOL_DEFINITIONS, CORE_GROUPS, EXTRA_GROUPS } from '../tools'
+
+describe('toolbar tool registry', () => {
+  const allGroupToolIds = [...CORE_GROUPS, ...EXTRA_GROUPS]
+    .filter((g) => !g.separator)
+    .flatMap((g) => g.tools)
+
+  it('every referenced tool ID resolves to a registered Component', () => {
+    for (const id of allGroupToolIds) {
+      expect(TOOL_DEFINITIONS[id], `missing tool definition for "${id}"`).toBeDefined()
+      expect(typeof TOOL_DEFINITIONS[id].Component).toBe('function')
+    }
+  })
+
+  it('group IDs are unique', () => {
+    const ids = [...CORE_GROUPS, ...EXTRA_GROUPS].map((g) => g.id)
+    expect(new Set(ids).size).toBe(ids.length)
+  })
+
+  it('mobileOnly tools only appear in groups that exist on mobile (CORE)', () => {
+    const mobileOnlyIds = Object.entries(TOOL_DEFINITIONS)
+      .filter(([, def]) => def.mobileOnly)
+      .map(([id]) => id)
+    const extraIds = EXTRA_GROUPS.filter((g) => !g.separator).flatMap((g) => g.tools)
+    for (const id of mobileOnlyIds) {
+      expect(extraIds, `${id} should be in CORE, not EXTRA`).not.toContain(id)
+    }
+  })
+
+  it('separator entries are well-formed', () => {
+    const separators = EXTRA_GROUPS.filter((g) => g.separator)
+    for (const sep of separators) {
+      expect(sep.id).toBeTruthy()
+      expect(sep.tools).toBeUndefined()
+    }
+  })
+})

--- a/src/components/editor/toolbar/tools.jsx
+++ b/src/components/editor/toolbar/tools.jsx
@@ -1,0 +1,930 @@
+import { useCallback, useMemo, useRef, useState } from 'react'
+import { mixColors } from '../../../utils/colorUtils'
+import { serializeDocForExport } from '../../../lib/serializeDocForExport'
+import { toggleLineStrike } from '../../../extensions/keyboard/toggleLineStrike'
+import { getListItemInfo } from '../../../utils/listHelpers'
+import { useEditorUIStore } from '../../../stores/editorUIStore'
+import ToolButton from '../ToolButton'
+import HighlightPicker from './HighlightPicker'
+import ShadingPicker from './ShadingPicker'
+import TablePicker from './TablePicker'
+import AiDailyPicker from './AiDailyPicker'
+import MoreMenu from './MoreMenu'
+import { useToolbarContext } from './ToolbarContext'
+import { useOutsideClick } from './useOutsideClick'
+import { TextSelection } from '@tiptap/pm/state'
+import {
+  BoldIcon, ItalicIcon, UnderlineIcon, StrikethroughIcon,
+  HighlightIcon,
+  BulletListIcon, OrderedListIcon, TaskListIcon,
+  AlignLeftIcon, AlignCenterIcon, AlignRightIcon,
+  LinkIcon, UnlinkIcon, ImageIcon,
+  TableIcon, AddRowIcon, AddColIcon, DeleteTableIcon, ShadingIcon,
+  UndoIcon, RedoIcon,
+  SearchIcon, ExportIcon, CopyIcon, MoreIcon, AiIcon,
+  IndentIcon, OutdentIcon,
+} from '../ToolbarIcons'
+
+// --- Shared helpers -------------------------------------------------------
+
+const cmd = (editor) => editor?.chain().focus() ?? null
+
+/** Thin ToolButton wrapper that injects ctx-driven defaults. */
+function Btn({ disabled, ...rest }) {
+  const { isTouchOnly, hasTracker } = useToolbarContext()
+  return (
+    <ToolButton
+      isTouchOnly={isTouchOnly}
+      disabled={disabled ?? !hasTracker}
+      {...rest}
+    />
+  )
+}
+
+// --- Inline marks ---------------------------------------------------------
+
+function BoldTool({ editor }) {
+  return (
+    <Btn
+      active={editor?.isActive('bold')}
+      onActivate={() => cmd(editor)?.toggleBold().run()}
+      title="Bold"
+    >
+      <BoldIcon />
+    </Btn>
+  )
+}
+
+function ItalicTool({ editor }) {
+  return (
+    <Btn
+      active={editor?.isActive('italic')}
+      onActivate={() => cmd(editor)?.toggleItalic().run()}
+      title="Italic"
+    >
+      <ItalicIcon />
+    </Btn>
+  )
+}
+
+function UnderlineTool({ editor }) {
+  return (
+    <Btn
+      active={editor?.isActive('underline')}
+      onActivate={() => cmd(editor)?.toggleUnderline().run()}
+      title="Underline"
+    >
+      <UnderlineIcon />
+    </Btn>
+  )
+}
+
+function StrikeTool({ editor }) {
+  return (
+    <Btn
+      active={editor?.isActive('strike')}
+      onActivate={() => editor && toggleLineStrike(editor)}
+      title="Strikethrough"
+      ariaLabel="Toggle strikethrough"
+      testId="toolbar-strikethrough"
+    >
+      <StrikethroughIcon />
+    </Btn>
+  )
+}
+
+// --- Headings -------------------------------------------------------------
+
+function H1Tool({ editor }) {
+  return (
+    <Btn
+      active={editor?.isActive('heading', { level: 1 })}
+      onActivate={() => cmd(editor)?.toggleHeading({ level: 1 }).run()}
+      title="Heading 1"
+    >
+      <span className="toolbar-btn-label">H1</span>
+    </Btn>
+  )
+}
+
+function H2Tool({ editor }) {
+  return (
+    <Btn
+      active={editor?.isActive('heading', { level: 2 })}
+      onActivate={() => cmd(editor)?.toggleHeading({ level: 2 }).run()}
+      title="Heading 2"
+    >
+      <span className="toolbar-btn-label">H2</span>
+    </Btn>
+  )
+}
+
+// --- Lists ----------------------------------------------------------------
+
+function BulletListTool({ editor }) {
+  return (
+    <Btn
+      active={editor?.isActive('bulletList')}
+      onActivate={() => cmd(editor)?.toggleBulletList().run()}
+      title="Bullet list"
+    >
+      <BulletListIcon />
+    </Btn>
+  )
+}
+
+function OrderedListTool({ editor }) {
+  return (
+    <Btn
+      active={editor?.isActive('orderedList')}
+      onActivate={() => cmd(editor)?.toggleOrderedList().run()}
+      title="Numbered list"
+    >
+      <OrderedListIcon />
+    </Btn>
+  )
+}
+
+function TaskListTool({ editor }) {
+  return (
+    <Btn
+      active={editor?.isActive('taskList')}
+      onActivate={() => cmd(editor)?.toggleTaskList().run()}
+      title="Task list"
+    >
+      <TaskListIcon />
+    </Btn>
+  )
+}
+
+// Mobile-only indent/outdent. On touch, the editor selection often lives in
+// the DOM only (no focus); we sync it into ProseMirror before dispatching.
+function useIndentOutdent(editor) {
+  const syncSelectionFromDom = useCallback(() => {
+    if (!editor || editor.isDestroyed || editor.view.hasFocus()) return
+    const selection = window.getSelection?.()
+    const anchorNode = selection?.anchorNode
+    const focusNode = selection?.focusNode
+    if (!selection || selection.rangeCount === 0 || !anchorNode || !focusNode) return
+    const root = editor.view.dom
+    const anchorElement =
+      anchorNode.nodeType === Node.ELEMENT_NODE ? anchorNode : anchorNode.parentElement
+    const focusElement =
+      focusNode.nodeType === Node.ELEMENT_NODE ? focusNode : focusNode.parentElement
+    const selectionInEditor =
+      (anchorElement && root.contains(anchorElement)) ||
+      (focusElement && root.contains(focusElement))
+    if (!selectionInEditor) return
+    try {
+      const anchorPos = editor.view.posAtDOM(anchorNode, selection.anchorOffset)
+      const headPos = editor.view.posAtDOM(focusNode, selection.focusOffset)
+      const nextSelection = TextSelection.create(editor.state.doc, anchorPos, headPos)
+      if (nextSelection.eq(editor.state.selection)) return
+      editor.view.dispatch(editor.state.tr.setSelection(nextSelection))
+    } catch {
+      // Ignore DOM-to-state selection sync failures
+    }
+  }, [editor])
+
+  const handleIndent = useCallback(() => {
+    if (!editor) return
+    syncSelectionFromDom()
+    const info = getListItemInfo(editor)
+    if (!info || info.index === 0) return
+    editor.chain().focus().sinkListItem(info.itemTypeName).run()
+  }, [editor, syncSelectionFromDom])
+
+  const handleOutdent = useCallback(() => {
+    if (!editor) return
+    syncSelectionFromDom()
+    const info = getListItemInfo(editor)
+    if (!info || !info.isNested) return
+    editor.chain().focus().liftListItem(info.itemTypeName).run()
+  }, [editor, syncSelectionFromDom])
+
+  return { handleIndent, handleOutdent }
+}
+
+function isInAnyList(editor) {
+  return Boolean(
+    editor?.isActive('bulletList') ||
+    editor?.isActive('orderedList') ||
+    editor?.isActive('taskList'),
+  )
+}
+
+function OutdentTool({ editor }) {
+  const { hasTracker } = useToolbarContext()
+  const { handleOutdent } = useIndentOutdent(editor)
+  return (
+    <Btn
+      disabled={!hasTracker || !isInAnyList(editor)}
+      onActivate={handleOutdent}
+      title="Outdent"
+      ariaLabel="Outdent list item"
+      testId="toolbar-outdent"
+    >
+      <OutdentIcon />
+    </Btn>
+  )
+}
+
+function IndentTool({ editor }) {
+  const { hasTracker } = useToolbarContext()
+  const { handleIndent } = useIndentOutdent(editor)
+  return (
+    <Btn
+      disabled={!hasTracker || !isInAnyList(editor)}
+      onActivate={handleIndent}
+      title="Indent"
+      ariaLabel="Indent list item"
+      testId="toolbar-indent"
+    >
+      <IndentIcon />
+    </Btn>
+  )
+}
+
+// --- Link / Unlink --------------------------------------------------------
+
+function LinkTool({ editor }) {
+  const handleSetLink = () => {
+    if (!editor) return
+    const previousUrl = editor.getAttributes('link').href
+    const url = window.prompt('Paste a link URL', previousUrl || '')
+    if (url === null) return
+    if (url === '') {
+      editor.chain().focus().unsetLink().run()
+      return
+    }
+    editor.chain().focus().extendMarkRange('link').setLink({ href: url }).run()
+  }
+  return (
+    <Btn onActivate={handleSetLink} title="Link" ariaLabel="Insert link">
+      <LinkIcon />
+    </Btn>
+  )
+}
+
+function UnlinkTool({ editor }) {
+  return (
+    <Btn
+      onActivate={() => cmd(editor)?.unsetLink().run()}
+      title="Unlink"
+      ariaLabel="Remove link"
+    >
+      <UnlinkIcon />
+    </Btn>
+  )
+}
+
+// --- Highlight (with picker) ---------------------------------------------
+
+const HIGHLIGHT_COLORS = [
+  [
+    { label: 'Yellow', value: '#fef08a' },
+    { label: 'Green', value: '#86efac' },
+    { label: 'Cyan', value: '#67e8f9' },
+    { label: 'Magenta', value: '#f0abfc' },
+    { label: 'Blue', value: '#93c5fd' },
+  ],
+  [
+    { label: 'Red', value: '#fca5a5' },
+    { label: 'Dark Navy', value: '#0f172a' },
+    { label: 'Teal', value: '#0d9488' },
+    { label: 'Dark Green', value: '#166534' },
+    { label: 'Purple', value: '#7c3aed' },
+  ],
+  [
+    { label: 'Dark Maroon', value: '#7f1d1d' },
+    { label: 'Olive', value: '#a16207' },
+    { label: 'Gray', value: '#6b7280' },
+    { label: 'Light Gray', value: '#d1d5db' },
+    { label: 'Black', value: '#000000' },
+  ],
+  [
+    { label: 'Light Yellow', value: '#fef9c3' },
+    { label: 'Light Green', value: '#dcfce7' },
+    { label: 'Light Cyan', value: '#cffafe' },
+    { label: 'Pink', value: '#fbcfe8' },
+    { label: 'Light Blue', value: '#dbeafe' },
+  ],
+  [
+    { label: 'Orange', value: '#fdba74' },
+    { label: 'Medium Light Green', value: '#bbf7d0' },
+    { label: 'Medium Cyan', value: '#99f6e4' },
+    { label: 'Lavender', value: '#e9d5ff' },
+    { label: 'Bright Cyan', value: '#22d3ee' },
+  ],
+  [
+    { label: 'Light Orange', value: '#fed7aa' },
+    { label: 'Pale Green', value: '#ecfccb' },
+    { label: 'Pale Teal', value: '#ccfbf1' },
+    { label: 'Pale Lavender', value: '#f3e8ff' },
+    { label: 'Pale Blue', value: '#e0f2fe' },
+  ],
+]
+
+function HighlightTool({ editor }) {
+  const highlightColor = useEditorUIStore((s) => s.highlightColor)
+  const setHighlightColor = useEditorUIStore((s) => s.setHighlightColor)
+  const [open, setOpen] = useState(false)
+  const wrapRef = useRef(null)
+  const pickerRef = useRef(null)
+  const refs = useMemo(() => [wrapRef, pickerRef], [])
+  useOutsideClick({ isOpen: open, onClose: () => setOpen(false), refs })
+
+  const apply = () => {
+    if (!editor) return
+    if (!highlightColor) cmd(editor)?.unsetHighlight().run()
+    else cmd(editor)?.setHighlight({ color: highlightColor }).run()
+  }
+
+  const pick = (color) => {
+    if (!editor) return
+    if (!color) {
+      setHighlightColor(null)
+      cmd(editor)?.unsetHighlight().run()
+    } else {
+      setHighlightColor(color)
+      cmd(editor)?.setHighlight({ color }).run()
+    }
+    setOpen(false)
+  }
+
+  return (
+    <div className="highlight-control" ref={wrapRef}>
+      <Btn
+        active={editor?.isActive('highlight')}
+        onActivate={apply}
+        title="Highlight"
+      >
+        <HighlightIcon />
+        <span
+          className="toolbar-color-bar"
+          style={{ backgroundColor: highlightColor ?? 'transparent' }}
+        />
+      </Btn>
+      <Btn
+        className="toolbar-btn-caret"
+        onActivate={() => setOpen((prev) => !prev)}
+        ariaLabel="Highlight colors"
+      >
+        ▾
+      </Btn>
+      {open && (
+        <HighlightPicker
+          pickerRef={pickerRef}
+          colors={HIGHLIGHT_COLORS}
+          onPick={pick}
+        />
+      )}
+    </div>
+  )
+}
+
+// --- Text color (native input) -------------------------------------------
+
+function TextColorTool({ editor }) {
+  const { hasTracker } = useToolbarContext()
+  return (
+    <input
+      type="color"
+      aria-label="Text color"
+      className="toolbar-color-input"
+      onChange={(event) => cmd(editor)?.setColor(event.target.value).run()}
+      disabled={!hasTracker}
+    />
+  )
+}
+
+// --- Alignment ------------------------------------------------------------
+
+function AlignLeftTool({ editor }) {
+  return (
+    <Btn
+      active={editor?.isActive({ textAlign: 'left' })}
+      onActivate={() => cmd(editor)?.setTextAlign('left').run()}
+      title="Align left"
+    >
+      <AlignLeftIcon />
+    </Btn>
+  )
+}
+
+function AlignCenterTool({ editor }) {
+  return (
+    <Btn
+      active={editor?.isActive({ textAlign: 'center' })}
+      onActivate={() => cmd(editor)?.setTextAlign('center').run()}
+      title="Align center"
+    >
+      <AlignCenterIcon />
+    </Btn>
+  )
+}
+
+function AlignRightTool({ editor }) {
+  return (
+    <Btn
+      active={editor?.isActive({ textAlign: 'right' })}
+      onActivate={() => cmd(editor)?.setTextAlign('right').run()}
+      title="Align right"
+    >
+      <AlignRightIcon />
+    </Btn>
+  )
+}
+
+// --- Image (button + hidden file input) ----------------------------------
+
+function ImageTool() {
+  const { onImageUpload } = useToolbarContext()
+  const inputRef = useRef(null)
+  const handleFileChange = (event) => {
+    const file = event.target.files?.[0]
+    if (file) onImageUpload?.(file)
+    event.target.value = ''
+  }
+  return (
+    <>
+      <Btn
+        onActivate={() => inputRef.current?.click()}
+        title="Image"
+        ariaLabel="Insert image"
+      >
+        <ImageIcon />
+      </Btn>
+      <input
+        ref={inputRef}
+        type="file"
+        accept="image/*"
+        onChange={handleFileChange}
+        className="file-input"
+      />
+    </>
+  )
+}
+
+// --- Table (insert picker + row/col/delete + shading) --------------------
+
+function TableTool({ editor }) {
+  const [open, setOpen] = useState(false)
+  const [size, setSize] = useState({ rows: 2, cols: 2 })
+  const wrapRef = useRef(null)
+  const pickerRef = useRef(null)
+  const refs = useMemo(() => [wrapRef, pickerRef], [])
+  useOutsideClick({ isOpen: open, onClose: () => setOpen(false), refs })
+
+  const insert = (rows, cols) => {
+    cmd(editor)?.insertTable({ rows, cols, withHeaderRow: false }).run()
+    setOpen(false)
+  }
+
+  return (
+    <div className="table-picker-wrap" ref={wrapRef}>
+      <Btn
+        onActivate={() => setOpen((prev) => !prev)}
+        title="Table"
+        ariaLabel="Insert table"
+      >
+        <TableIcon />
+      </Btn>
+      {open && (
+        <TablePicker
+          pickerRef={pickerRef}
+          size={size}
+          setSize={setSize}
+          onInsert={insert}
+          onClose={() => setOpen(false)}
+        />
+      )}
+    </div>
+  )
+}
+
+function AddRowTool({ editor }) {
+  return (
+    <Btn
+      onActivate={() => cmd(editor)?.addRowAfter().run()}
+      title="Add row"
+    >
+      <AddRowIcon />
+    </Btn>
+  )
+}
+
+function AddColTool({ editor }) {
+  return (
+    <Btn
+      onActivate={() => cmd(editor)?.addColumnAfter().run()}
+      title="Add column"
+    >
+      <AddColIcon />
+    </Btn>
+  )
+}
+
+function DeleteTableTool({ editor }) {
+  return (
+    <Btn
+      onActivate={() => cmd(editor)?.deleteTable().run()}
+      title="Delete table"
+    >
+      <DeleteTableIcon />
+    </Btn>
+  )
+}
+
+// Shading is conditional: only rendered when the selection is inside a table.
+// Theme palette mirrors the original derived swatches (10 base × 5 brightness).
+const THEME_BASE_COLORS = [
+  '#ffffff', '#000000', '#1f2937', '#1e3a8a', '#2563eb',
+  '#ef4444', '#7f1d1d', '#f97316', '#f59e0b', '#16a34a',
+]
+const STANDARD_SHADING_COLORS = [
+  '#7f1d1d', '#ef4444', '#f97316', '#f59e0b', '#22c55e',
+  '#0f766e', '#3b82f6', '#1e3a8a', '#0f172a', '#7c3aed',
+]
+
+function buildThemeRows() {
+  const lightSteps = [0.2, 0.4, 0.6, 0.8]
+  return [
+    THEME_BASE_COLORS.slice(),
+    ...lightSteps.map((amount) =>
+      THEME_BASE_COLORS.map((base) => {
+        const lower = base.toLowerCase()
+        if (lower === '#ffffff') return mixColors(lower, '#000000', amount)
+        return mixColors(lower, '#ffffff', amount)
+      }),
+    ),
+  ]
+}
+
+function ShadingTool({ editor }) {
+  const inTable = useEditorUIStore((s) => s.inTable)
+  const shadingColor = useEditorUIStore((s) => s.shadingColor)
+  const setShadingColor = useEditorUIStore((s) => s.setShadingColor)
+  const [open, setOpen] = useState(false)
+  const wrapRef = useRef(null)
+  const pickerRef = useRef(null)
+  const customInputRef = useRef(null)
+  const refs = useMemo(() => [wrapRef, pickerRef], [])
+  useOutsideClick({ isOpen: open, onClose: () => setOpen(false), refs })
+
+  const themeRows = useMemo(() => buildThemeRows(), [])
+
+  if (!inTable) return null
+
+  const apply = () => {
+    if (!editor) return
+    cmd(editor)?.setCellAttribute('backgroundColor', shadingColor || null).run()
+  }
+
+  const pick = (color) => {
+    if (!editor) return
+    setShadingColor(color || null)
+    cmd(editor)?.setCellAttribute('backgroundColor', color || null).run()
+    setOpen(false)
+  }
+
+  const handleCustom = (event) => {
+    const color = event.target.value
+    if (!color) return
+    pick(color)
+  }
+
+  return (
+    <div className="shading-control" ref={wrapRef}>
+      <Btn
+        active={Boolean(shadingColor)}
+        onActivate={apply}
+        title="Shading"
+        ariaLabel="Cell shading"
+      >
+        <ShadingIcon />
+      </Btn>
+      <Btn
+        className="toolbar-btn-caret"
+        onActivate={() => setOpen((prev) => !prev)}
+        ariaLabel="Shading colors"
+      >
+        ▾
+      </Btn>
+      {open && (
+        <ShadingPicker
+          pickerRef={pickerRef}
+          themeRows={themeRows}
+          standardColors={STANDARD_SHADING_COLORS}
+          shadingColor={shadingColor}
+          customInputRef={customInputRef}
+          onPick={pick}
+          onOpenCustom={() => customInputRef.current?.click()}
+          onCustomChange={handleCustom}
+        />
+      )}
+    </div>
+  )
+}
+
+// --- History --------------------------------------------------------------
+
+function UndoTool({ editor }) {
+  return (
+    <Btn
+      onActivate={() => cmd(editor)?.undo().run()}
+      title="Undo"
+      testId="toolbar-undo"
+    >
+      <UndoIcon />
+    </Btn>
+  )
+}
+
+function RedoTool({ editor }) {
+  return (
+    <Btn
+      onActivate={() => cmd(editor)?.redo().run()}
+      title="Redo"
+    >
+      <RedoIcon />
+    </Btn>
+  )
+}
+
+// --- Export / Copy --------------------------------------------------------
+
+function ExportTool({ editor }) {
+  const { hasTracker, title } = useToolbarContext()
+  const handleExport = () => {
+    if (!editor || !hasTracker) return
+    const rawTitle = title?.trim() || 'Untitled'
+    const safeTitle = rawTitle.replace(/[\\/:*?"<>|]+/g, '').trim() || 'Untitled'
+    const doc = editor.getJSON()
+    const text = serializeDocForExport(doc, rawTitle)
+    const blob = new Blob([text], { type: 'text/plain;charset=utf-8' })
+    const url = URL.createObjectURL(blob)
+    const link = document.createElement('a')
+    link.href = url
+    link.download = `${safeTitle}.txt`
+    document.body.appendChild(link)
+    link.click()
+    link.remove()
+    URL.revokeObjectURL(url)
+  }
+  return (
+    <Btn onActivate={handleExport} title="Export">
+      <ExportIcon />
+    </Btn>
+  )
+}
+
+function CopyTool({ editor }) {
+  const { hasTracker, title } = useToolbarContext()
+  const copyLabel = useEditorUIStore((s) => s.copyLabel)
+  const setCopyLabel = useEditorUIStore((s) => s.setCopyLabel)
+  const handleCopy = async () => {
+    if (!editor || !hasTracker) return
+    const rawTitle = title?.trim() || 'Untitled'
+    const doc = editor.getJSON()
+    const text = serializeDocForExport(doc, rawTitle)
+    try {
+      await navigator.clipboard.writeText(text)
+      setCopyLabel('Copied!')
+      setTimeout(() => setCopyLabel('Copy'), 2000)
+    } catch {
+      window.alert('Failed to copy to clipboard.')
+    }
+  }
+  return (
+    <Btn onActivate={handleCopy} title={copyLabel} ariaLabel="Copy text">
+      <CopyIcon />
+    </Btn>
+  )
+}
+
+// --- AI group -------------------------------------------------------------
+
+function AiDailyTool() {
+  const { hasTracker, onAiDailyGenerate } = useToolbarContext()
+  const aiLoading = useEditorUIStore((s) => s.aiLoading)
+  const aiInsertLoading = useEditorUIStore((s) => s.aiInsertLoading)
+  const aiDailyDate = useEditorUIStore((s) => s.aiDailyDate)
+  const setAiDailyDate = useEditorUIStore((s) => s.setAiDailyDate)
+  const [open, setOpen] = useState(false)
+  const wrapRef = useRef(null)
+  const pickerRef = useRef(null)
+  const refs = useMemo(() => [wrapRef, pickerRef], [])
+  useOutsideClick({ isOpen: open, onClose: () => setOpen(false), refs })
+
+  const shiftDay = (delta) => {
+    setAiDailyDate((prev) => {
+      const next = new Date(prev)
+      next.setDate(next.getDate() + delta)
+      return next
+    })
+  }
+
+  const onDateChange = (dateString) => {
+    const parsed = new Date(dateString + 'T00:00:00')
+    if (!isNaN(parsed.getTime())) setAiDailyDate(parsed)
+  }
+
+  const disabled = !hasTracker || aiLoading || aiInsertLoading
+
+  return (
+    <div className="ai-daily-control" ref={wrapRef}>
+      <Btn
+        disabled={disabled}
+        className="toolbar-btn-ai"
+        onActivate={onAiDailyGenerate}
+        title={aiLoading ? 'Generating...' : 'AI Daily'}
+        ariaLabel="AI Daily"
+      >
+        <AiIcon />
+        <span className="toolbar-btn-label toolbar-btn-ai-label">
+          {aiLoading ? '...' : 'AI'}
+        </span>
+      </Btn>
+      <Btn
+        disabled={disabled}
+        className="toolbar-btn-caret"
+        onActivate={() => setOpen((prev) => !prev)}
+        ariaLabel="Pick date for AI Daily"
+      >
+        ▾
+      </Btn>
+      {open && (
+        <AiDailyPicker
+          pickerRef={pickerRef}
+          date={aiDailyDate}
+          onPrevDay={() => shiftDay(-1)}
+          onNextDay={() => shiftDay(1)}
+          onDateChange={onDateChange}
+        />
+      )}
+    </div>
+  )
+}
+
+function AiInsertTool() {
+  const { hasTracker, showAiInsert } = useToolbarContext()
+  const aiLoading = useEditorUIStore((s) => s.aiLoading)
+  const aiInsertLoading = useEditorUIStore((s) => s.aiInsertLoading)
+  const setAiInsertOpen = useEditorUIStore((s) => s.setAiInsertOpen)
+  if (!showAiInsert) return null
+  return (
+    <Btn
+      disabled={!hasTracker || aiLoading || aiInsertLoading}
+      className="toolbar-btn-ai"
+      onActivate={() => setAiInsertOpen(true)}
+      title={aiInsertLoading ? 'Inserting...' : 'AI Insert'}
+      ariaLabel="AI Insert"
+    >
+      <AiIcon />
+      <span className="toolbar-btn-label toolbar-btn-ai-label">
+        {aiInsertLoading ? '...' : '⊕'}
+      </span>
+    </Btn>
+  )
+}
+
+// --- Find -----------------------------------------------------------------
+
+function FindTool() {
+  const { openFind } = useToolbarContext()
+  return (
+    <Btn
+      onActivate={openFind}
+      title="Find"
+      ariaLabel="Find in page"
+    >
+      <SearchIcon />
+    </Btn>
+  )
+}
+
+// --- More menu ------------------------------------------------------------
+
+function MoreTool() {
+  const ctx = useToolbarContext()
+  const {
+    hasTracker,
+    toolbarDeepLinkHash,
+    isCurrentPageTracker,
+    trackerPageSaving,
+    onSetTrackerPage,
+    handleSetTrackerFromToolbar,
+    contextMenuItems,
+  } = ctx
+  const inTable = useEditorUIStore((s) => s.inTable)
+  const [open, setOpen] = useState(false)
+  const wrapRef = useRef(null)
+  const refs = useMemo(() => [wrapRef], [])
+  useOutsideClick({ isOpen: open, onClose: () => setOpen(false), refs })
+
+  const onCopyLink = async () => {
+    if (toolbarDeepLinkHash) await navigator.clipboard.writeText(toolbarDeepLinkHash)
+    setOpen(false)
+  }
+
+  const onSetTracker = async () => {
+    await handleSetTrackerFromToolbar()
+    setOpen(false)
+  }
+
+  return (
+    <div className="more-menu-wrap" ref={wrapRef}>
+      <Btn
+        onActivate={() => setOpen((prev) => !prev)}
+        title="More"
+        ariaLabel="More actions"
+      >
+        <MoreIcon />
+      </Btn>
+      {open && (
+        <MoreMenu
+          onClose={() => setOpen(false)}
+          onCopyLink={onCopyLink}
+          copyLinkDisabled={!toolbarDeepLinkHash}
+          onSetTrackerPage={onSetTracker}
+          setTrackerLabel={
+            isCurrentPageTracker
+              ? 'This page is the tracker page'
+              : trackerPageSaving
+              ? 'Setting tracker page...'
+              : 'Set this page as tracker'
+          }
+          setTrackerDisabled={
+            !hasTracker || isCurrentPageTracker || trackerPageSaving || !onSetTrackerPage
+          }
+          inTable={inTable}
+          contextMenuItems={contextMenuItems}
+        />
+      )}
+    </div>
+  )
+}
+
+// --- Registry -------------------------------------------------------------
+
+export const TOOL_DEFINITIONS = {
+  bold:        { Component: BoldTool },
+  italic:      { Component: ItalicTool },
+  underline:   { Component: UnderlineTool },
+  strike:      { Component: StrikeTool },
+  h1:          { Component: H1Tool },
+  h2:          { Component: H2Tool },
+  bulletList:  { Component: BulletListTool },
+  orderedList: { Component: OrderedListTool },
+  taskList:    { Component: TaskListTool },
+  outdent:     { Component: OutdentTool, mobileOnly: true },
+  indent:      { Component: IndentTool, mobileOnly: true },
+  link:        { Component: LinkTool },
+  unlink:      { Component: UnlinkTool },
+  highlight:   { Component: HighlightTool },
+  textColor:   { Component: TextColorTool },
+  alignLeft:   { Component: AlignLeftTool },
+  alignCenter: { Component: AlignCenterTool },
+  alignRight:  { Component: AlignRightTool },
+  image:       { Component: ImageTool },
+  table:       { Component: TableTool },
+  addRow:      { Component: AddRowTool },
+  addCol:      { Component: AddColTool },
+  shading:     { Component: ShadingTool },
+  deleteTable: { Component: DeleteTableTool },
+  undo:        { Component: UndoTool },
+  redo:        { Component: RedoTool },
+  export:      { Component: ExportTool },
+  copy:        { Component: CopyTool },
+  aiDaily:     { Component: AiDailyTool },
+  aiInsert:    { Component: AiInsertTool },
+  find:        { Component: FindTool },
+  more:        { Component: MoreTool },
+}
+
+/**
+ * Groups rendered inside `.toolbar-core` (always visible, even on mobile
+ * collapsed state). Mobile-only tools (indent/outdent) are filtered out on
+ * desktop by the renderer.
+ */
+export const CORE_GROUPS = [
+  { id: 'core-inline', tools: ['bold', 'italic', 'h1', 'bulletList', 'outdent', 'indent'] },
+  { id: 'core-link-undo', tools: ['link', 'undo'] },
+]
+
+/**
+ * Groups rendered inside `.toolbar-extra` (hidden on mobile when collapsed).
+ * Order is verbatim from the legacy Toolbar.jsx render path.
+ */
+export const EXTRA_GROUPS = [
+  { id: 'extra-text', tools: ['underline', 'strike', 'highlight', 'textColor'] },
+  { id: 'extra-headings', tools: ['h2', 'orderedList', 'taskList'] },
+  { id: 'extra-align', tools: ['alignLeft', 'alignCenter', 'alignRight'] },
+  { separator: true, id: 'sep-1' },
+  { id: 'extra-insert', tools: ['unlink', 'image', 'table', 'addRow', 'addCol', 'shading', 'deleteTable'] },
+  { separator: true, id: 'sep-2' },
+  { id: 'extra-utility', tools: ['redo', 'export', 'copy'] },
+  { id: 'extra-ai', tools: ['aiDaily', 'aiInsert'], visible: (ctx) => Boolean(ctx.showAiDaily) },
+  { id: 'extra-find-more', tools: ['find', 'more'] },
+]

--- a/src/components/editor/toolbar/useFindBar.js
+++ b/src/components/editor/toolbar/useFindBar.js
@@ -1,0 +1,119 @@
+import { useCallback, useEffect } from 'react'
+import { findInDocPluginKey } from '../../../extensions/findInDoc'
+import { useEditorUIStore } from '../../../stores/editorUIStore'
+
+/**
+ * Owns the FindBar's wiring:
+ *  1. Registers open/close callbacks on editor.storage.findInDoc so the custom
+ *     extension can trigger the bar (e.g. from a keyboard shortcut).
+ *  2. Syncs find plugin state → store on every transaction.
+ *  3. Exposes the handlers the FindBar UI needs.
+ *
+ * The two ProseMirror reaches (editor.storage.findInDoc and
+ * findInDocPluginKey.getState) are load-bearing; preserve their semantics.
+ */
+export function useFindBar({ editor, hasTracker, controlsDisabled, editorPanelRef, findInputRef }) {
+  const setFindOpen = useEditorUIStore((s) => s.setFindOpen)
+  const setFindQuery = useEditorUIStore((s) => s.setFindQuery)
+  const setFindStatus = useEditorUIStore((s) => s.setFindStatus)
+
+  const openFind = useCallback(() => {
+    if (!editor || !hasTracker) return
+    setFindOpen(true)
+    requestAnimationFrame(() => {
+      findInputRef.current?.focus()
+      findInputRef.current?.select()
+    })
+  }, [editor, hasTracker, setFindOpen, findInputRef])
+
+  const closeFind = useCallback(() => {
+    setFindOpen(false)
+    setFindQuery('')
+    editor?.commands?.clearFind?.()
+    if (!editor || controlsDisabled) return
+    requestAnimationFrame(() => {
+      editor.chain().focus().run()
+    })
+  }, [editor, controlsDisabled, setFindOpen, setFindQuery])
+
+  const handleFindQueryChange = useCallback((value) => {
+    setFindQuery(value)
+    editor?.commands?.setFindQuery?.(value)
+  }, [editor, setFindQuery])
+
+  const scrollMatchIntoView = useCallback(() => {
+    if (!editor) return
+    requestAnimationFrame(() => {
+      const container = editorPanelRef?.current
+      if (!container) return
+      const { view } = editor
+      const { from } = view.state.selection
+      const coords = view.coordsAtPos(from)
+      const containerRect = container.getBoundingClientRect()
+      const toolbarEl = container.querySelector('.toolbar')
+      const bottomPadding = 50
+
+      const isScrollContainer =
+        container.scrollHeight > container.clientHeight &&
+        getComputedStyle(container).overflowY !== 'visible'
+
+      if (isScrollContainer) {
+        const toolbarBottom = toolbarEl ? toolbarEl.getBoundingClientRect().bottom : containerRect.top
+        if (coords.top < toolbarBottom) {
+          container.scrollBy({ top: -(toolbarBottom - coords.top + 20), behavior: 'instant' })
+        } else if (coords.bottom > containerRect.bottom - bottomPadding) {
+          container.scrollBy({ top: coords.bottom - containerRect.bottom + bottomPadding + 20, behavior: 'instant' })
+        }
+      } else {
+        const toolbarBottom = toolbarEl ? toolbarEl.getBoundingClientRect().bottom : 0
+        if (coords.top < toolbarBottom) {
+          window.scrollBy({ top: -(toolbarBottom - coords.top + 20), behavior: 'instant' })
+        } else if (coords.bottom > window.innerHeight - bottomPadding) {
+          window.scrollBy({ top: coords.bottom - window.innerHeight + bottomPadding + 20, behavior: 'instant' })
+        }
+      }
+    })
+  }, [editor, editorPanelRef])
+
+  const handleFindNext = useCallback(() => {
+    editor?.commands?.findNext?.()
+    scrollMatchIntoView()
+  }, [editor, scrollMatchIntoView])
+
+  const handleFindPrev = useCallback(() => {
+    editor?.commands?.findPrev?.()
+    scrollMatchIntoView()
+  }, [editor, scrollMatchIntoView])
+
+  // The findInDoc extension stores open/close callbacks on its storage so the
+  // keyboard-shortcut binding can trigger them; preserved verbatim.
+  useEffect(() => {
+    if (!editor) return undefined
+    const findStorage = editor.storage.findInDoc
+    if (!findStorage) return undefined
+    findStorage.open = openFind
+    findStorage.close = closeFind
+    return () => {
+      if (editor.storage?.findInDoc) {
+        editor.storage.findInDoc.open = null
+        editor.storage.findInDoc.close = null
+      }
+    }
+  }, [editor, openFind, closeFind])
+
+  // Mirror plugin state (matches, index, query) into the store on every txn.
+  useEffect(() => {
+    if (!editor) return undefined
+    const syncFindState = () => {
+      const pluginState = findInDocPluginKey.getState(editor.state)
+      if (!pluginState) return
+      setFindStatus(pluginState)
+      setFindQuery(pluginState.query || '')
+    }
+    syncFindState()
+    editor.on('transaction', syncFindState)
+    return () => editor.off('transaction', syncFindState)
+  }, [editor, setFindStatus, setFindQuery])
+
+  return { openFind, closeFind, handleFindQueryChange, handleFindNext, handleFindPrev }
+}

--- a/src/components/editor/toolbar/useOutsideClick.js
+++ b/src/components/editor/toolbar/useOutsideClick.js
@@ -1,0 +1,35 @@
+import { useEffect } from 'react'
+
+/**
+ * Close a popup when the user clicks outside its anchor button + popup, or
+ * presses Escape. No-op when `isOpen` is false. Each picker owns its own
+ * instance — replaces the toolbar-wide mega-effect that previously juggled
+ * five pickers in one handler.
+ */
+export function useOutsideClick({ isOpen, onClose, refs }) {
+  useEffect(() => {
+    if (!isOpen) return undefined
+
+    const isInsideAnyRef = (target) =>
+      refs.some((ref) => ref.current?.contains(target))
+
+    const handleMouseDown = (event) => {
+      if (isInsideAnyRef(event.target)) return
+      onClose()
+    }
+
+    const handleKeyDown = (event) => {
+      if (event.key === 'Escape') onClose()
+    }
+
+    document.addEventListener('mousedown', handleMouseDown)
+    document.addEventListener('keydown', handleKeyDown)
+    return () => {
+      document.removeEventListener('mousedown', handleMouseDown)
+      document.removeEventListener('keydown', handleKeyDown)
+    }
+    // refs are mutable containers — reading .current at event time is correct;
+    // including them in deps would force re-binding on every parent render.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isOpen, onClose])
+}

--- a/src/utils/listHelpers.js
+++ b/src/utils/listHelpers.js
@@ -30,3 +30,38 @@ export const getListItemTypeAt = (state, pos) => {
   }
   return null
 }
+
+/**
+ * Describe the list item enclosing the current selection for indent/outdent
+ * decisions on mobile. Returns null when the selection is not inside any list.
+ *
+ * Fields:
+ *   - itemTypeName: 'taskItem' or 'listItem' — the chain command to invoke
+ *   - itemDepth:    ProseMirror depth of the listItem/taskItem node
+ *   - listDepth:    depth of the enclosing list (one less than itemDepth)
+ *   - index:        index of this item within its list (0 disallows sink)
+ *   - isNested:     true when the list itself is inside another list item
+ *                   (only nested items can be lifted)
+ */
+export const getListItemInfo = (editor) => {
+  if (!editor) return null
+  const { $from } = editor.state.selection
+  const itemTypeName = editor.isActive('taskList') || editor.isActive('taskItem')
+    ? 'taskItem'
+    : 'listItem'
+  let itemDepth = null
+  for (let depth = $from.depth; depth > 0; depth -= 1) {
+    const node = $from.node(depth)
+    if (node.type?.name === 'listItem' || node.type?.name === 'taskItem') {
+      itemDepth = depth
+      break
+    }
+  }
+  if (!itemDepth) return null
+  const listDepth = itemDepth - 1
+  const index = $from.index(listDepth)
+  const listParentDepth = listDepth - 1
+  const listParent = listParentDepth > 0 ? $from.node(listParentDepth) : null
+  const isNested = listParent?.type?.name === 'listItem' || listParent?.type?.name === 'taskItem'
+  return { itemTypeName, itemDepth, listDepth, index, isNested }
+}


### PR DESCRIPTION
## Summary

Rebuilds `src/components/editor/Toolbar.jsx` from a 1003-line monolith into a data-driven tool registry pattern modeled on Notesnook's editor toolbar. Each button is now a small self-contained component; mobile/desktop differences are config, not code; pickers own their own popup state.

Toolbar's external props are unchanged, so `EditorPanel.jsx` needs no edits and behavior is preserved exactly (every button stays in the same position on desktop and mobile).

## Changes

- **`Toolbar.jsx`: 1003 → 138 lines.** It now reads the store, calls `useFindBar` + `useKeepCursorVisible`, publishes `--toolbar-height`, and renders `CORE_GROUPS` and `EXTRA_GROUPS` via `<ToolbarGroup>` inside a `<ToolbarContext.Provider>`.
- **New `toolbar/tools.jsx`**: declares every tool component (Bold, Italic, Highlight w/ picker, Table w/ picker, AI Daily, More menu, etc.) plus the `TOOL_DEFINITIONS` map and `CORE_GROUPS` / `EXTRA_GROUPS` arrays. Mobile-only tools (indent/outdent) are tagged with `mobileOnly: true`.
- **New `toolbar/ToolbarGroup.jsx`**: dumb renderer that filters `mobileOnly` tools on desktop and skips groups whose `visible(ctx)` returns false (e.g., the AI group when `showAiDaily` is off).
- **New `toolbar/ToolbarContext.js`**: carries the ~11 parent-owned values tools need (image upload, AI handlers, tracker-page state, deep-link hash, etc.) so they don't get threaded as single-use props.
- **New `toolbar/useOutsideClick.js`**: small shared hook used by each picker. Replaces the old 50-line toolbar-wide mega-effect that handled outside-click + Escape for all five pickers in one place.
- **New `toolbar/useFindBar.js`**: extracts the FindBar wiring — `editor.storage.findInDoc` callback registration and the `transaction` → store sync — preserved verbatim (load-bearing).
- **`src/utils/listHelpers.js`**: added `getListItemInfo(editor)`, promoted from inline in the old Toolbar so it lives alongside `getListDepthAt` / `getListItemTypeAt`.
- **Mobile indent/outdent**: the `syncSelectionFromDom` path moves into a local `useIndentOutdent` hook in `tools.jsx`, unchanged in semantics.

## Files Changed

| File | Change |
|---|---|
| `src/components/editor/Toolbar.jsx` | Modified (−865 lines) |
| `src/components/editor/toolbar/tools.jsx` | Added |
| `src/components/editor/toolbar/ToolbarGroup.jsx` | Added |
| `src/components/editor/toolbar/ToolbarContext.js` | Added |
| `src/components/editor/toolbar/useOutsideClick.js` | Added |
| `src/components/editor/toolbar/useFindBar.js` | Added |
| `src/components/editor/toolbar/__tests__/tools.test.js` | Added |
| `src/utils/listHelpers.js` | Modified (+`getListItemInfo`) |

## Testing

- `npm run test:unit` — **190 passing** (4 new registry sanity tests covering: every group's tool IDs resolve to a registered Component, group IDs are unique, `mobileOnly` tools never land in EXTRA_GROUPS, separator entries are well-formed).
- `npm run build` — green.
- `npm run test:e2e` — will run in CI. Manual smoke pending on dev server.

## Test Plan

- [ ] Inline marks: bold / italic / underline / strikethrough toggle and persist
- [ ] Lists: bullet / numbered / task list
- [ ] **Mobile indent / outdent** (uses `syncSelectionFromDom` path — must work via touch)
- [ ] Highlight picker: opens, applies a color, closes on outside-click and Escape
- [ ] Shading picker: appears only when in a table cell; "More Colors..." opens native input
- [ ] Table picker: inserts an NxM table
- [ ] Image upload via hidden file input
- [ ] Link / Unlink prompt
- [ ] Alignment (L / C / R)
- [ ] Undo / Redo
- [ ] **Find**: opens, finds, next/prev, Escape closes, scroll-into-view works
- [ ] Export downloads a .txt; Copy button flashes "Copied!"
- [ ] AI Daily: date picker prev/next, date input, Generate; AI Insert opens modal
- [ ] More menu: Copy Link uses `toolbarDeepLinkHash`; Set Tracker Page calls through
- [ ] Mobile expand / collapse toggle still publishes `--toolbar-height`

## Related Issues

None — direct refactor, no tracking issue.

## Notes

- LOC for the toolbar surface area went from 1003 to ~1289 across the new files (+286). The win is structural: the hotspot file shrank dramatically and each tool is now isolated. Adding a new feature = one entry in `TOOL_DEFINITIONS` + one entry in a group array.
- The two load-bearing ProseMirror reaches (`editor.storage.findInDoc.open/close` and `findInDocPluginKey.getState`) are preserved verbatim, just relocated into `useFindBar`.
- Out of scope (separate follow-ups): `useTrackers.js` (858 lines), `EditorPanel.jsx` (884 lines), `App.jsx` (845 lines), and the constellation of mobile hooks (`useMobileToolbarTransform`, `useKeepCursorVisible`, `useEditorFocusRecovery`, `usePasteAlignFix`, `useContentZoom`).