### PR TITLE
feat: name the target section in bot add-to-tracker preview caption

### DIFF
--- a/supabase/functions/telegram-bot/prompt.ts
+++ b/supabase/functions/telegram-bot/prompt.ts
@@ -41,7 +41,9 @@ Adding things to the tracker:
   "call w/ Sam {{date:6/16 6:59 PM}}". The M/D inside the token also makes it register as a due
   date. Leave incidental or context dates plain — only flag dates that matter. Not limited to "due".
 - After proposing, keep your reply to one short line asking them to confirm to add it, or
-  tell you what to change. Don't restate the items; the screenshot already shows them.
+  tell you what to change. Don't restate the items; the screenshot already shows them. The
+  preview's caption already names the target section ("📍 Adding to …"), so don't restate
+  the section either — just confirm or ask what to change.
 - If they ask for a change ("put it under Finance instead"), propose again with the new
   placement. The user's confirmation and the actual save are handled outside this conversation
   — you never need to claim something was saved.

--- a/supabase/functions/telegram-bot/sectionTitle.test.ts
+++ b/supabase/functions/telegram-bot/sectionTitle.test.ts
@@ -1,0 +1,151 @@
+import { describe, expect, it } from 'vitest'
+
+import { findSectionTitle } from './sectionTitle.ts'
+
+type Node = {
+  type?: string
+  text?: string
+  marks?: Array<{ type?: string; attrs?: Record<string, unknown> }>
+  attrs?: Record<string, unknown>
+  content?: Node[]
+}
+
+// --- fixture builders ---
+
+const boldPara = (id: string, text: string): Node => ({
+  type: 'paragraph',
+  attrs: { id },
+  content: [{ type: 'text', text, marks: [{ type: 'bold' }] }],
+})
+
+const para = (id: string, text: string): Node => ({
+  type: 'paragraph',
+  attrs: { id },
+  content: text ? [{ type: 'text', text }] : [],
+})
+
+const heading = (id: string, text: string): Node => ({
+  type: 'heading',
+  attrs: { id, level: 2 },
+  content: [{ type: 'text', text }],
+})
+
+const bulletList = (id: string, itemParas: Node[]): Node => ({
+  type: 'bulletList',
+  attrs: { id },
+  content: itemParas.map((p) => ({ type: 'listItem', content: [p] })),
+})
+
+// A single-column category table: one cell per category, each holding a bold
+// category-name paragraph followed by the bullet list (the user's common layout).
+const singleColumnTable = (cells: Node[]): Node => ({
+  type: 'table',
+  content: cells.map((cell) => ({
+    type: 'tableRow',
+    content: [cell],
+  })),
+})
+
+const cell = (children: Node[]): Node => ({ type: 'tableCell', content: children })
+
+const doc = (content: Node[]): Node => ({ type: 'doc', content })
+
+describe('findSectionTitle', () => {
+  it('returns the bold category when the target is a list item paragraph in the cell', () => {
+    const itemPara = para('item-1', 'buy more gels')
+    const tracker = doc([
+      singleColumnTable([
+        cell([boldPara('cat-1', 'Running'), bulletList('list-1', [itemPara])]),
+        cell([boldPara('cat-2', 'Financial Stuff'), bulletList('list-2', [para('item-2', 'pay rent')])]),
+      ]),
+    ])
+    expect(findSectionTitle(tracker, 'item-1')).toBe('Running')
+    expect(findSectionTitle(tracker, 'item-2')).toBe('Financial Stuff')
+  })
+
+  it('returns the bold category when the target is the list wrapper id (append_to_list)', () => {
+    const tracker = doc([
+      singleColumnTable([
+        cell([boldPara('cat-1', 'Financial Stuff'), bulletList('list-1', [para('item-1', 'pay rent')])]),
+      ]),
+    ])
+    expect(findSectionTitle(tracker, 'list-1')).toBe('Financial Stuff')
+  })
+
+  it('returns the bold category when the target is a plain paragraph after it (after_block)', () => {
+    const tracker = doc([
+      singleColumnTable([
+        cell([boldPara('cat-1', 'Wedding'), para('note-1', 'book venue')]),
+      ]),
+    ])
+    expect(findSectionTitle(tracker, 'note-1')).toBe('Wedding')
+  })
+
+  it('returns the category text when the target IS the bold category paragraph', () => {
+    const tracker = doc([
+      singleColumnTable([
+        cell([boldPara('cat-1', 'Financial Stuff'), bulletList('list-1', [para('item-1', 'pay rent')])]),
+      ]),
+    ])
+    expect(findSectionTitle(tracker, 'cat-1')).toBe('Financial Stuff')
+  })
+
+  it('returns the nearest preceding heading in a heading-organized doc', () => {
+    const tracker = doc([
+      heading('h-1', 'Running'),
+      bulletList('list-1', [para('item-1', 'long run Saturday')]),
+      heading('h-2', 'Finance'),
+      bulletList('list-2', [para('item-2', 'pay rent')]),
+    ])
+    expect(findSectionTitle(tracker, 'item-1')).toBe('Running')
+    expect(findSectionTitle(tracker, 'item-2')).toBe('Finance')
+    expect(findSectionTitle(tracker, 'list-2')).toBe('Finance')
+  })
+
+  it('returns the heading text when the target IS a heading', () => {
+    const tracker = doc([heading('h-1', 'Running'), para('p-1', 'note')])
+    expect(findSectionTitle(tracker, 'h-1')).toBe('Running')
+  })
+
+  it('falls back to the first non-empty paragraph when the cell has no bold line', () => {
+    const tracker = doc([
+      singleColumnTable([
+        cell([para('cat-1', 'Misc Notes'), bulletList('list-1', [para('item-1', 'random thought')])]),
+      ]),
+    ])
+    expect(findSectionTitle(tracker, 'item-1')).toBe('Misc Notes')
+  })
+
+  it('skips a leading empty paragraph for the first-non-empty fallback', () => {
+    const tracker = doc([
+      singleColumnTable([
+        cell([para('blank', ''), para('cat-1', 'Misc Notes'), para('item-1', 'thought')]),
+      ]),
+    ])
+    expect(findSectionTitle(tracker, 'item-1')).toBe('Misc Notes')
+  })
+
+  it('returns null for a missing or unresolvable id', () => {
+    const tracker = doc([
+      singleColumnTable([cell([boldPara('cat-1', 'Running'), para('item-1', 'go run')])]),
+    ])
+    expect(findSectionTitle(tracker, 'does-not-exist')).toBeNull()
+    expect(findSectionTitle(tracker, '')).toBeNull()
+  })
+
+  it('returns null when a heading-less, table-less target has no section', () => {
+    const tracker = doc([para('p-1', 'floating note')])
+    expect(findSectionTitle(tracker, 'p-1')).toBeNull()
+  })
+
+  it('returns clean plain text for categories with markdown-special characters', () => {
+    const tracker = doc([
+      singleColumnTable([
+        cell([boldPara('cat-1', 'Rewards/Credit Cards'), para('item-1', 'redeem points')]),
+        cell([boldPara('cat-2', 'Friends & Family'), para('item-2', 'call mom')]),
+      ]),
+    ])
+    expect(findSectionTitle(tracker, 'item-1')).toBe('Rewards/Credit Cards')
+    expect(findSectionTitle(tracker, 'item-2')).toBe('Friends & Family')
+  })
+})

