### PR TITLE
fix: apply remembered color when clicking the main Shading button

### DIFF
--- a/e2e/persist-toolbar-colors.spec.js
+++ b/e2e/persist-toolbar-colors.spec.js
@@ -27,6 +27,8 @@ import {
 
 const HIGHLIGHT_GREEN_RGB = 'rgb(134, 239, 172)'
 const TEXT_BLUE_RGB = 'rgb(37, 99, 235)'
+// First swatch under "Standard Colors" in the shading picker (#7f1d1d).
+const SHADING_MAROON_RGB = 'rgb(127, 29, 29)'
 
 const buildSeedContent = () => ({
   type: 'doc',
@@ -35,6 +37,35 @@ const buildSeedContent = () => ({
       type: 'paragraph',
       attrs: { id: 'p-color-1' },
       content: [{ type: 'text', text: 'Persisted color test line' }],
+    },
+  ],
+})
+
+// A single-row, two-cell table. Cell shading is stored on the cell node's
+// `backgroundColor` attribute and rendered as an inline `background-color` style.
+const buildTableSeedContent = () => ({
+  type: 'doc',
+  content: [
+    {
+      type: 'table',
+      attrs: { id: 'tbl-shading-1' },
+      content: [
+        {
+          type: 'tableRow',
+          content: [
+            {
+              type: 'tableCell',
+              attrs: { colspan: 1, rowspan: 1 },
+              content: [{ type: 'paragraph', content: [{ type: 'text', text: 'Shade me' }] }],
+            },
+            {
+              type: 'tableCell',
+              attrs: { colspan: 1, rowspan: 1 },
+              content: [{ type: 'paragraph', content: [{ type: 'text', text: 'Target cell' }] }],
+            },
+          ],
+        },
+      ],
     },
   ],
 })
@@ -60,6 +91,14 @@ const readSeedColor = (page, tag, prop) =>
     },
     { tag, prop },
   )
