### PR TITLE
fix: raise grammY webhook timeout so capture flow can finish

### DIFF
--- a/supabase/functions/telegram-bot/index.ts
+++ b/supabase/functions/telegram-bot/index.ts
@@ -175,7 +175,15 @@ bot.on('message:text', async (ctx) => {
 registerCommands(bot.api)
 
 // grammY verifies the secret-token header; mismatches get 401.
-const handleUpdate = webhookCallback(bot, 'std/http', { secretToken: WEBHOOK_SECRET })
+// timeoutMilliseconds: grammY's default is 10s, after which it abandons the
+// handler and the edge worker is torn down mid-flight. The capture flow (a few
+// Claude calls + a headless-Chrome render + photo send) routinely needs longer,
+// so we raise the ceiling well under Telegram's ~60s webhook tolerance and
+// Supabase's wall-clock limit. Slow flows still complete and reply.
+const handleUpdate = webhookCallback(bot, 'std/http', {
+  secretToken: WEBHOOK_SECRET,
+  timeoutMilliseconds: 55_000,
+})
 
 Deno.serve(async (req) => {
   try {


### PR DESCRIPTION
## Problem

Texting the bot *"add buy more gels to running"* showed "typing…" then nothing — no preview, no reply. The DB showed the proposal row was staged but `preview_message_id` was null and no assistant turn was persisted.

## Root cause

grammY's `webhookCallback` defaults to **`timeoutMilliseconds: 10_000`** with `onTimeout: 'throw'`. The capture flow does ~2 Claude calls (read structure → propose) **then** a headless-Chrome render (~6.5s warm, more on Vercel cold start) **then** the photo send — all in one webhook invocation, which crosses 10s. grammY threw at 10s, the outer `Deno.serve` catch returned 200, and the edge worker was torn down mid-render.

Timing from the failed run confirmed it: user message at `:37`, proposal staged at `:46` (~9s of Claude calls), function returned 200 at exactly **10,387 ms**. Phase A's render-only `/preview` finished under 10s, which is why it worked and Phase B didn't.

## Fix

Raise `timeoutMilliseconds` to 55s — comfortably above the worst-case capture flow, under Telegram's ~60s webhook tolerance and Supabase's wall-clock limit. grammY awaits the handler and only responds once it completes, so the worker stays alive through the render + send.

## Verification

- Reproduced the staged proposal's render locally: succeeds in ~6.5s (86 KB doc), confirming the render itself is fine — the failure was purely the webhook timeout.
- Cleared the dangling pending job left by the aborted run.
- Edge function redeployed. Pending live phone test: add → preview → confirm.