--- a/supabase/functions/telegram-bot/sectionTitle.ts
+++ b/supabase/functions/telegram-bot/sectionTitle.ts
@@ -1,0 +1,101 @@
+// Pure helper (no Deno / jsr imports) so it can be unit-tested with Vitest like
+// insertContent.ts / trackerText.ts. Resolves which category/section a proposed
+// addition lands in, so the preview photo's caption can name it.
+//
+// The preview screenshot is cropped to the highlighted block + ~160px of context,
+// which often hides the enclosing category title — so we resolve it here, in code,
+// from the pre-insert doc + the anchor the model picked.
+
+type TiptapNode = {
+  type?: string
+  text?: string
+  marks?: Array<{ type?: string; attrs?: Record<string, unknown> }>
+  attrs?: Record<string, unknown>
+  content?: TiptapNode[]
+}
+
+// Concatenate the text of all descendant text nodes — plain, with no markdown.
+// Deliberately NOT serializeInline (trackerText.ts): that injects **/[] markers,
+// which we don't want in a caption that gets bolded separately.
+function plainText(node: TiptapNode): string {
+  if (node.type === 'text') return node.text ?? ''
+  return (node.content ?? []).map(plainText).join('')
+}
+
+// The category title of a table cell: the first paragraph carrying a bold run
+// (the user's category-name convention), else the first non-empty paragraph.
+function boldCategoryOfCell(cell: TiptapNode): string | null {
+  const paras = (cell.content ?? []).filter((c) => c.type === 'paragraph')
+
+  for (const p of paras) {
+    const hasBold = (p.content ?? []).some(
+      (run) => run.type === 'text' && (run.marks ?? []).some((m) => m.type === 'bold'),
+    )
+    if (hasBold) {
+      const text = plainText(p).trim()
+      if (text) return text
+    }
+  }
+
+  for (const p of paras) {
+    const text = plainText(p).trim()
+    if (text) return text
+  }
+
+  return null
+}
+
+/**
+ * Resolve the title of the section/category that the block `targetBlockId` lives
+ * in, for use as the preview caption. Best-effort:
+ *   - target IS a heading        -> its own text
+ *   - target inside a table cell -> the cell's bold category name (or first line)
+ *   - otherwise                  -> the nearest preceding heading (may be null)
+ *
+ * Returns null when the id is missing/unresolvable or nothing names the section.
+ */
+export function findSectionTitle(doc: TiptapNode, targetBlockId: string): string | null {
+  if (!doc || typeof doc !== 'object' || !targetBlockId) return null
+
+  let lastHeading: string | null = null
+  let result: string | null = null
+  let found = false
+
+  const visit = (node: TiptapNode, ancestors: TiptapNode[]): void => {
+    if (found) return
+
+    // Track the most recent heading in document order (headings organize some docs).
+    if (node.type === 'heading') {
+      lastHeading = plainText(node).trim() || lastHeading
+    }
+
+    if (node.attrs?.id === targetBlockId) {
+      found = true
+      if (node.type === 'heading') {
+        result = plainText(node).trim() || null
+        return
+      }
+      // Nearest enclosing table cell -> its category title (the single-column
+      // category table is the common case).
+      for (let i = ancestors.length - 1; i >= 0; i--) {
+        const a = ancestors[i]
+        if (a.type === 'tableCell' || a.type === 'tableHeader') {
+          result = boldCategoryOfCell(a)
+          return
+        }
+      }
+      // Heading-organized doc (no table): the most recent heading.
+      result = lastHeading
+      return
+    }
+
+    const childAncestors = [...ancestors, node]
+    for (const child of node.content ?? []) {
+      visit(child, childAncestors)
+      if (found) return
+    }
+  }
+
+  visit(doc, [])
+  return result
+}

