### PR TITLE
fix: stop the WelcomeScreen flash on launch

### DIFF
--- a/e2e/welcome-flash-on-launch.spec.js
+++ b/e2e/welcome-flash-on-launch.spec.js
@@ -1,0 +1,80 @@
+/**
+ * Regression test for the "Create your first notebook" flash on launch.
+ *
+ * Root cause: the boot splash (and the null render gate) were torn down as soon
+ * as auth resolved, but notebooks had not been fetched yet. For a returning user
+ * that left a brief window — auth done, session present, notebooks still [] —
+ * where the render gate hit `notebooks.length === 0` and rendered WelcomeScreen
+ * before the real editor shell. Fixed by gating boot on a notebooks first-load
+ * flag (`notebooksLoading`) so launch goes splash -> editor with no flash.
+ *
+ * The flash is sub-second, so a retrying assertion can miss it. Instead we
+ * install a MutationObserver before the app boots and record whether the
+ * WelcomeScreen heading ever entered the DOM at all.
+ */
+import { test, expect } from './fixtures'
+import { createNotebook, createPage, createSection, getSupabase } from './test-helpers'
+
+const WELCOME_HEADING = /Create your first notebook/i
+
+test.describe('launch never flashes the welcome screen for a user with notebooks', () => {
+  let notebook, section
+
+  test.beforeAll(async () => {
+    const { client, userId } = await getSupabase()
+    notebook = await createNotebook(client, userId, `Welcome Flash Notebook ${Date.now()}`, -99999)
+    section = await createSection(client, userId, notebook.id, 'Welcome Flash Section', 0)
+    await createPage(
+      client,
+      userId,
+      section.id,
+      'Welcome Flash Page',
+      {
+        type: 'doc',
+        content: [{ type: 'paragraph', content: [{ type: 'text', text: 'WelcomeFlashMarker' }] }],
+      },
+      0,
+    )
+  })
+
+  test('WelcomeScreen heading never appears during a cold launch', async ({ page }) => {
+    // Install the observer before any app code runs so we catch even a 1-frame
+    // render of the empty-account WelcomeScreen.
+    await page.addInitScript(() => {
+      window.__welcomeFlashSeen = false
+      const scan = () => {
+        const headings = document.querySelectorAll('h2')
+        for (const heading of headings) {
+          if (/Create your first notebook/i.test(heading.textContent || '')) {
+            window.__welcomeFlashSeen = true
+            return
+          }
+        }
+      }
+      const startObserving = () => {
+        scan()
+        new MutationObserver(scan).observe(document.documentElement, {
+          childList: true,
+          subtree: true,
+        })
+      }
+      if (document.documentElement) {
+        startObserving()
+      } else {
+        document.addEventListener('DOMContentLoaded', startObserving)
+      }
+    })
+
+    await page.goto('/')
+
+    // The real editor shell renders `.workspace`; WelcomeScreen renders `.welcome`
+    // instead. Waiting on `.workspace` confirms we reached the logged-in shell.
+    await expect(page.locator('.workspace')).toBeVisible({ timeout: 15000 })
+
+    const flashSeen = await page.evaluate(() => window.__welcomeFlashSeen)
+    expect(flashSeen).toBe(false)
+
+    // And the welcome heading is not present now either.
+    await expect(page.getByText(WELCOME_HEADING)).toHaveCount(0)
+  })
+})

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -123,6 +123,7 @@ function App() {
 
   const {
     notebooks,
+    notebooksLoading,
     activeNotebookId,
     setActiveNotebookId,
     activeNotebook,
@@ -134,6 +135,11 @@ function App() {
     renameNotebook,
     deleteNotebook,
   } = useNotebooks(userId)
+
+  // Keep the boot splash up until BOTH auth and the initial notebooks fetch
+  // resolve. Gating on auth alone tore the splash down before notebooks loaded,
+  // briefly flashing the empty-account WelcomeScreen for returning users.
+  const bootLoading = loading || (Boolean(session) && notebooksLoading)
 
   const {
     sections,
@@ -450,10 +456,10 @@ function App() {
   // error boundary and an inline failsafe timeout also remove it, so this is
   // just the primary, happy-path removal.
   useEffect(() => {
-    if ((missingEnv || !loading) && typeof window !== 'undefined' && window.__removeAppSplash) {
+    if ((missingEnv || !bootLoading) && typeof window !== 'undefined' && window.__removeAppSplash) {
       window.__removeAppSplash()
     }
-  }, [missingEnv, loading])
+  }, [missingEnv, bootLoading, session, notebooksLoading])
 
   // On returning to the foreground / regaining network: resubscribe realtime
   // and refetch the active tracker so a change made on another device shows up.
@@ -656,9 +662,11 @@ function App() {
     )
   }
 
-  if (loading) {
+  if (bootLoading) {
     // The branded splash baked into index.html is still covering the screen;
-    // render nothing so there's one continuous loading state, not three.
+    // render nothing so there's one continuous loading state, not three. This
+    // also waits on the initial notebooks fetch so returning users don't flash
+    // the empty-account WelcomeScreen before their trackers load.
     return null
   }
 

--- a/src/hooks/useNotebooks.js
+++ b/src/hooks/useNotebooks.js
@@ -15,6 +15,7 @@ export const useNotebooks = (userId) => {
   // stays up while this is true so a returning user goes splash -> editor
   // without flashing the empty-account WelcomeScreen in between.
   const [notebooksLoading, setNotebooksLoading] = useState(true)
+  const [loadedUserId, setLoadedUserId] = useState(null)
   const loadRequestIdRef = useRef(0)
 
   const loadNotebooks = useCallback(async () => {
@@ -33,11 +34,13 @@ export const useNotebooks = (userId) => {
 
     if (error) {
       setMessage(error.message)
+      setLoadedUserId(userId)
       setNotebooksLoading(false)
       return
     }
 
     setNotebooks(data ?? [])
+    setLoadedUserId(userId)
     setNotebooksLoading(false)
     setActiveNotebookId((prev) => {
       if (prev && data?.some((item) => item.id === prev)) return prev
@@ -52,9 +55,11 @@ export const useNotebooks = (userId) => {
         setNotebooks([])
         setActiveNotebookId(null)
         setMessage('')
+        setLoadedUserId(null)
         setNotebooksLoading(false)
         return
       }
+      setNotebooksLoading(true)
       void loadNotebooks()
     }, 0)
     return () => window.clearTimeout(timer)
@@ -193,7 +198,7 @@ export const useNotebooks = (userId) => {
 
   return {
     notebooks,
-    notebooksLoading,
+    notebooksLoading: Boolean(userId) && (notebooksLoading || loadedUserId !== userId),
     activeNotebookId,
     setActiveNotebookId,
     activeNotebook,

--- a/src/hooks/useNotebooks.js
+++ b/src/hooks/useNotebooks.js
@@ -11,6 +11,10 @@ export const useNotebooks = (userId) => {
   const [notebooks, setNotebooks] = useState([])
   const [activeNotebookId, setActiveNotebookId] = useState(null)
   const [message, setMessage] = useState('')
+  // True until the initial fetch has resolved at least once. The boot splash
+  // stays up while this is true so a returning user goes splash -> editor
+  // without flashing the empty-account WelcomeScreen in between.
+  const [notebooksLoading, setNotebooksLoading] = useState(true)
   const loadRequestIdRef = useRef(0)
 
   const loadNotebooks = useCallback(async () => {
@@ -29,10 +33,12 @@ export const useNotebooks = (userId) => {
 
     if (error) {
       setMessage(error.message)
+      setNotebooksLoading(false)
       return
     }
 
     setNotebooks(data ?? [])
+    setNotebooksLoading(false)
     setActiveNotebookId((prev) => {
       if (prev && data?.some((item) => item.id === prev)) return prev
       return data?.[0]?.id ?? null
@@ -46,6 +52,7 @@ export const useNotebooks = (userId) => {
         setNotebooks([])
         setActiveNotebookId(null)
         setMessage('')
+        setNotebooksLoading(false)
         return
       }
       void loadNotebooks()
@@ -186,6 +193,7 @@ export const useNotebooks = (userId) => {
 
   return {
     notebooks,
+    notebooksLoading,
     activeNotebookId,
     setActiveNotebookId,
     activeNotebook,


### PR DESCRIPTION
## Summary

Returning users saw a brief flash of the empty-account `WelcomeScreen` ("Create your first notebook" under a "Signed in as…" header) before their real tracker UI rendered on launch. This is the last remaining annoyance from the PR #147 launch-UX work. This PR closes the race so launch goes splash → editor with no `WelcomeScreen` in between.

## Root cause

The boot splash (and the `null` render gate) were torn down the instant **auth** resolved, but **notebooks** had not been fetched yet at that moment:

- `useAuth` exposes a `loading` flag; the splash was removed and the gate opened as soon as it flipped to `false`.
- `useNotebooks` had **no loading flag** — `notebooks` starts as `[]` and the fetch is deferred via `setTimeout(…, 0)`.
- So there was a window — auth done, splash gone, session present, `notebooks` still `[]` — where the render gate hit `notebooks.length === 0` and rendered `WelcomeScreen`. A moment later the fetch resolved and the editor shell rendered. That swap was the flash.

## Changes

**`src/hooks/useNotebooks.js`** — first-load flag
- Add `notebooksLoading` state (initialized `true`).
- Flip it to `false` after the query resolves on both the error and success paths (respecting the existing `loadRequestIdRef` guard — superseded requests return and let the latest flip it).
- Flip it to `false` in the signed-out (`!userId`) branch so the flag never strands the gate when there is no user.
- Export `notebooksLoading`.

**`src/App.jsx`** — gate splash + render on notebooks too
- Destructure `notebooksLoading`.
- `const bootLoading = loading || (Boolean(session) && notebooksLoading)`.
- Render gate: `if (loading)` → `if (bootLoading)` so the splash stays up until notebooks are in.
- Splash-removal effect: condition `(missingEnv || !bootLoading)` with `session` + `notebooksLoading` added to deps. `missingEnv` still short-circuits so the missing-env screen stays reachable.

No external contracts change — `useNotebooks` only gains a field.

## Files Changed

| File | Type | Notes |
|---|---|---|
| `src/hooks/useNotebooks.js` | Modified | Add + export `notebooksLoading` first-load flag |
| `src/App.jsx` | Modified | `bootLoading` gate on render + splash-removal effect |
| `e2e/welcome-flash-on-launch.spec.js` | Added | Regression spec — asserts the WelcomeScreen heading never enters the DOM during launch |

## Testing

- `npm run test:unit` → 198 passed (no pure-logic changed; flag lives in the hook).
- `npm run build` → clean.
- ESLint on changed files → no new problems (the pre-existing errors/warnings are unchanged, confirmed via `git stash`).
- New e2e spec installs a `MutationObserver` via `addInitScript` **before** the app boots (a retrying assertion would miss the sub-second flash) and asserts `Create your first notebook` never appears while the `.workspace` shell loads. Full e2e runs in CI per the project's skip-local-tests convention.
- **Manual (recommended):** hard-reload as the logged-in user on throttled network + the Android PWA → splash → editor, no intermediate frame. Empty-account sanity: `WelcomeScreen` still appears cleanly after the splash for a zero-notebook account.

## Hotspot-file checklist (App.jsx)

- **Concern changed:** boot-loading gate now waits on notebooks' first fetch, not just auth.
- **Extracted:** none needed — reused the existing `useNotebooks` contract (only gained a field) plus one local derived boolean; no responsibility sprawl.
- **Regression checks run:** unit tests, build, lint (all above).

## Related Issues

Relates to #147 (follow-up to the branded launch splash work). No tracking issue.