+
+// Read the computed background color of the table cell (td/th) containing text.
+const readCellColor = (page, cellText) =>
+  page.evaluate((cellText) => {
+    const cells = Array.from(document.querySelectorAll('.ProseMirror td, .ProseMirror th'))
+    const match = cells.find((c) => (c.textContent ?? '').includes(cellText))
+    return match ? getComputedStyle(match).backgroundColor : null
+  }, cellText)
 
 const pressHighlightShortcut = async (page) => {
   await page.locator('.ProseMirror').dispatchEvent('keydown', {
@@ -100,7 +139,15 @@ test.beforeAll(async () => {
     buildSeedContent(),
     2,
   )
-  seedIds = { notebook, section, highlightPage, shortcutPage, textPage }
+  const shadingPage = await createPage(
+    client,
+    userId,
+    section.id,
+    `${seedLabel} Shading Page`,
+    buildTableSeedContent(),
+    3,
+  )
+  seedIds = { notebook, section, highlightPage, shortcutPage, textPage, shadingPage }
 })
 
 test.afterAll(async () => {
@@ -196,5 +243,45 @@ test('text color picked via caret persists across reload and the main button app
 
   await expect(async () => {
     expect(await readSeedColor(page, 'span', 'color')).toBe(TEXT_BLUE_RGB)
+  }).toPass({ timeout: 5000 })
+})
+
+test('shading color persists across reload and the main button shades a different cell', async ({
+  page,
+  isMobile,
+}) => {
+  test.skip(isMobile, 'Desktop-only: shading caret lives in the collapsed extra group on touch')
+
+  await waitForApp(page, seedHash(seedIds.shadingPage), { expectedText: 'Shade me' })
+  await page.waitForSelector('.ProseMirror[contenteditable="true"]', { timeout: 10000 })
+
+  // Click into the first cell so the in-table shading control renders, then
+  // pick a non-default color (first Standard swatch) via the caret picker.
+  await page.locator('.ProseMirror td', { hasText: 'Shade me' }).first().click()
+  await page.getByRole('button', { name: 'Shading colors' }).click()
+  await page.getByRole('button', { name: 'Standard color 1', exact: true }).click()
+
+  // Reload — the store must rehydrate the persisted shading color.
+  await page.reload()
+  await page.waitForSelector('.ProseMirror[contenteditable="true"]', { timeout: 10000 })
+  await expect(page.locator('.ProseMirror')).toContainText('Target cell')
+
+  // Move the cursor to a *different, unshaded* cell. The remembered color must
+  // survive this (regression: it used to be reset to null by cursor movement
+  // into an unshaded cell, leaving the main button a no-op).
+  await page.locator('.ProseMirror td', { hasText: 'Target cell' }).first().click()
+
+  // The preview underbar still reflects the persisted color.
+  await expect(page.locator('.shading-control .toolbar-color-bar')).toHaveCSS(
+    'background-color',
+    SHADING_MAROON_RGB,
+  )
+
+  // Clicking the main button (not the dropdown) shades the current cell with
+  // the remembered color.
+  await page.getByRole('button', { name: 'Cell shading', exact: true }).click()
+
+  await expect(async () => {
+    expect(await readCellColor(page, 'Target cell')).toBe(SHADING_MAROON_RGB)
   }).toPass({ timeout: 5000 })
 })

--- a/src/components/EditorPanel.jsx
+++ b/src/components/EditorPanel.jsx
@@ -687,9 +687,13 @@ function EditorPanel({
       setCurrentBlockId(blockId)
 
       if (!nextInTable) return
+      // Only update the remembered shading color when the cell actually has a
+      // background. Mirrors the highlight/text-color guards so cursor movement
+      // into an unshaded cell does not clobber the remembered (persisted) color.
       const headerColor = editor.getAttributes('tableHeader')?.backgroundColor
       const cellColor = editor.getAttributes('tableCell')?.backgroundColor
-      setShadingColor(headerColor || cellColor || null)
+      const cellShading = headerColor || cellColor
+      if (cellShading) setShadingColor(cellShading)
     }
     syncEditorState()
     editor.on('selectionUpdate', syncEditorState)

--- a/src/components/editor/toolbar/tools.jsx
+++ b/src/components/editor/toolbar/tools.jsx
@@ -647,6 +647,16 @@ function ShadingTool({ editor }) {
 
   if (!inTable) return null
 
+  // The remembered/persisted color drives the swatch and the main-button apply.
+  // The active (pressed) affordance should reflect the *current* cell's actual
+  // background instead, so the button isn't permanently "pressed" once a color
+  // is remembered. This stays fresh because the toolbar re-renders on every
+  // selection update.
+  const currentCellShading =
+    editor?.getAttributes('tableHeader')?.backgroundColor ||
+    editor?.getAttributes('tableCell')?.backgroundColor ||
+    null
+
   const apply = () => {
     if (!editor) return
     cmd(editor)?.setCellAttribute('backgroundColor', shadingColor || null).run()
@@ -668,7 +678,7 @@ function ShadingTool({ editor }) {
   return (
     <div className="shading-control" ref={wrapRef}>
       <Btn
-        active={Boolean(shadingColor)}
+        active={Boolean(currentCellShading)}
         onActivate={apply}
         title="Shading"
         ariaLabel="Cell shading"


### PR DESCRIPTION
## Summary

PR #152 made the Highlight, Text-color, and cell-Shading toolbar tools into split buttons: a caret opens a color picker, and clicking the **main** button applies the last-picked (remembered, persisted) color directly. This worked for Highlight and Text color, but **not** for Shading — the toolbar swatch showed the remembered color, but clicking the main button did nothing, forcing the user to reopen the dropdown and re-pick the color every time.

## Root cause

All three tools' `apply()` handlers read the remembered color from `editorUIStore`. The difference was in how each color is **synced from the editor selection** in `EditorPanel.jsx`:

- Highlight / Text-color sync: **guarded** — only update the remembered color when the selection actually has the mark, preserving the remembered value in unmarked text.
- Shading sync: **unguarded** — `setShadingColor(headerColor || cellColor || null)`. Whenever the cursor sat in an unshaded cell, this overwrote the remembered color with `null`, so the main-button `apply()` ran `setCellAttribute('backgroundColor', null)` → applied nothing. The dropdown `pick()` still worked because it sets the color explicitly.

## Changes

- **`src/components/EditorPanel.jsx`** — guard the shading sync so the remembered/persisted color only updates when the cell actually has a background, mirroring the highlight/text-color guards.
- **`src/components/editor/toolbar/tools.jsx`** (`ShadingTool`) — now that `shadingColor` is the *remembered* color rather than the current cell's color, derive the button's active (pressed) affordance from the current cell's live background instead, so it isn't permanently "pressed" once a color is remembered. The swatch and `apply()` keep using the remembered color.
- **`e2e/persist-toolbar-colors.spec.js`** — add a desktop-only regression test: pick a shading color in one cell, reload, then click the **main** Shading button in a different *unshaded* cell and assert that cell gets the remembered color.

## Test plan

- [x] `npm run build` passes
- [x] No new lint errors (the two pre-existing `no-unused-vars` errors in `EditorPanel.jsx` exist on `main` and are untouched)
- [ ] CI: new E2E test + existing `persist-toolbar-colors.spec.js` cases
- [ ] Manual (desktop): pick a shading color, click into a different empty cell, click the main Shading button → cell fills with remembered color; reload → still works; Highlight/Text color still apply on direct click; Shading button's pressed state reflects the current cell.

## Note

Shading's persisted default is `null` (Highlight defaults to yellow), so a brand-new profile that has never picked a shading color will still no-op on a direct main-button click until a color is picked once. This is intentionally unchanged to avoid surprising auto-fill.

🤖 Generated with [Claude Code](https://claude.com/claude-code)