--- a/supabase/functions/telegram-bot/telegram.ts
+++ b/supabase/functions/telegram-bot/telegram.ts
@@ -40,14 +40,36 @@ export async function sendPhoto(
   png: Uint8Array,
   caption?: string,
 ): Promise<number | null> {
-  const form = new FormData()
-  form.append('chat_id', String(chatId))
-  form.append('photo', new Blob([png], { type: 'image/png' }), 'preview.png')
-  if (caption) form.append('caption', caption)
-  const resp = await fetch(`https://api.telegram.org/bot${BOT_TOKEN}/sendPhoto`, {
-    method: 'POST',
-    body: form,
-  })
+  // Build a fresh multipart body each attempt (a FormData/Blob can't be reused).
+  const buildForm = (cap: { text: string; markdown: boolean } | null): FormData => {
+    const form = new FormData()
+    form.append('chat_id', String(chatId))
+    form.append('photo', new Blob([png], { type: 'image/png' }), 'preview.png')
+    if (cap) {
+      if (cap.markdown) {
+        // Same Markdown -> MarkdownV2 path sendReply uses (e.g. **bold** section name).
+        form.append('caption', telegramifyMarkdown(cap.text, 'escape'))
+        form.append('parse_mode', 'MarkdownV2')
+      } else {
+        form.append('caption', cap.text)
+      }
+    }
+    return form
+  }
+
+  const post = (form: FormData) =>
+    fetch(`https://api.telegram.org/bot${BOT_TOKEN}/sendPhoto`, { method: 'POST', body: form })
+
+  let resp = await post(buildForm(caption ? { text: caption, markdown: true } : null))
+
+  // If a formatted caption was rejected, retry once with the caption stripped to
+  // plain text — a formatting edge case should degrade to an unbolded caption,
+  // never drop the preview (which would roll back the staged proposal).
+  if (!resp.ok && caption) {
+    const plain = caption.replace(/\*\*/g, '')
+    resp = await post(buildForm({ text: plain, markdown: false }))
+  }
+
   if (!resp.ok) {
     const detail = await resp.text().catch(() => '')
     throw new Error(`telegram sendPhoto failed (${resp.status}) ${detail}`.trim())

--- a/supabase/functions/telegram-bot/tools.ts
+++ b/supabase/functions/telegram-bot/tools.ts
@@ -15,6 +15,7 @@ import {
   selectCurrentMonthTracker,
 } from './trackerText.ts'
 import { buildItems, insertRelativeToBlock } from './insertContent.ts'
+import { findSectionTitle } from './sectionTitle.ts'
 import type { Format, Placement, TiptapNode } from './insertContent.ts'
 import type { ToolDef } from './anthropic.ts'
 
@@ -206,9 +207,18 @@ export function buildTools(
       return 'Could not stage the proposal. Please try again.'
     }
 
+    // Name the target section in the caption so the user knows where it lands
+    // even though the cropped screenshot may not show the category title.
+    const section = targetBlockId
+      ? findSectionTitle(page.content as TiptapNode, targetBlockId)
+      : null
+    const caption = section
+      ? `📍 Adding to **${section}**`
+      : '📍 Adding to the end of your tracker'
+
     try {
       const png = await capture.renderPreview(doc, insertedBlockIds)
-      const messageId = await capture.sendPhoto(capture.api, capture.chatId, png)
+      const messageId = await capture.sendPhoto(capture.api, capture.chatId, png, caption)
       if (messageId != null) {
         await supabase
           .from('bot_preview_jobs')


### PR DESCRIPTION
## Summary

When the Telegram bot proposes adding an item, the preview screenshot is cropped to the highlighted block + ~160px of context, so it often doesn't show the enclosing category title. This attaches a **caption to the preview photo** naming the target section, with the section title **bolded** (e.g. `📍 Adding to **Financial Stuff**`).

The section is resolved deterministically in code from the pre-insert doc + the model's anchor — not asked of the model.

## Changes (all in `supabase/functions/telegram-bot/`)

- **`sectionTitle.ts`** (new) — pure `findSectionTitle(doc, targetBlockId)`: target-is-heading → own text; target inside a table cell → the cell's bold category name (first-non-empty fallback); otherwise → nearest preceding heading; `null` when unresolvable.
- **`tools.ts`** — resolve the section after a successful insert and pass the caption to `sendPhoto` (`📍 Adding to **X**`, or `📍 Adding to the end of your tracker` when no anchor).
- **`telegram.ts`** — format the caption as MarkdownV2 (same path as `sendReply`), with a plain-text retry so a formatting edge case never drops the preview (which would roll back the staged job).
- **`prompt.ts`** — note the caption already names the section so the reply shouldn't restate it.
- **`sectionTitle.test.ts`** (new) — 11 cases covering the resolution paths.

## Test plan

- [x] `npm run test:unit` — 298 passing (287 existing + 11 new)
- [x] Edge function deployed to Supabase
- [ ] Phone E2E: add to a category → caption names it (bolded); vague add → "end of your tracker"

🤖 Generated with [Claude Code](https://claude.com/claude-code)