### PR TITLE
feat: show strikethrough in collapsed mobile toolbar

### DIFF
--- a/src/components/editor/toolbar/tools.jsx
+++ b/src/components/editor/toolbar/tools.jsx
@@ -995,7 +995,7 @@ export const TOOL_DEFINITIONS = {
  * desktop by the renderer.
  */
 export const CORE_GROUPS = [
-  { id: 'core-inline', tools: ['bold', 'italic', 'h1', 'bulletList', 'outdent', 'indent'] },
+  { id: 'core-inline', tools: ['bold', 'italic', 'strike', 'h1', 'bulletList', 'outdent', 'indent'] },
   { id: 'core-link-undo', tools: ['link', 'undo'] },
 ]
 
@@ -1004,7 +1004,7 @@ export const CORE_GROUPS = [
  * Order is verbatim from the legacy Toolbar.jsx render path.
  */
 export const EXTRA_GROUPS = [
-  { id: 'extra-text', tools: ['underline', 'strike', 'highlight', 'textColor'] },
+  { id: 'extra-text', tools: ['underline', 'highlight', 'textColor'] },
   { id: 'extra-headings', tools: ['h2', 'orderedList', 'taskList'] },
   { id: 'extra-align', tools: ['alignLeft', 'alignCenter', 'alignRight'] },
   { separator: true, id: 'sep-1' },


### PR DESCRIPTION
## Summary

On mobile the editor toolbar has two rows: an always-visible `.toolbar-core` row and a `.toolbar-extra` row that is hidden when the toolbar is collapsed. Strikethrough lived in the extra row, so on a phone it was only reachable after tapping the expand toggle (▾/▴). Since strikethrough is used frequently on mobile (crossing off tracker items), this moves it into the always-visible row.

## Change

`src/components/editor/toolbar/tools.jsx`:
- Move `'strike'` from the `extra-text` group into the `core-inline` group, placed right after `'italic'` so inline-formatting buttons stay grouped.

No other files change — the `StrikeTool` component, its icon, the `toggleLineStrike` command, and the `toolbar-strikethrough` testId all stay the same. `CORE_GROUPS` is never hidden by the `.toolbar-collapsed` CSS rule, so this alone surfaces strikethrough in the collapsed mobile toolbar.

## Effect
- **Mobile:** strikethrough visible in the collapsed (always-on) row; no longer duplicated in the expanded extra row.
- **Desktop:** full toolbar always shown — strikethrough simply moves next to italic.

## Test plan
- [ ] Mobile viewport, toolbar collapsed: strikethrough button visible in the always-on row and toggles strikethrough on selected text.
- [ ] Expanded "extra" row no longer shows a duplicate strikethrough.
- [ ] Desktop renders correctly with strikethrough next to italic.
- [ ] CI: existing `e2e/issue-68-line-strikethrough-toggle.spec.js` passes (uses the unchanged `toolbar-strikethrough` testId and behavioral assertions).