### PR TITLE
[codex] Toggle remembered cell shading

### DIFF
--- a/e2e/persist-toolbar-colors.spec.js
+++ b/e2e/persist-toolbar-colors.spec.js
@@ -246,7 +246,7 @@ test('text color picked via caret persists across reload and the main button app
   }).toPass({ timeout: 5000 })
 })
 
-test('shading color persists across reload and the main button shades a different cell', async ({
+test('shading color persists across reload and the main button toggles a different cell', async ({
   page,
   isMobile,
 }) => {
@@ -284,4 +284,17 @@ test('shading color persists across reload and the main button shades a differen
   await expect(async () => {
     expect(await readCellColor(page, 'Target cell')).toBe(SHADING_MAROON_RGB)
   }).toPass({ timeout: 5000 })
+
+  // Clicking the main button again while the current cell is shaded clears it
+  // back to the table's default background without forgetting the swatch color.
+  await page.getByRole('button', { name: 'Cell shading', exact: true }).click()
+
+  await expect(async () => {
+    expect(await readCellColor(page, 'Target cell')).toBe('rgba(0, 0, 0, 0)')
+  }).toPass({ timeout: 5000 })
+
+  await expect(page.locator('.shading-control .toolbar-color-bar')).toHaveCSS(
+    'background-color',
+    SHADING_MAROON_RGB,
+  )
 })

--- a/src/components/editor/toolbar/tools.jsx
+++ b/src/components/editor/toolbar/tools.jsx
@@ -659,7 +659,8 @@ function ShadingTool({ editor }) {
 
   const apply = () => {
     if (!editor) return
-    cmd(editor)?.setCellAttribute('backgroundColor', shadingColor || null).run()
+    const nextColor = currentCellShading ? null : shadingColor || null
+    cmd(editor)?.setCellAttribute('backgroundColor', nextColor).run()
   }
 
   const pick = (color) => {


### PR DESCRIPTION
## Summary

- Make the main Cell shading toolbar button toggle the current cell: apply the remembered swatch color when unshaded, clear shading when already shaded.
- Extend the persisted toolbar color E2E coverage to verify apply, clear, and retained swatch color.

## Root Cause

After the hard reload confirmed the deployed bundle was current, tracing showed the main Shading button was firing normally. Applying the remembered color worked, but clicking the same button on an already shaded cell simply reapplied the same `backgroundColor`, producing no ProseMirror document change and no save. The button needed explicit toggle semantics for shaded cells.

## Validation

- `npx playwright test e2e/persist-toolbar-colors.spec.js`
- Result: 5 passed, 4 skipped