### PR TITLE
[codex] Fix AI Daily date updater crash

### DIFF
--- a/src/stores/__tests__/editorUIStore.test.js
+++ b/src/stores/__tests__/editorUIStore.test.js
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach } from 'vitest'
 import { useEditorUIStore } from '../editorUIStore'
 
 const reset = () => {
-  useEditorUIStore.setState({ toolbarExpanded: false })
+  useEditorUIStore.setState({ toolbarExpanded: false, aiDailyDate: new Date('2026-05-26T00:00:00') })
 }
 
 describe('useEditorUIStore - setToolbarExpanded', () => {
@@ -38,5 +38,27 @@ describe('useEditorUIStore - setToolbarExpanded', () => {
       return prev
     })
     expect(received).toBe(true)
+  })
+})
+
+describe('useEditorUIStore - setAiDailyDate', () => {
+  beforeEach(reset)
+
+  it('accepts a Date value', () => {
+    const next = new Date('2026-05-27T00:00:00')
+    useEditorUIStore.getState().setAiDailyDate(next)
+    expect(useEditorUIStore.getState().aiDailyDate).toBe(next)
+  })
+
+  it('accepts a functional updater without storing the function', () => {
+    useEditorUIStore.getState().setAiDailyDate((prev) => {
+      const next = new Date(prev)
+      next.setDate(next.getDate() + 1)
+      return next
+    })
+
+    const aiDailyDate = useEditorUIStore.getState().aiDailyDate
+    expect(aiDailyDate).toBeInstanceOf(Date)
+    expect(aiDailyDate.toLocaleDateString('en-CA')).toBe('2026-05-27')
   })
 })

--- a/src/stores/editorUIStore.js
+++ b/src/stores/editorUIStore.js
@@ -28,7 +28,9 @@ export const useEditorUIStore = create((set) => ({
   aiLoading: false,
   aiDailyDate: new Date(),
   setAiLoading: (v) => set({ aiLoading: v }),
-  setAiDailyDate: (d) => set({ aiDailyDate: d }),
+  setAiDailyDate: (d) => set((state) => ({
+    aiDailyDate: typeof d === 'function' ? d(state.aiDailyDate) : d,
+  })),
 
   // Selection context (synced from editor selection)
   inTable: false,


### PR DESCRIPTION
## Summary

Fixes an AI Daily toolbar crash where the date picker could store a functional updater as the date value. After using the previous/next date controls, the picker would render with a function instead of a Date and crash on `toLocaleDateString`.

## Changes

- Updated `setAiDailyDate` to support functional updaters, matching the existing `setToolbarExpanded` pattern.
- Added unit coverage for direct Date assignment and functional date updates.

## Validation

- `npm run test:unit -- src/stores/__tests__/editorUIStore.test.js`
- `npm run build`