### PR TITLE
feat: highlight key dates (cyan) in bot-added tracker items

### DIFF
--- a/supabase/functions/telegram-bot/insertContent.test.ts
+++ b/supabase/functions/telegram-bot/insertContent.test.ts
@@ -84,13 +84,14 @@ describe('buildInlineRuns — cyan date highlighting', () => {
     expect(textOf({ type: 'paragraph', content: runs })).toBe('renew pass 6/15')
   })
 
-  it('highlights the whole phrase span, not just the number ("by EOD 2/8")', () => {
-    const runs = runsForItem('finish report {{date:by EOD 2/8}}')
-    const highlighted = runs.find((r) => r.marks)
-    expect(highlighted).toEqual({ type: 'text', text: 'by EOD 2/8', marks: dateHighlight })
+  it('highlights only the date, leaving qualifier words ("by EOD") plain', () => {
+    // The user highlights the date alone; "by EOD" stays outside the token.
+    const runs = runsForItem('finish report by EOD {{date:2/8}}')
+    expect(runs[0]).toEqual({ type: 'text', text: 'finish report by EOD ' })
+    expect(runs[1]).toEqual({ type: 'text', text: '2/8', marks: dateHighlight })
   })
 
-  it('keeps a time inside the highlighted phrase ("6/16 6:59 PM")', () => {
+  it('keeps a clock time inside the highlighted date ("6/16 6:59 PM")', () => {
     const runs = runsForItem('call w/ Sam {{date:6/16 6:59 PM}}')
     const highlighted = runs.find((r) => r.marks)
     expect(highlighted).toEqual({ type: 'text', text: '6/16 6:59 PM', marks: dateHighlight })

--- a/supabase/functions/telegram-bot/insertContent.test.ts
+++ b/supabase/functions/telegram-bot/insertContent.test.ts
@@ -1,7 +1,18 @@
 import { describe, expect, it } from 'vitest'
 
-import { buildItems, insertRelativeToBlock } from './insertContent.ts'
+import { buildInlineRuns, buildItems, insertRelativeToBlock } from './insertContent.ts'
 import type { TiptapNode } from './insertContent.ts'
+
+const CYAN = '#67e8f9'
+
+// The highlight mark a cyan-highlighted date run should carry.
+const dateHighlight = [{ type: 'highlight', attrs: { color: CYAN } }]
+
+// The first paragraph's inline runs for a single built item.
+function runsForItem(item: string): TiptapNode[] {
+  const para = buildItems('paragraphs', [item])[0]
+  return para.content ?? []
+}
 
 // Find a block by id anywhere in the doc (depth-first).
 function findById(node: TiptapNode, id: string): TiptapNode | null {
@@ -60,6 +71,78 @@ describe('buildItems', () => {
     const nodes = buildItems('paragraphs', ['x', 'y'])
     const ids = nodes.map((n) => n.attrs?.id)
     expect(new Set(ids).size).toBe(2)
+  })
+})
+
+describe('buildInlineRuns — cyan date highlighting', () => {
+  it('splits a {{date:…}} token into a plain run + a cyan-highlighted run', () => {
+    const runs = runsForItem('renew pass {{date:6/15}}')
+    expect(runs).toHaveLength(2)
+    expect(runs[0]).toEqual({ type: 'text', text: 'renew pass ' })
+    expect(runs[1]).toEqual({ type: 'text', text: '6/15', marks: dateHighlight })
+    // Visible text is unchanged (no token, no braces).
+    expect(textOf({ type: 'paragraph', content: runs })).toBe('renew pass 6/15')
+  })
+
+  it('highlights the whole phrase span, not just the number ("by EOD 2/8")', () => {
+    const runs = runsForItem('finish report {{date:by EOD 2/8}}')
+    const highlighted = runs.find((r) => r.marks)
+    expect(highlighted).toEqual({ type: 'text', text: 'by EOD 2/8', marks: dateHighlight })
+  })
+
+  it('keeps a time inside the highlighted phrase ("6/16 6:59 PM")', () => {
+    const runs = runsForItem('call w/ Sam {{date:6/16 6:59 PM}}')
+    const highlighted = runs.find((r) => r.marks)
+    expect(highlighted).toEqual({ type: 'text', text: '6/16 6:59 PM', marks: dateHighlight })
+  })
+
+  it('handles a token at the start of the item', () => {
+    const runs = buildInlineRuns('{{date:3/13}} kickoff')
+    expect(runs).toHaveLength(2)
+    expect(runs[0]).toEqual({ type: 'text', text: '3/13', marks: dateHighlight })
+    expect(runs[1]).toEqual({ type: 'text', text: ' kickoff' })
+  })
+
+  it('handles a token in the middle of the item', () => {
+    const runs = buildInlineRuns('pay rent {{date:6/1}} via portal')
+    expect(runs.map((r) => r.text)).toEqual(['pay rent ', '6/1', ' via portal'])
+    expect(runs[1].marks).toEqual(dateHighlight)
+    expect(runs[0].marks).toBeUndefined()
+    expect(runs[2].marks).toBeUndefined()
+  })
+
+  it('handles a token at the end of the item', () => {
+    const runs = buildInlineRuns('submit taxes {{date:4/15}}')
+    expect(runs[runs.length - 1]).toEqual({ type: 'text', text: '4/15', marks: dateHighlight })
+  })
+
+  it('handles multiple tokens in one item', () => {
+    const runs = buildInlineRuns('trip {{date:6/10}} to {{date:6/14}}')
+    const highlighted = runs.filter((r) => r.marks)
+    expect(highlighted.map((r) => r.text)).toEqual(['6/10', '6/14'])
+    expect(textOf({ type: 'paragraph', content: runs })).toBe('trip 6/10 to 6/14')
+  })
+
+  it('handles an item that is only a token', () => {
+    const runs = buildInlineRuns('{{date:6/15}}')
+    expect(runs).toEqual([{ type: 'text', text: '6/15', marks: dateHighlight }])
+  })
+
+  it('trims whitespace inside the token', () => {
+    const runs = buildInlineRuns('renew {{date:  6/15  }}')
+    expect(runs[1]).toEqual({ type: 'text', text: '6/15', marks: dateHighlight })
+  })
+
+  it('leaves a no-token item as a single plain text node', () => {
+    const runs = runsForItem('buy more gels')
+    expect(runs).toEqual([{ type: 'text', text: 'buy more gels' }])
+  })
+
+  it('still yields content: [] for an empty item', () => {
+    // Blank items are dropped by buildItems' clean step, so build the paragraph
+    // path directly: an all-whitespace token leaves no runs.
+    expect(buildInlineRuns('')).toEqual([])
+    expect(buildInlineRuns('{{date:   }}')).toEqual([])
   })
 })
 

--- a/supabase/functions/telegram-bot/insertContent.ts
+++ b/supabase/functions/telegram-bot/insertContent.ts
@@ -26,12 +26,51 @@ function createNodeId(): string {
 
 const LIST_TYPES = new Set(['bulletList', 'orderedList', 'taskList'])
 
+// The user highlights key dates in this cyan; the app treats a highlighted date
+// as an explicit due date. Mirrors aiInsertHelpers.js `makeHighlightedTextNode`
+// (same mark shape, different color — that one is the yellow review highlight).
+const DATE_HIGHLIGHT_COLOR = '#67e8f9'
+
+// Matches the {{date:…}} sentinel the model wraps a key date phrase in.
+const DATE_TOKEN_RE = /\{\{date:([^}]*)\}\}/g
+
+/**
+ * Split an item string into inline text runs, turning each {{date:…}} token into
+ * a cyan-highlighted run (the phrase inside the token) and leaving the rest plain.
+ * Empty segments are dropped — ProseMirror rejects a text node with text:''.
+ */
+export function buildInlineRuns(text: string): TiptapNode[] {
+  const runs: TiptapNode[] = []
+  let lastIndex = 0
+
+  const pushPlain = (segment: string) => {
+    if (segment) runs.push({ type: 'text', text: segment })
+  }
+
+  for (const match of text.matchAll(DATE_TOKEN_RE)) {
+    const start = match.index ?? 0
+    pushPlain(text.slice(lastIndex, start))
+    const phrase = (match[1] ?? '').trim()
+    if (phrase) {
+      runs.push({
+        type: 'text',
+        text: phrase,
+        marks: [{ type: 'highlight', attrs: { color: DATE_HIGHLIGHT_COLOR } }],
+      })
+    }
+    lastIndex = start + match[0].length
+  }
+  pushPlain(text.slice(lastIndex))
+
+  return runs
+}
+
 function makeParagraph(text: string, createdAt: string): TiptapNode {
   return {
     type: 'paragraph',
     attrs: { id: createNodeId(), created_at: createdAt },
     // A text node with text:'' is invalid in ProseMirror; an empty paragraph is fine.
-    content: text ? [{ type: 'text', text }] : [],
+    content: buildInlineRuns(text),
   }
 }
 

--- a/supabase/functions/telegram-bot/prompt.ts
+++ b/supabase/functions/telegram-bot/prompt.ts
@@ -34,11 +34,12 @@ Adding things to the tracker:
   screenshot of the new item highlighted in place — it does NOT save anything.
 - When an added item has a key date worth flagging — a deadline, event, or time, the way you
   see the user's own dates highlighted as [date]{highlight:#67e8f9} when you read the tracker —
-  wrap that date phrase in a {{date:…}} token inside the item (e.g. "renew pass {{date:6/15}}",
-  "Submit blog post {{date:by EOD 6/15}}", "call w/ Sam {{date:6/16 6:59 PM}}"). It gets
-  highlighted in the user's date color. You can include their usual qualifiers ("by EOD", a time)
-  inside the token, but keep a numeric M/D so it also registers as a due date. Leave incidental or
-  context dates plain — only flag dates that matter. This is not limited to the word "due".
+  wrap ONLY the date itself in a {{date:…}} token. Highlight just the date (a numeric M/D, plus a
+  clock time if there is one) and keep qualifier words like "by", "EOD", or "due" OUTSIDE the
+  token — the user highlights the date alone, not the surrounding words. E.g.
+  "renew pass {{date:6/15}}", "Submit blog post by EOD {{date:6/15}}",
+  "call w/ Sam {{date:6/16 6:59 PM}}". The M/D inside the token also makes it register as a due
+  date. Leave incidental or context dates plain — only flag dates that matter. Not limited to "due".
 - After proposing, keep your reply to one short line asking them to confirm to add it, or
   tell you what to change. Don't restate the items; the screenshot already shows them.
 - If they ask for a change ("put it under Finance instead"), propose again with the new

--- a/supabase/functions/telegram-bot/prompt.ts
+++ b/supabase/functions/telegram-bot/prompt.ts
@@ -32,6 +32,13 @@ Adding things to the tracker:
   read_tracker_structure to see the tracker with {{id:…}} anchors, then call
   propose_tracker_addition with a real targetBlockId. That tool shows the user a preview
   screenshot of the new item highlighted in place — it does NOT save anything.
+- When an added item has a key date worth flagging — a deadline, event, or time, the way you
+  see the user's own dates highlighted as [date]{highlight:#67e8f9} when you read the tracker —
+  wrap that date phrase in a {{date:…}} token inside the item (e.g. "renew pass {{date:6/15}}",
+  "Submit blog post {{date:by EOD 6/15}}", "call w/ Sam {{date:6/16 6:59 PM}}"). It gets
+  highlighted in the user's date color. You can include their usual qualifiers ("by EOD", a time)
+  inside the token, but keep a numeric M/D so it also registers as a due date. Leave incidental or
+  context dates plain — only flag dates that matter. This is not limited to the word "due".
 - After proposing, keep your reply to one short line asking them to confirm to add it, or
   tell you what to change. Don't restate the items; the screenshot already shows them.
 - If they ask for a change ("put it under Finance instead"), propose again with the new

--- a/supabase/functions/telegram-bot/tools.ts
+++ b/supabase/functions/telegram-bot/tools.ts
@@ -114,7 +114,14 @@ export function buildTools(
           items: {
             type: 'array',
             items: { type: 'string' },
-            description: 'Concise plain-text lines to add.',
+            description:
+              'Concise plain-text lines to add. If a line has a key date worth flagging ' +
+              "(a deadline, event, or time — the way the user highlights dates in their tracker), " +
+              'wrap just that date phrase in a {{date:…}} token so it gets highlighted in the ' +
+              'user\'s date color. The phrase is however the user would write it — e.g. ' +
+              '"Submit GRC blog post {{date:by EOD 6/15}}", "call w/ Sam {{date:6/16 6:59 PM}}", ' +
+              '"renew pass {{date:6/15}}". Keep a numeric M/D inside the phrase so it also registers ' +
+              "as a due date. Don't wrap incidental/context dates; leave those plain.",
           },
         },
         required: ['placement', 'format', 'items'],

--- a/supabase/functions/telegram-bot/tools.ts
+++ b/supabase/functions/telegram-bot/tools.ts
@@ -116,12 +116,12 @@ export function buildTools(
             items: { type: 'string' },
             description:
               'Concise plain-text lines to add. If a line has a key date worth flagging ' +
-              "(a deadline, event, or time — the way the user highlights dates in their tracker), " +
-              'wrap just that date phrase in a {{date:…}} token so it gets highlighted in the ' +
-              'user\'s date color. The phrase is however the user would write it — e.g. ' +
-              '"Submit GRC blog post {{date:by EOD 6/15}}", "call w/ Sam {{date:6/16 6:59 PM}}", ' +
-              '"renew pass {{date:6/15}}". Keep a numeric M/D inside the phrase so it also registers ' +
-              "as a due date. Don't wrap incidental/context dates; leave those plain.",
+              "(a deadline, event, or time), wrap ONLY the date itself in a {{date:…}} token so it " +
+              "gets highlighted in the user's date color. Highlight just the date (a numeric M/D, " +
+              'plus a clock time if present) — keep qualifier words like "by", "EOD", or "due" ' +
+              'OUTSIDE the token. E.g. "Submit GRC blog post by EOD {{date:6/15}}", ' +
+              '"call w/ Sam {{date:6/16 6:59 PM}}", "renew pass {{date:6/15}}". The M/D inside the ' +
+              "token also makes it register as a due date. Don't wrap incidental/context dates.",
           },
         },
         required: ['placement', 'format', 'items'],


### PR DESCRIPTION
## What

When the Telegram bot adds an item that has a key date, the AI now flags that date so it's highlighted in **cyan `#67e8f9`** — the user's convention. The app treats a highlighted date as an explicit **due date** (`generate-daily`), so AI-added dates now read consistently and get picked up as due dates.

## How

The model wraps a key date phrase in a neutral sentinel token — `{{date:…}}` — inside the item string whenever it judges the date worth flagging (mirroring how the user highlights dates). `buildInlineRuns` splits that token into a cyan-highlighted text run; plain items are unchanged. The token's inner value is the phrase the user would highlight (`6/15`, `by EOD 2/8`, `6/16 6:59 PM`), not a rigid "due" token — so the highlighted span matches the user's varied style.

### Changes (all in `supabase/functions/telegram-bot/`)
- **`insertContent.ts`** — `DATE_HIGHLIGHT_COLOR` + `buildInlineRuns(text)`; `makeParagraph` routes all three formats (bullet/task/paragraphs) through it.
- **`tools.ts`** — `propose_tracker_addition` `items` description: wrap a key date in `{{date:…}}`, keep a numeric `M/D`, leave incidental dates plain.
- **`prompt.ts`** — "Adding things to the tracker": flag a key date (deadline/event/time) the way it sees `[…]{highlight:#67e8f9}` when reading the tracker; not limited to "due".
- **`insertContent.test.ts`** — 11 new cases (start/mid/end token, multi-token, token-only, phrase span `by EOD 2/8` / `6/16 6:59 PM`, trim, no-token, empty).

No render/Vercel change needed — the preview renderer already supports the highlight mark.

## Test plan
- [x] `npm run test:unit` — 287 passed (276 prior + 11 new)
- [x] Local render smoke: item `"Submit blog post {{date:by EOD 6/15}}"` → PNG shows `by EOD 6/15` in the cyan box, rest plain
- [ ] Deploy `telegram-bot` edge function
- [ ] Phone E2E: add an item with a key date → preview shows cyan highlight → confirm → deep link matches existing date style and reads as a due date; verify a no-date item stays plain and a context date stays plain

🤖 Generated with [Claude Code](https://claude.com/claude-code)