### PR TITLE
fix: retry Gemini summary call with backoff in check-scores

### DIFF
--- a/supabase/functions/check-scores/index.ts
+++ b/supabase/functions/check-scores/index.ts
@@ -141,31 +141,50 @@ async function fetchCompletedGames(team: Team): Promise<GameResult[]> {
 
 // --- Gemini AI Summary ---
 
+// Number of times to attempt the Gemini call (original + retries).
+// Gemini occasionally returns a transient 5xx/429 or an empty 200 body,
+// so a couple of retries with a short backoff usually recovers the summary.
+const GEMINI_MAX_ATTEMPTS = 3
+
 async function generateSummary(team: Team, apiKey: string): Promise<string | null> {
   const prompt = GEMINI_PROMPT_TEMPLATE(team.display_name, sportLabel(team))
   const url = `https://generativelanguage.googleapis.com/v1beta/models/${GEMINI_MODEL}:generateContent?key=${apiKey}`
 
-  try {
-    const resp = await fetch(url, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({
-        contents: [{ parts: [{ text: prompt }] }],
-        tools: [{ google_search: {} }],
-      }),
-    })
+  for (let attempt = 1; attempt <= GEMINI_MAX_ATTEMPTS; attempt++) {
+    try {
+      const resp = await fetch(url, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          contents: [{ parts: [{ text: prompt }] }],
+          tools: [{ google_search: {} }],
+        }),
+      })
 
-    if (!resp.ok) {
-      console.error(`Gemini API error for ${team.display_name}: ${resp.status}`)
-      return null
+      if (resp.ok) {
+        const data = await resp.json()
+        const text = data.candidates?.[0]?.content?.parts?.[0]?.text ?? null
+        if (text) return text
+        // 200 but no usable text — transient grounding hiccup, worth retrying
+        console.error(`Gemini empty response for ${team.display_name} (attempt ${attempt}/${GEMINI_MAX_ATTEMPTS})`)
+      } else {
+        console.error(`Gemini API error for ${team.display_name}: ${resp.status} (attempt ${attempt}/${GEMINI_MAX_ATTEMPTS})`)
+        // 4xx (except 429 rate limit) are permanent — don't waste retries on them
+        if (resp.status >= 400 && resp.status < 500 && resp.status !== 429) {
+          return null
+        }
+      }
+    } catch (err) {
+      console.error(`Gemini call failed for ${team.display_name} (attempt ${attempt}/${GEMINI_MAX_ATTEMPTS}):`, err)
     }
 
-    const data = await resp.json()
-    return data.candidates?.[0]?.content?.parts?.[0]?.text ?? null
-  } catch (err) {
-    console.error(`Gemini call failed for ${team.display_name}:`, err)
-    return null
+    // Linear backoff between attempts: 1s, then 2s. Skip the wait after the last attempt.
+    if (attempt < GEMINI_MAX_ATTEMPTS) {
+      await new Promise((resolve) => setTimeout(resolve, 1000 * attempt))
+    }
   }
+
+  return null
 }
 
 // --- Email via Resend ---


### PR DESCRIPTION
## Problem

The sports-score emails occasionally arrived with **no AI summary** — just the score line (e.g. the 2026-06-09 `Nats Win! 4-3 vs Giants` email).

Investigation against the live DB + edge-function logs confirmed it's intermittent and transient: 1 of the last 6 games had `score_history.ai_summary = NULL` while the other 5 had full summaries. The email itself sent fine each time. Root cause is in `generateSummary()` — a single Gemini failure (a transient 5xx/429, or a 200 response with an empty body from the grounding tool) makes it return `null`, and the function falls through to a score-only email by design.

## Fix

Wrap the Gemini call in a retry loop:

- **3 attempts**, **1s → 2s linear backoff** between them.
- Retries cover the transient cases: 5xx, 429, and the 200-but-empty-body grounding hiccup.
- **Permanent 4xx errors** (except 429) bail immediately so retries aren't wasted.
- Error logs now include `(attempt N/3)`.

Behavior is unchanged on success and when all attempts ultimately fail (still sends the score-only email, same as before).

## Notes

- We also investigated upgrading to Gemini 3 for summaries. Ruled out: a real test curl against the prod key showed `gemini-3-flash-preview` returns a consistent `429 RESOURCE_EXHAUSTED` **whenever Google Search grounding is enabled** (free tier doesn't grant 3.x-family grounding quota), while `gemini-2.5-flash` grounding works. Since grounding is the whole point of these summaries, 2.5-flash remains the correct model.

## Test plan

- [x] Confirmed the bug via DB (`ai_summary IS NULL`) + `notification_log` (status `sent`).
- [x] Verified `gemini-2.5-flash` + grounding returns real grounded text on the prod key.
- [ ] Deploy `check-scores` edge function and observe summaries on the next completed game.