### PR TITLE
fix: sharpen bot date answers, upgrade to Sonnet 4.6, add prompt caching

### DIFF
--- a/src/components/EditorPanel.jsx
+++ b/src/components/EditorPanel.jsx
@@ -148,7 +148,7 @@ function EditorPanel({
     setAiInsertLoading(true)
     try {
       const provider = localStorage.getItem('ai-provider') || 'anthropic'
-      const model = localStorage.getItem('ai-model') || 'claude-sonnet-4-20250514'
+      const model = localStorage.getItem('ai-model') || 'claude-sonnet-4-6'
       const pageText = serializeDocToText(editor.getJSON())
 
       const { data: { session } } = await supabase.auth.getSession()
@@ -221,7 +221,7 @@ function EditorPanel({
     setAiLoading(true)
     try {
       const provider = localStorage.getItem('ai-provider') || 'anthropic'
-      const model = localStorage.getItem('ai-model') || 'claude-sonnet-4-20250514'
+      const model = localStorage.getItem('ai-model') || 'claude-sonnet-4-6'
       const selectedDate = useEditorUIStore.getState().aiDailyDate
       const today = selectedDate.toLocaleDateString('en-CA')
       const dayOfWeek = selectedDate.toLocaleDateString('en-US', { weekday: 'long' })

--- a/src/components/app/NavigationTree.jsx
+++ b/src/components/app/NavigationTree.jsx
@@ -212,7 +212,7 @@ function NavigationTree({
     setPasteRecipeLoading(true)
     try {
       const provider = localStorage.getItem('ai-provider') || 'anthropic'
-      const model = localStorage.getItem('ai-model') || 'claude-sonnet-4-20250514'
+      const model = localStorage.getItem('ai-model') || 'claude-sonnet-4-6'
 
       const {
         data: { session: currentSession },

--- a/supabase/functions/telegram-bot/anthropic.ts
+++ b/supabase/functions/telegram-bot/anthropic.ts
@@ -51,7 +51,16 @@ export async function callClaude({
         'x-api-key': apiKey,
         'anthropic-version': ANTHROPIC_VERSION,
       },
-      body: JSON.stringify({ model, max_tokens: maxTokens, system, tools, messages: working }),
+      // cache_control on the system block caches the stable tools+system prefix
+      // (Anthropic caches everything before the breakpoint). Back-to-back messages
+      // within the cache TTL re-read it at ~10% cost instead of re-billing it.
+      body: JSON.stringify({
+        model,
+        max_tokens: maxTokens,
+        system: [{ type: 'text', text: system, cache_control: { type: 'ephemeral' } }],
+        tools,
+        messages: working,
+      }),
     })
 
     const data = await response.json()

--- a/supabase/functions/telegram-bot/index.ts
+++ b/supabase/functions/telegram-bot/index.ts
@@ -19,7 +19,7 @@ import {
 // --- Constants (tunable) ---
 const IDLE_MINUTES = 30 // continue same conversation if last reply was within this window
 const MAX_TURNS = 12 // recent turns loaded into context (sessions are short by design)
-const MODEL = 'claude-sonnet-4-20250514' // matches the app's default
+const MODEL = 'claude-sonnet-4-6' // matches the app's default
 const TYPING_INTERVAL_MS = 4000 // re-send "typing…" before Telegram's ~5s expiry
 
 // --- Secrets / config ---

--- a/supabase/functions/telegram-bot/prompt.test.ts
+++ b/supabase/functions/telegram-bot/prompt.test.ts
@@ -23,6 +23,17 @@ describe('buildSystemPrompt', () => {
     expect(withLegend).toContain('cell shaded')
   })
 
+  it('includes adaptive-verbosity and date-grouping rules', () => {
+    const base = buildSystemPrompt(false)
+    // Match the user's energy / brevity by default.
+    expect(base).toContain('Match the user')
+    expect(base).toContain('Default to brief')
+    // Date grouping + no vague urgency words.
+    expect(base).toContain('Due today')
+    expect(base).toContain('tomorrow')
+    expect(base).toContain('coming up very soon')
+  })
+
   it('omits the date anchor when no nowDisplay is given', () => {
     expect(buildSystemPrompt(true)).not.toContain('current local date and time')
     expect(buildSystemPrompt(false)).not.toContain('current local date and time')

--- a/supabase/functions/telegram-bot/prompt.ts
+++ b/supabase/functions/telegram-bot/prompt.ts
@@ -5,11 +5,23 @@
 // tracker text correctly.
 
 const BASE_PROMPT = `You are the user's personal life-tracker assistant, chatting over Telegram.
-Be concise and conversational — this is a phone chat, not a document.
+
+Match the user's energy. A quick question gets a quick answer; if they ask you to explain, plan,
+or think something through, go into more depth. Default to brief — no preambles ("Looking at your
+tracker…") and no sign-offs ("Hope that helps!"). Meet them where they are.
+
 Answer only from the tracker data and the current conversation. Never invent items, dates, or facts.
 If something isn't on the tracker, say so plainly.
 
 When a question needs the user's current tracker, call the read_current_tracker tool to fetch it.
+
+Dates and deadlines:
+- "Due today" means the item's date is exactly today. An item dated later is NOT due today — if it
+  falls on the next day call it "tomorrow", otherwise give the actual day or date.
+- When listing what's due, group as Due today / Due tomorrow / Later (with the real date). If nothing
+  is due today, say so plainly, then show what's coming next.
+- Never use vague urgency words like "coming up very soon" or "upcoming". State the actual day, date,
+  or number of days away.
 
 Reply formatting (Telegram-friendly subset only):
 - Short paragraphs, **bold**, simple "- " bullet lists, and \`inline code\`.


### PR DESCRIPTION
## What & why

Iterating on the Telegram tracker bot. When asked "what have I got to do today?" it was:
- labeling **tomorrow's** items as **due today**,
- using vague urgency words ("coming up very soon"),
- padding replies with preamble ("Looking at your tracker…") and sign-offs.

This tightens the system prompt to fix those, and folds in two things we'd been meaning to do: a model bump and prompt caching.

## Changes

- **`prompt.ts`** — system prompt now:
  - groups deadlines as **Due today / Due tomorrow / Later** (with the real date); "due today" means the date *equals* today. Says "nothing's due today" plainly when that's the case.
  - bans vague urgency words — use the actual day/date or days-away.
  - **matches the user's energy**: brief by default (no preamble/sign-off), detailed only when asked to explain or plan.
  - covered by a new unit test in `prompt.test.ts`.
- **Model bump → `claude-sonnet-4-6`** (off the old dated Sonnet 4 snapshot):
  - `telegram-bot/index.ts` `MODEL` constant.
  - frontend fallbacks in `EditorPanel.jsx` and `NavigationTree.jsx` that drive **daily generation** and the other AI features.
- **Prompt caching** (`telegram-bot/anthropic.ts`) — `cache_control` on the system block caches the stable tools+system prefix, cutting cost on back-to-back messages. Silently inactive below Anthropic's cache minimum (no harm).

## Notes

- Frontend model is read from `localStorage('ai-model')` and only uses the new fallback when unset — there's no picker UI, so it's effectively always the fallback.
- Caching gives no benefit to one-off questions spread out or to once-a-day generation; it's a modest win on bot chatting bursts.

## Test plan

- [x] `npm run test:unit` — 244 passing
- [ ] Deploy `telegram-bot` edge function
- [ ] Re-ask "what have I got to do today?" on the live bot and confirm dates/length are right