### PR TITLE
feat: AI-assisted "AI Find" semantic search

### DIFF
--- a/e2e/ai-find.spec.js
+++ b/e2e/ai-find.spec.js
@@ -1,0 +1,158 @@
+import { test, expect } from './fixtures'
+import {
+  getSupabase,
+  createNotebook,
+  createSection,
+  createPage,
+  deleteNotebookById,
+  waitForApp,
+} from './test-helpers'
+
+// Self-contained seed: a page with several bullet points whose ids are known,
+// so the route stub can return deterministic matchIds.
+const SEED_CONTENT = {
+  type: 'doc',
+  content: [
+    {
+      type: 'bulletList',
+      attrs: { id: 'aifind-ul' },
+      content: [
+        {
+          type: 'listItem',
+          content: [
+            {
+              type: 'paragraph',
+              attrs: { id: 'aifind-jerry' },
+              content: [{ type: 'text', text: 'Send Jerry a weekly update' }],
+            },
+          ],
+        },
+        {
+          type: 'listItem',
+          content: [
+            {
+              type: 'paragraph',
+              attrs: { id: 'aifind-rent' },
+              content: [{ type: 'text', text: 'Pay rent before the first' }],
+            },
+          ],
+        },
+        {
+          type: 'listItem',
+          content: [
+            {
+              type: 'paragraph',
+              attrs: { id: 'aifind-call' },
+              content: [{ type: 'text', text: 'Call the dentist to reschedule' }],
+            },
+          ],
+        },
+      ],
+    },
+  ],
+}
+
+test.describe('AI Find', () => {
+  let notebookId = null
+  let testPage = null
+
+  test.beforeAll(async () => {
+    const { client, userId } = await getSupabase()
+    const nb = await createNotebook(client, userId, `AIFind Notebook ${Date.now()}`)
+    notebookId = nb.id
+    const sec = await createSection(client, userId, nb.id, 'AIFind Section')
+    testPage = await createPage(client, userId, sec.id, 'AIFind Page', SEED_CONTENT)
+  })
+
+  test.afterAll(async () => {
+    const { client } = await getSupabase()
+    await deleteNotebookById(client, notebookId)
+  })
+
+  // Deterministic stub: the ai-find edge function returns the two "follow up
+  // with people" blocks regardless of the exact query the model would receive.
+  const stubAiFind = async (page, matchIds) => {
+    await page.route('**/functions/v1/ai-find', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ success: true, data: { matchIds } }),
+      })
+    })
+  }
+
+  test('AI toggle is present and on by default', async ({ page }) => {
+    await waitForApp(page, `/#pg=${testPage.id}`, { expectedText: 'Send Jerry a weekly update' })
+
+    await page.keyboard.press('Control+f')
+
+    const toggle = page.getByRole('button', { name: 'AI', exact: true })
+    await expect(toggle).toBeVisible()
+    await expect(toggle).toHaveAttribute('aria-pressed', 'true')
+  })
+
+  test('semantic search highlights matched blocks and cycles with next/prev', async ({ page }) => {
+    await stubAiFind(page, ['aifind-jerry', 'aifind-call'])
+    await waitForApp(page, `/#pg=${testPage.id}`, { expectedText: 'Send Jerry a weekly update' })
+
+    await page.keyboard.press('Control+f')
+    const input = page.locator('.find-input')
+    await expect(input).toBeVisible()
+
+    await input.fill('things I need to follow up on with people')
+
+    // Two blocks should pick up the AI highlight class.
+    await expect(page.locator('.ProseMirror .ai-find-match')).toHaveCount(2, { timeout: 5000 })
+
+    // Counter reflects "1 of 2".
+    await expect(page.locator('.find-count')).toHaveText('1 of 2')
+
+    // First match is the "current" one.
+    const current = page.locator('.ProseMirror .ai-find-match.current')
+    await expect(current).toHaveCount(1)
+    await expect(current).toContainText('Send Jerry a weekly update')
+
+    // Next cycles to the second match.
+    await page.getByRole('button', { name: 'Next' }).click()
+    await expect(page.locator('.find-count')).toHaveText('2 of 2')
+    await expect(page.locator('.ProseMirror .ai-find-match.current')).toContainText(
+      'Call the dentist to reschedule',
+    )
+
+    // Next wraps back to the first.
+    await page.getByRole('button', { name: 'Next' }).click()
+    await expect(page.locator('.find-count')).toHaveText('1 of 2')
+
+    // Prev wraps back to the last.
+    await page.getByRole('button', { name: 'Prev' }).click()
+    await expect(page.locator('.find-count')).toHaveText('2 of 2')
+  })
+
+  test('toggling AI off reverts to literal substring find with zero AI calls', async ({ page }) => {
+    let aiCalls = 0
+    await page.route('**/functions/v1/ai-find', async (route) => {
+      aiCalls += 1
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ success: true, data: { matchIds: ['aifind-jerry'] } }),
+      })
+    })
+
+    await waitForApp(page, `/#pg=${testPage.id}`, { expectedText: 'Pay rent before the first' })
+
+    await page.keyboard.press('Control+f')
+    const toggle = page.getByRole('button', { name: 'AI', exact: true })
+    await toggle.click()
+    await expect(toggle).toHaveAttribute('aria-pressed', 'false')
+
+    // Literal substring search: "rent" matches one block inline.
+    const input = page.locator('.find-input')
+    await input.fill('rent')
+
+    await expect(page.locator('.ProseMirror .find-match')).not.toHaveCount(0, { timeout: 5000 })
+    // No AI block-level highlights while AI is off.
+    await expect(page.locator('.ProseMirror .ai-find-match')).toHaveCount(0)
+    expect(aiCalls).toBe(0)
+  })
+})

--- a/src/components/editor/FindBar.jsx
+++ b/src/components/editor/FindBar.jsx
@@ -2,6 +2,9 @@ function FindBar({
   inputRef,
   findQuery,
   findStatus,
+  aiSearchMode,
+  aiSearchLoading,
+  onToggleAiMode,
   onFindQueryChange,
   onFindPrev,
   onFindNext,
@@ -9,11 +12,20 @@ function FindBar({
 }) {
   return (
     <div className="find-bar">
+      <button
+        type="button"
+        className={`find-ai-toggle${aiSearchMode ? ' active' : ''}`}
+        onClick={onToggleAiMode}
+        aria-pressed={aiSearchMode}
+        title={aiSearchMode ? 'AI find on — searching by meaning' : 'AI find off — exact text only'}
+      >
+        AI
+      </button>
       <input
         ref={inputRef}
         type="text"
         className="find-input"
-        placeholder="Find in tracker"
+        placeholder={aiSearchMode ? 'Describe what to find' : 'Find in tracker'}
         value={findQuery}
         onChange={(event) => onFindQueryChange(event.target.value)}
         onKeyDown={(event) => {
@@ -36,6 +48,9 @@ function FindBar({
           }
         }}
       />
+      {aiSearchMode && aiSearchLoading && (
+        <span className="find-ai-spinner" aria-label="Thinking" title="Thinking…" />
+      )}
       <span className="find-count">
         {findStatus.matches.length > 0 ? findStatus.index + 1 : 0} of {findStatus.matches.length}
       </span>

--- a/src/components/editor/Toolbar.jsx
+++ b/src/components/editor/Toolbar.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef } from 'react'
+import { useCallback, useEffect, useMemo, useRef } from 'react'
 import { useKeepCursorVisible } from '../../hooks/useKeepCursorVisible'
 import { useEditorUIStore } from '../../stores/editorUIStore'
 import FindBar from './FindBar'
@@ -7,6 +7,7 @@ import { ToolbarContext } from './toolbar/ToolbarContext'
 import ToolbarGroup from './toolbar/ToolbarGroup'
 import { CORE_GROUPS, EXTRA_GROUPS } from './toolbar/tools'
 import { useFindBar } from './toolbar/useFindBar'
+import { useAiSearch } from './toolbar/useAiSearch'
 
 function Toolbar({
   editor,
@@ -32,11 +33,50 @@ function Toolbar({
   const findOpen = useEditorUIStore((s) => s.findOpen)
   const findQuery = useEditorUIStore((s) => s.findQuery)
   const findStatus = useEditorUIStore((s) => s.findStatus)
+  const aiSearchMode = useEditorUIStore((s) => s.aiSearchMode)
+  const aiSearchLoading = useEditorUIStore((s) => s.aiSearchLoading)
+  const setAiSearchMode = useEditorUIStore((s) => s.setAiSearchMode)
 
   const findInputRef = useRef(null)
 
   const { openFind, closeFind, handleFindQueryChange, handleFindNext, handleFindPrev } =
     useFindBar({ editor, hasTracker, controlsDisabled, editorPanelRef, findInputRef })
+
+  const { scheduleAiSearch, cancelAiSearch } = useAiSearch({ editor })
+
+  // On query change: always give instant literal feedback (handleFindQueryChange
+  // updates the store + literal highlights). In AI mode, additionally schedule
+  // the debounced semantic search, which replaces the literal matches on settle.
+  const onFindQueryChange = useCallback(
+    (value) => {
+      handleFindQueryChange(value)
+      if (aiSearchMode) {
+        scheduleAiSearch(value)
+      } else {
+        cancelAiSearch()
+      }
+    },
+    [handleFindQueryChange, aiSearchMode, scheduleAiSearch, cancelAiSearch],
+  )
+
+  // Toggling AI mode is one tap. Off = cancel any pending/in-flight request and
+  // immediately revert to literal find for the current query (zero AI calls).
+  const handleToggleAiMode = useCallback(() => {
+    const next = !aiSearchMode
+    setAiSearchMode(next)
+    if (next) {
+      if (findQuery) scheduleAiSearch(findQuery)
+    } else {
+      cancelAiSearch()
+      editor?.commands?.setFindQuery?.(findQuery)
+    }
+  }, [aiSearchMode, setAiSearchMode, findQuery, scheduleAiSearch, cancelAiSearch, editor])
+
+  // Closing the bar must also stop any pending/in-flight AI request.
+  const handleCloseFind = useCallback(() => {
+    cancelAiSearch()
+    closeFind()
+  }, [cancelAiSearch, closeFind])
 
   // Mobile cursor visibility when the toolbar lifts.
   useKeepCursorVisible({ enabled: isTouchOnly, editor, toolbarExpanded, toolbarRef, editorPanelRef })
@@ -124,10 +164,13 @@ function Toolbar({
             inputRef={findInputRef}
             findQuery={findQuery}
             findStatus={findStatus}
-            onFindQueryChange={handleFindQueryChange}
+            aiSearchMode={aiSearchMode}
+            aiSearchLoading={aiSearchLoading}
+            onToggleAiMode={handleToggleAiMode}
+            onFindQueryChange={onFindQueryChange}
             onFindPrev={handleFindPrev}
             onFindNext={handleFindNext}
-            onClose={closeFind}
+            onClose={handleCloseFind}
           />
         )}
       </div>

--- a/src/components/editor/toolbar/tools.jsx
+++ b/src/components/editor/toolbar/tools.jsx
@@ -996,7 +996,7 @@ export const TOOL_DEFINITIONS = {
  */
 export const CORE_GROUPS = [
   { id: 'core-inline', tools: ['bold', 'italic', 'strike', 'h1', 'bulletList', 'outdent', 'indent'] },
-  { id: 'core-link-undo', tools: ['link', 'find', 'undo'] },
+  { id: 'core-find-undo', tools: ['find', 'undo'] },
 ]
 
 /**
@@ -1008,7 +1008,7 @@ export const EXTRA_GROUPS = [
   { id: 'extra-headings', tools: ['h2', 'orderedList', 'taskList'] },
   { id: 'extra-align', tools: ['alignLeft', 'alignCenter', 'alignRight'] },
   { separator: true, id: 'sep-1' },
-  { id: 'extra-insert', tools: ['unlink', 'image', 'table', 'addRow', 'addCol', 'shading', 'deleteTable'] },
+  { id: 'extra-insert', tools: ['link', 'unlink', 'image', 'table', 'addRow', 'addCol', 'shading', 'deleteTable'] },
   { separator: true, id: 'sep-2' },
   { id: 'extra-utility', tools: ['redo', 'export', 'copy'] },
   { id: 'extra-ai', tools: ['aiDaily', 'aiInsert'], visible: (ctx) => Boolean(ctx.showAiDaily) },

--- a/src/components/editor/toolbar/tools.jsx
+++ b/src/components/editor/toolbar/tools.jsx
@@ -996,7 +996,7 @@ export const TOOL_DEFINITIONS = {
  */
 export const CORE_GROUPS = [
   { id: 'core-inline', tools: ['bold', 'italic', 'strike', 'h1', 'bulletList', 'outdent', 'indent'] },
-  { id: 'core-link-undo', tools: ['link', 'undo'] },
+  { id: 'core-link-undo', tools: ['link', 'find', 'undo'] },
 ]
 
 /**
@@ -1012,5 +1012,5 @@ export const EXTRA_GROUPS = [
   { separator: true, id: 'sep-2' },
   { id: 'extra-utility', tools: ['redo', 'export', 'copy'] },
   { id: 'extra-ai', tools: ['aiDaily', 'aiInsert'], visible: (ctx) => Boolean(ctx.showAiDaily) },
-  { id: 'extra-find-more', tools: ['find', 'more'] },
+  { id: 'extra-more', tools: ['more'] },
 ]

--- a/src/components/editor/toolbar/useAiSearch.js
+++ b/src/components/editor/toolbar/useAiSearch.js
@@ -1,0 +1,142 @@
+import { useCallback, useEffect, useRef } from 'react'
+import { supabase } from '../../../lib/supabase'
+import { useEditorUIStore } from '../../../stores/editorUIStore'
+import {
+  extractSearchableBlocks,
+  resolveBlockRanges,
+  buildSearchCacheKey,
+} from '../../../utils/aiSearchHelpers'
+
+const DEBOUNCE_MS = 600
+const MIN_QUERY_LENGTH = 3
+const DEFAULT_MODEL = 'claude-haiku-4-5-20251001'
+
+/**
+ * Owns the latency/cost control for AI find:
+ *  - debounces after typing stops (the literal highlight already gives instant
+ *    feedback, wired separately in the toolbar)
+ *  - requires a minimum query length
+ *  - caches results per (docVersion, query) so re-typing is instant + free
+ *  - cancels stale requests via a monotonic token so out-of-order responses
+ *    never apply
+ *  - validates returned ids against the sent set before highlighting
+ *
+ * Resolves matching block ids into whole-block ranges and feeds them to the
+ * findInDoc plugin via `setAiMatches`, reusing all downstream UI.
+ */
+export function useAiSearch({ editor }) {
+  const setAiSearchLoading = useEditorUIStore((s) => s.setAiSearchLoading)
+
+  const debounceRef = useRef(null)
+  const tokenRef = useRef(0)
+  const cacheRef = useRef(new Map())
+  const docVersionRef = useRef(0)
+
+  // Bump a doc version on every content change so the cache invalidates when
+  // the document is edited (buildSearchCacheKey folds it into the key).
+  useEffect(() => {
+    if (!editor) return undefined
+    const onUpdate = () => {
+      docVersionRef.current += 1
+    }
+    editor.on('update', onUpdate)
+    return () => editor.off('update', onUpdate)
+  }, [editor])
+
+  const applyMatchIds = useCallback(
+    (ids) => {
+      if (!editor) return
+      const ranges = resolveBlockRanges(editor.state.doc, new Set(ids))
+      editor.commands.setAiMatches(ranges)
+    },
+    [editor],
+  )
+
+  const performSearch = useCallback(
+    async (query) => {
+      if (!editor) return
+
+      const cacheKey = buildSearchCacheKey(docVersionRef.current, query)
+      const cached = cacheRef.current.get(cacheKey)
+      if (cached) {
+        applyMatchIds(cached)
+        return
+      }
+
+      const blocks = extractSearchableBlocks(editor.getJSON())
+      if (!blocks.length) {
+        applyMatchIds([])
+        return
+      }
+
+      const myToken = (tokenRef.current += 1)
+      setAiSearchLoading(true)
+      try {
+        const {
+          data: { session },
+        } = await supabase.auth.getSession()
+        if (!session) throw new Error('You must be logged in to use AI Find')
+
+        const provider = localStorage.getItem('ai-provider') || 'anthropic'
+        const model = localStorage.getItem('ai-find-model') || DEFAULT_MODEL
+
+        const { data, error } = await supabase.functions.invoke('ai-find', {
+          body: { query, blocks, provider, model },
+          headers: { Authorization: `Bearer ${session.access_token}` },
+        })
+
+        // Stale response — a newer search superseded this one.
+        if (myToken !== tokenRef.current) return
+        if (error) throw error
+        if (data?.success === false) throw new Error(data?.error || 'AI Find failed')
+
+        const matchIds = Array.isArray(data?.data?.matchIds) ? data.data.matchIds : []
+        // Client-side validation: drop any id we didn't send (hallucinations).
+        const sentIds = new Set(blocks.map((b) => b.id))
+        const validIds = matchIds.map(String).filter((id) => sentIds.has(id))
+
+        cacheRef.current.set(cacheKey, validIds)
+        applyMatchIds(validIds)
+      } catch (err) {
+        if (myToken === tokenRef.current) {
+          console.error('AI Find error:', err)
+        }
+      } finally {
+        if (myToken === tokenRef.current) setAiSearchLoading(false)
+      }
+    },
+    [editor, applyMatchIds, setAiSearchLoading],
+  )
+
+  // Debounced entry point — call on every query change while AI mode is on.
+  const scheduleAiSearch = useCallback(
+    (value) => {
+      if (debounceRef.current) clearTimeout(debounceRef.current)
+      const query = String(value || '').trim()
+      if (query.length < MIN_QUERY_LENGTH) {
+        // Too short to search; the literal highlight (wired separately) stands.
+        setAiSearchLoading(false)
+        return
+      }
+      debounceRef.current = setTimeout(() => {
+        debounceRef.current = null
+        performSearch(query)
+      }, DEBOUNCE_MS)
+    },
+    [performSearch, setAiSearchLoading],
+  )
+
+  // Cancel any pending debounce and invalidate any in-flight request.
+  const cancelAiSearch = useCallback(() => {
+    if (debounceRef.current) {
+      clearTimeout(debounceRef.current)
+      debounceRef.current = null
+    }
+    tokenRef.current += 1 // invalidate in-flight responses
+    setAiSearchLoading(false)
+  }, [setAiSearchLoading])
+
+  useEffect(() => () => cancelAiSearch(), [cancelAiSearch])
+
+  return { scheduleAiSearch, cancelAiSearch }
+}

--- a/src/extensions/findInDoc.js
+++ b/src/extensions/findInDoc.js
@@ -92,6 +92,7 @@ const createEmptyState = () => ({
   query: '',
   matches: [],
   index: -1,
+  mode: 'literal',
 })
 
 const FindInDoc = Extension.create({
@@ -115,6 +116,27 @@ const FindInDoc = Extension.create({
           const index = matches.length > 0 ? 0 : -1
           const nextTr = tr.setMeta(findInDocPluginKey, {
             query: normalized,
+            index,
+          })
+          if (matches.length > 0) {
+            const { from, to } = matches[0]
+            nextTr.setSelection(TextSelection.create(state.doc, from, to)).scrollIntoView()
+          }
+          dispatch(nextTr)
+          return true
+        },
+      // AI find supplies whole-block ranges (resolved from matching block ids)
+      // instead of literal substring ranges. Everything downstream — counter,
+      // next/prev, scroll — reuses the same `matches` array.
+      setAiMatches:
+        (ranges) =>
+        ({ tr, state, dispatch }) => {
+          if (!dispatch) return true
+          const matches = Array.isArray(ranges) ? ranges : []
+          const index = matches.length > 0 ? 0 : -1
+          const nextTr = tr.setMeta(findInDocPluginKey, {
+            aiMatches: matches,
+            mode: 'ai',
             index,
           })
           if (matches.length > 0) {
@@ -204,9 +226,45 @@ const FindInDoc = Extension.create({
             let query = prev.query
             let matches = prev.matches
             let index = prev.index
+            let mode = prev.mode || 'literal'
 
+            // Switching into AI mode: adopt the supplied whole-block ranges and
+            // stop running literal substring matching.
+            if (Array.isArray(meta?.aiMatches)) {
+              mode = 'ai'
+              matches = meta.aiMatches
+              index = matches.length > 0 ? 0 : -1
+              return { query, matches, index, mode }
+            }
+
+            // A literal query always reverts to literal mode.
             if (typeof meta?.query === 'string') {
+              mode = 'literal'
               query = normalizeQuery(meta.query)
+            }
+
+            if (mode === 'ai') {
+              // Keep AI matches; remap their positions across edits so the
+              // block highlights survive document changes.
+              if (tr.docChanged && matches.length) {
+                matches = matches
+                  .map((m) => {
+                    const from = tr.mapping.map(m.from, 1)
+                    const to = tr.mapping.map(m.to, -1)
+                    return to > from ? { from, to } : null
+                  })
+                  .filter(Boolean)
+              }
+              if (!matches.length) {
+                index = -1
+              } else if (typeof meta?.index === 'number') {
+                index = Math.max(0, Math.min(meta.index, matches.length - 1))
+              } else if (index >= matches.length) {
+                index = matches.length - 1
+              } else if (index < 0) {
+                index = 0
+              }
+              return { query, matches, index, mode }
             }
 
             const shouldRecompute = tr.docChanged || typeof meta?.query === 'string'
@@ -224,13 +282,28 @@ const FindInDoc = Extension.create({
               index = matches.length - 1
             }
 
-            return { query, matches, index }
+            return { query, matches, index, mode }
           },
         },
         props: {
           decorations(state) {
             const pluginState = findInDocPluginKey.getState(state)
-            if (!pluginState?.matches?.length || !pluginState?.query) {
+            if (!pluginState?.matches?.length) {
+              return DecorationSet.empty
+            }
+
+            // AI mode: whole-block node decorations using the deep-link look.
+            if (pluginState.mode === 'ai') {
+              const decorations = pluginState.matches.map((match, idx) =>
+                Decoration.node(match.from, match.to, {
+                  class: idx === pluginState.index ? 'ai-find-match current' : 'ai-find-match',
+                }),
+              )
+              return DecorationSet.create(state.doc, decorations)
+            }
+
+            // Literal mode: inline substring decorations (unchanged).
+            if (!pluginState.query) {
               return DecorationSet.empty
             }
             const decorations = pluginState.matches.map((match, idx) =>

--- a/src/stores/editorUIStore.js
+++ b/src/stores/editorUIStore.js
@@ -22,6 +22,13 @@ export const useEditorUIStore = create((set, get) => ({
   setFindQuery: (q) => set({ findQuery: q }),
   setFindStatus: (s) => set({ findStatus: s }),
 
+  // AI Find — semantic mode layered over the literal find bar. Defaults on and
+  // persists for the session so the user isn't re-opting-out each time.
+  aiSearchMode: true,
+  aiSearchLoading: false,
+  setAiSearchMode: (v) => set({ aiSearchMode: v }),
+  setAiSearchLoading: (v) => set({ aiSearchLoading: v }),
+
   // AI Insert modal
   aiInsertOpen: false,
   aiInsertLoading: false,
@@ -85,6 +92,7 @@ export const useEditorUIStore = create((set, get) => ({
     findOpen: false,
     findQuery: '',
     findStatus: { query: '', matches: [], index: -1 },
+    aiSearchLoading: false,
     aiInsertOpen: false,
     aiInsertText: '',
     contextMenu: { open: false, x: 0, y: 0, blockId: null, inTable: false },

--- a/src/styles/editor.css
+++ b/src/styles/editor.css
@@ -168,6 +168,20 @@
   border-radius: 8px;
 }
 
+/* AI find matches reuse the deep-link palette as whole-block highlights. The
+   current match is slightly stronger so the cycled-to block stands out. */
+.editor-shell .ProseMirror .ai-find-match {
+  background: rgba(250, 204, 21, 0.18);
+  outline: 2px solid rgba(245, 158, 11, 0.55);
+  outline-offset: 2px;
+  border-radius: 8px;
+}
+
+.editor-shell .ProseMirror .ai-find-match.current {
+  background: rgba(250, 204, 21, 0.28);
+  outline: 2px solid rgba(245, 158, 11, 0.95);
+}
+
 .editor-shell th,
 .editor-shell td {
   border: 1px solid var(--table-border);

--- a/src/styles/responsive.css
+++ b/src/styles/responsive.css
@@ -142,6 +142,20 @@
     top: auto;
     bottom: calc(100% + 4px);
   }
+
+  /* On narrow phones the find bar's controls won't fit on one row. Let the
+     search field take a full row (order:-1 puts it above the AI toggle) and
+     wrap the remaining controls onto a second row, so every button stays
+     inside the fixed toolbar's width and remains tappable. */
+  .find-input {
+    flex-basis: 100%;
+    min-width: 0;
+    order: -1;
+  }
+
+  .find-count {
+    flex: 1;
+  }
 }
 
 @media (max-width: 600px) {

--- a/src/styles/toolbar.css
+++ b/src/styles/toolbar.css
@@ -187,6 +187,60 @@
   text-align: right;
 }
 
+/* AI find toggle — a small pill, on by default. Active = teal accent. */
+.find-ai-toggle {
+  flex: 0 0 auto;
+  font-size: 0.7rem;
+  font-weight: 600;
+  letter-spacing: 0.03em;
+  padding: 0.2rem 0.5rem;
+  border-radius: 999px;
+  border: 1px solid var(--border-strong);
+  background: var(--surface);
+  color: var(--text-secondary);
+  cursor: pointer;
+  transition: background 150ms ease, color 150ms ease, border-color 150ms ease;
+}
+
+.find-ai-toggle:hover {
+  border-color: var(--accent);
+  color: var(--accent-dark);
+}
+
+.find-ai-toggle.active {
+  background: var(--accent);
+  border-color: var(--accent);
+  color: #fff;
+}
+
+.find-ai-toggle:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 1px;
+}
+
+/* Subtle "thinking" spinner shown while an AI find request is in flight. */
+.find-ai-spinner {
+  flex: 0 0 auto;
+  width: 0.8rem;
+  height: 0.8rem;
+  border-radius: 50%;
+  border: 2px solid var(--accent-subtle);
+  border-top-color: var(--accent);
+  animation: find-ai-spin 0.6s linear infinite;
+}
+
+@keyframes find-ai-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .find-ai-spinner {
+    animation-duration: 1.4s;
+  }
+}
+
 .highlight-control,
 .text-color-control {
   position: relative;

--- a/src/styles/toolbar.css
+++ b/src/styles/toolbar.css
@@ -38,7 +38,8 @@
   pointer-events: none;
 }
 
-.toolbar-collapsed:not(.disabled) .toolbar-core {
+.toolbar-collapsed:not(.disabled) .toolbar-core,
+.toolbar-collapsed:not(.disabled) .find-bar {
   pointer-events: auto;
 }
 
@@ -162,7 +163,9 @@
 .find-bar {
   display: flex;
   align-items: center;
+  flex-wrap: wrap;
   gap: 0.4rem;
+  row-gap: 0.4rem;
   padding: 0.35rem 0.5rem;
   border: 1px solid var(--border);
   border-radius: 8px;

--- a/src/utils/__tests__/aiSearchHelpers.test.js
+++ b/src/utils/__tests__/aiSearchHelpers.test.js
@@ -1,0 +1,232 @@
+import { describe, it, expect } from 'vitest'
+import { Schema } from '@tiptap/pm/model'
+import {
+  extractSearchableBlocks,
+  resolveBlockRanges,
+  buildSearchCacheKey,
+} from '../aiSearchHelpers'
+
+// --- extractSearchableBlocks (plain JSON) --------------------------------
+
+describe('extractSearchableBlocks', () => {
+  it('returns one {id,text} per text-bearing block', () => {
+    const docJson = {
+      type: 'doc',
+      content: [
+        {
+          type: 'heading',
+          attrs: { id: 'h1', level: 1 },
+          content: [{ type: 'text', text: 'Running' }],
+        },
+        {
+          type: 'paragraph',
+          attrs: { id: 'p1' },
+          content: [{ type: 'text', text: 'Long run Saturday' }],
+        },
+      ],
+    }
+    expect(extractSearchableBlocks(docJson)).toEqual([
+      { id: 'h1', text: 'Running' },
+      { id: 'p1', text: 'Long run Saturday' },
+    ])
+  })
+
+  it('collects paragraphs nested inside list items', () => {
+    const docJson = {
+      type: 'doc',
+      content: [
+        {
+          type: 'bulletList',
+          attrs: { id: 'ul1' },
+          content: [
+            {
+              type: 'listItem',
+              content: [
+                {
+                  type: 'paragraph',
+                  attrs: { id: 'li-p1' },
+                  content: [{ type: 'text', text: 'Send Jerry a weekly update' }],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    }
+    expect(extractSearchableBlocks(docJson)).toEqual([
+      { id: 'li-p1', text: 'Send Jerry a weekly update' },
+    ])
+  })
+
+  it('collects paragraphs inside table cells', () => {
+    const docJson = {
+      type: 'doc',
+      content: [
+        {
+          type: 'table',
+          attrs: { id: 't1' },
+          content: [
+            {
+              type: 'tableRow',
+              content: [
+                {
+                  type: 'tableCell',
+                  content: [
+                    {
+                      type: 'paragraph',
+                      attrs: { id: 'cell-p1' },
+                      content: [{ type: 'text', text: 'Pay rent' }],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    }
+    expect(extractSearchableBlocks(docJson)).toEqual([
+      { id: 'cell-p1', text: 'Pay rent' },
+    ])
+  })
+
+  it('joins multiple inline text nodes (marks) into one block', () => {
+    const docJson = {
+      type: 'doc',
+      content: [
+        {
+          type: 'paragraph',
+          attrs: { id: 'p1' },
+          content: [
+            { type: 'text', text: 'Call ' },
+            { type: 'text', marks: [{ type: 'bold' }], text: 'Dr. Smith' },
+            { type: 'text', text: ' tomorrow' },
+          ],
+        },
+      ],
+    }
+    expect(extractSearchableBlocks(docJson)).toEqual([
+      { id: 'p1', text: 'Call Dr. Smith tomorrow' },
+    ])
+  })
+
+  it('skips empty/whitespace blocks and blocks without an id', () => {
+    const docJson = {
+      type: 'doc',
+      content: [
+        { type: 'paragraph', attrs: { id: 'p1' }, content: [{ type: 'text', text: '   ' }] },
+        { type: 'paragraph', content: [{ type: 'text', text: 'no id here' }] },
+        { type: 'paragraph', attrs: { id: 'p2' } },
+        { type: 'paragraph', attrs: { id: 'p3' }, content: [{ type: 'text', text: 'kept' }] },
+      ],
+    }
+    expect(extractSearchableBlocks(docJson)).toEqual([{ id: 'p3', text: 'kept' }])
+  })
+
+  it('does not emit the same id twice', () => {
+    const docJson = {
+      type: 'doc',
+      content: [
+        { type: 'paragraph', attrs: { id: 'dup' }, content: [{ type: 'text', text: 'first' }] },
+        { type: 'paragraph', attrs: { id: 'dup' }, content: [{ type: 'text', text: 'second' }] },
+      ],
+    }
+    expect(extractSearchableBlocks(docJson)).toEqual([{ id: 'dup', text: 'first' }])
+  })
+
+  it('returns [] for empty or malformed input', () => {
+    expect(extractSearchableBlocks(null)).toEqual([])
+    expect(extractSearchableBlocks({})).toEqual([])
+    expect(extractSearchableBlocks({ type: 'doc' })).toEqual([])
+  })
+})
+
+// --- resolveBlockRanges (real ProseMirror doc) ---------------------------
+
+const schema = new Schema({
+  nodes: {
+    doc: { content: 'block+' },
+    paragraph: {
+      group: 'block',
+      content: 'inline*',
+      attrs: { id: { default: null } },
+    },
+    heading: {
+      group: 'block',
+      content: 'inline*',
+      attrs: { id: { default: null }, level: { default: 1 } },
+    },
+    text: { group: 'inline' },
+    bulletList: {
+      group: 'block',
+      content: 'listItem+',
+      attrs: { id: { default: null } },
+    },
+    listItem: { content: 'block+', defining: true },
+  },
+})
+
+const { doc, paragraph, heading, bulletList, listItem } = schema.nodes
+const p = (id, txt) => paragraph.create({ id }, txt ? schema.text(txt) : null)
+
+describe('resolveBlockRanges', () => {
+  it('returns whole-node ranges for matching ids, sorted by from', () => {
+    const d = doc.create(null, [
+      p('a', 'first'),
+      p('b', 'second'),
+      p('c', 'third'),
+    ])
+    const ranges = resolveBlockRanges(d, new Set(['a', 'c']))
+    expect(ranges).toHaveLength(2)
+    // Each range covers the full node: to === from + nodeSize.
+    d.descendants((node, pos) => {
+      if (node.attrs?.id === 'a') {
+        expect(ranges[0]).toEqual({ from: pos, to: pos + node.nodeSize })
+      }
+      if (node.attrs?.id === 'c') {
+        expect(ranges[1]).toEqual({ from: pos, to: pos + node.nodeSize })
+      }
+    })
+    // sorted
+    expect(ranges[0].from).toBeLessThan(ranges[1].from)
+  })
+
+  it('accepts an array of ids', () => {
+    const d = doc.create(null, [p('a', 'x'), p('b', 'y')])
+    expect(resolveBlockRanges(d, ['b'])).toHaveLength(1)
+  })
+
+  it('resolves nested list paragraph ids and a heading', () => {
+    const d = doc.create(null, [
+      heading.create({ id: 'h', level: 1 }, schema.text('Title')),
+      bulletList.create({ id: 'ul' }, [listItem.create(null, [p('li-p', 'bullet text')])]),
+    ])
+    const ranges = resolveBlockRanges(d, new Set(['li-p']))
+    expect(ranges).toHaveLength(1)
+    const node = d.nodeAt(ranges[0].from)
+    expect(node?.attrs?.id).toBe('li-p')
+  })
+
+  it('returns [] when no ids match or set is empty', () => {
+    const d = doc.create(null, [p('a', 'x')])
+    expect(resolveBlockRanges(d, new Set(['zzz']))).toEqual([])
+    expect(resolveBlockRanges(d, new Set())).toEqual([])
+    expect(resolveBlockRanges(null, new Set(['a']))).toEqual([])
+  })
+})
+
+// --- buildSearchCacheKey -------------------------------------------------
+
+describe('buildSearchCacheKey', () => {
+  it('combines version and normalized query', () => {
+    expect(buildSearchCacheKey(5, 'Find Me')).toBe('5::find me')
+  })
+
+  it('normalizes whitespace and case so re-typing is a cache hit', () => {
+    expect(buildSearchCacheKey('v1', '  Follow Up  ')).toBe(buildSearchCacheKey('v1', 'follow up'))
+  })
+
+  it('different versions produce different keys', () => {
+    expect(buildSearchCacheKey(1, 'q')).not.toBe(buildSearchCacheKey(2, 'q'))
+  })
+})

--- a/src/utils/aiSearchHelpers.js
+++ b/src/utils/aiSearchHelpers.js
@@ -1,0 +1,95 @@
+// Pure helpers for AI-assisted "find". These take plain Tiptap JSON or a real
+// ProseMirror doc and return plain data — no DOM, no editor view — so they're
+// unit-testable with Vitest. See src/utils/__tests__/aiSearchHelpers.test.js.
+
+// Block-level node types that carry their own stable `attrs.id` (set by the
+// EnsureNodeIds extension) and hold user-visible text we want to search over.
+const TEXT_BEARING_TYPES = new Set(['paragraph', 'heading'])
+
+/**
+ * Collect the visible text of a single Tiptap JSON node (recursively).
+ * @param {object} node
+ * @returns {string}
+ */
+function collectNodeText(node) {
+  if (!node || typeof node !== 'object') return ''
+  if (node.type === 'text') return typeof node.text === 'string' ? node.text : ''
+  if (!Array.isArray(node.content)) return ''
+  return node.content.map(collectNodeText).join('')
+}
+
+/**
+ * Walk Tiptap JSON and return one `{ id, text }` entry per text-bearing block
+ * (paragraphs/headings, including those nested inside list items and table
+ * cells). Blocks without an id or with only whitespace are skipped.
+ *
+ * @param {object} docJson - Tiptap document JSON (editor.getJSON()).
+ * @returns {{ id: string, text: string }[]}
+ */
+export function extractSearchableBlocks(docJson) {
+  const blocks = []
+  const seen = new Set()
+
+  const walk = (node) => {
+    if (!node || typeof node !== 'object') return
+
+    if (TEXT_BEARING_TYPES.has(node.type)) {
+      const id = node.attrs?.id
+      const text = collectNodeText(node).trim()
+      if (id && text && !seen.has(id)) {
+        seen.add(id)
+        blocks.push({ id, text })
+      }
+      // Paragraphs/headings only hold inline content, so no need to recurse
+      // for more blocks — but cells/list items are handled by the branch below.
+      return
+    }
+
+    if (Array.isArray(node.content)) {
+      node.content.forEach(walk)
+    }
+  }
+
+  walk(docJson)
+  return blocks
+}
+
+/**
+ * Given a real ProseMirror `doc` and a set/array of matching block ids, return
+ * `[{ from, to }]` whole-node ranges for each node whose `attrs.id` is in the
+ * set. Ranges are sorted by `from`.
+ *
+ * @param {import('@tiptap/pm/model').Node} doc
+ * @param {Iterable<string>} matchIds
+ * @returns {{ from: number, to: number }[]}
+ */
+export function resolveBlockRanges(doc, matchIds) {
+  const ids = matchIds instanceof Set ? matchIds : new Set(matchIds || [])
+  if (!doc || ids.size === 0) return []
+
+  const ranges = []
+  doc.descendants((node, pos) => {
+    const id = node.attrs?.id
+    if (id && ids.has(id)) {
+      ranges.push({ from: pos, to: pos + node.nodeSize })
+    }
+    return true
+  })
+
+  ranges.sort((a, b) => a.from - b.from)
+  return ranges
+}
+
+/**
+ * Stable client-cache key for an AI find result. Combines a document version
+ * (or any change token) with the normalized query so re-typing the same query
+ * against unchanged content is a cache hit.
+ *
+ * @param {string|number} docVersion
+ * @param {string} query
+ * @returns {string}
+ */
+export function buildSearchCacheKey(docVersion, query) {
+  const normalizedQuery = String(query || '').trim().toLowerCase()
+  return `${String(docVersion ?? '')}::${normalizedQuery}`
+}

--- a/supabase/functions/ai-find/index.ts
+++ b/supabase/functions/ai-find/index.ts
@@ -1,0 +1,272 @@
+import "jsr:@supabase/functions-js/edge-runtime.d.ts"
+import { createClient } from 'jsr:@supabase/supabase-js@2'
+
+// AI Find: given a short natural-language query and the current page's blocks
+// ({id, text}), return the ids of blocks that semantically match. Mirrors the
+// structure/CORS/auth of ai-insert/index.ts.
+//
+// Cost control: the (larger, stable) block list goes in the SYSTEM prompt with
+// cache_control so refining the query within the 5-min TTL re-reads it at ~10%
+// cost. The short query is the user message. Default model is Haiku.
+
+const ALLOWED_ORIGIN = Deno.env.get('ALLOWED_ORIGIN') || '*'
+const CORS_HEADERS = {
+  'Access-Control-Allow-Origin': ALLOWED_ORIGIN,
+  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
+}
+
+// Input guardrails (trust boundary).
+const MAX_QUERY_CHARS = 300
+const MAX_BLOCKS = 500
+const MAX_TOTAL_BLOCK_CHARS = 60000
+const MAX_BLOCK_TEXT_CHARS = 2000
+
+type Block = { id: string; text: string }
+
+const jsonResponse = (body: unknown, status = 200) =>
+  new Response(JSON.stringify(body), {
+    status,
+    headers: { ...CORS_HEADERS, 'Content-Type': 'application/json' },
+  })
+
+type ProviderConfig = {
+  url: string
+  buildRequest: (
+    model: string,
+    systemPrompt: string,
+    userMessage: string,
+    apiKey: string,
+  ) => { headers: Record<string, string>; body: string }
+  extractMatchIds: (data: any) => string[]
+}
+
+const FIND_TOOL = {
+  name: 'report_matches',
+  description:
+    'Report the ids of the blocks that semantically match the search description. Return an empty array if none match.',
+  input_schema: {
+    type: 'object',
+    properties: {
+      matchIds: {
+        type: 'array',
+        items: { type: 'string' },
+        description: 'Block ids (from the provided list) that match the description.',
+      },
+    },
+    required: ['matchIds'],
+  },
+}
+
+const extractIdsFromText = (text: string): string[] => {
+  const direct = String(text || '').trim()
+  if (!direct) return []
+  const tryParse = (raw: string): string[] | null => {
+    try {
+      const parsed = JSON.parse(raw)
+      const ids = parsed?.matchIds ?? parsed
+      if (Array.isArray(ids)) return ids.map((x) => String(x))
+      return null
+    } catch {
+      return null
+    }
+  }
+  const first = direct.indexOf('{')
+  const last = direct.lastIndexOf('}')
+  if (first !== -1 && last !== -1 && last > first) {
+    const out = tryParse(direct.slice(first, last + 1))
+    if (out) return out
+  }
+  return tryParse(direct) ?? []
+}
+
+const PROVIDERS: Record<string, ProviderConfig> = {
+  anthropic: {
+    url: 'https://api.anthropic.com/v1/messages',
+    buildRequest: (model, systemPrompt, userMessage, apiKey) => ({
+      headers: {
+        'Content-Type': 'application/json',
+        'x-api-key': apiKey,
+        'anthropic-version': '2023-06-01',
+      },
+      // cache_control on the system block caches the stable block list, so
+      // refining the query within the TTL re-reads it at ~10% cost.
+      body: JSON.stringify({
+        model,
+        max_tokens: 1024,
+        system: [{ type: 'text', text: systemPrompt, cache_control: { type: 'ephemeral' } }],
+        tools: [FIND_TOOL],
+        tool_choice: { type: 'tool', name: FIND_TOOL.name },
+        messages: [{ role: 'user', content: userMessage }],
+      }),
+    }),
+    extractMatchIds: (data) => {
+      const blocks = Array.isArray(data?.content) ? data.content : []
+      for (const block of blocks) {
+        if (block.type === 'tool_use' && block.name === FIND_TOOL.name) {
+          const ids = block.input?.matchIds
+          if (Array.isArray(ids)) return ids.map((x: unknown) => String(x))
+        }
+      }
+      // Fallback: some responses may include plain text.
+      const text = blocks.find((b: any) => b.type === 'text')?.text ?? ''
+      return extractIdsFromText(text)
+    },
+  },
+  openai: {
+    url: 'https://api.openai.com/v1/chat/completions',
+    buildRequest: (model, systemPrompt, userMessage, apiKey) => ({
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${apiKey}`,
+      },
+      body: JSON.stringify({
+        model,
+        response_format: { type: 'json_object' },
+        messages: [
+          { role: 'system', content: systemPrompt },
+          { role: 'user', content: userMessage },
+        ],
+      }),
+    }),
+    extractMatchIds: (data) => extractIdsFromText(data.choices?.[0]?.message?.content ?? ''),
+  },
+  google: {
+    url: 'https://generativelanguage.googleapis.com/v1beta/models/{model}:generateContent',
+    buildRequest: (model, systemPrompt, userMessage, _apiKey) => ({
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        system_instruction: { parts: [{ text: systemPrompt }] },
+        contents: [{ parts: [{ text: userMessage }] }],
+        generationConfig: { responseMimeType: 'application/json' },
+      }),
+    }),
+    extractMatchIds: (data) =>
+      extractIdsFromText(data.candidates?.[0]?.content?.parts?.[0]?.text ?? ''),
+  },
+}
+
+/**
+ * Validate and normalize the incoming blocks. Returns null on malformed input.
+ */
+const normalizeBlocks = (raw: unknown): Block[] | null => {
+  if (!Array.isArray(raw)) return null
+  if (raw.length > MAX_BLOCKS) return null
+  const blocks: Block[] = []
+  let totalChars = 0
+  for (const entry of raw) {
+    if (!entry || typeof entry !== 'object') return null
+    const id = String((entry as Record<string, unknown>).id ?? '').trim()
+    const text = String((entry as Record<string, unknown>).text ?? '')
+      .slice(0, MAX_BLOCK_TEXT_CHARS)
+      .trim()
+    if (!id || !text) continue
+    totalChars += text.length
+    if (totalChars > MAX_TOTAL_BLOCK_CHARS) return null
+    blocks.push({ id, text })
+  }
+  return blocks
+}
+
+Deno.serve(async (req) => {
+  if (req.method === 'OPTIONS') {
+    return new Response('ok', { headers: CORS_HEADERS })
+  }
+
+  const authHeader = req.headers.get('Authorization')
+  if (!authHeader) {
+    return jsonResponse({ success: false, error: 'Not authenticated' }, 401)
+  }
+
+  const supabaseClient = createClient(
+    Deno.env.get('SUPABASE_URL') ?? '',
+    Deno.env.get('SUPABASE_ANON_KEY') ?? '',
+    { global: { headers: { Authorization: authHeader } } },
+  )
+
+  const {
+    data: { user },
+    error: authError,
+  } = await supabaseClient.auth.getUser()
+
+  if (authError || !user) {
+    return jsonResponse({ success: false, error: 'Invalid token' }, 401)
+  }
+
+  try {
+    const body = await req.json()
+    const provider = String(body?.provider || 'anthropic')
+    const model = String(body?.model || 'claude-haiku-4-5-20251001')
+    const query = String(body?.query ?? '').trim()
+
+    if (!query) {
+      return jsonResponse({ success: false, error: 'Missing query.' }, 400)
+    }
+    if (query.length > MAX_QUERY_CHARS) {
+      return jsonResponse({ success: false, error: 'Query too long.' }, 400)
+    }
+
+    const blocks = normalizeBlocks(body?.blocks)
+    if (blocks === null) {
+      return jsonResponse({ success: false, error: 'Malformed or oversized blocks.' }, 400)
+    }
+    if (blocks.length === 0) {
+      return jsonResponse({ success: true, data: { matchIds: [] } })
+    }
+
+    const providerConfig = PROVIDERS[provider]
+    if (!providerConfig) {
+      return jsonResponse({ success: false, error: `Unknown provider: ${provider}` }, 400)
+    }
+
+    const apiKeyEnvMap: Record<string, string> = {
+      anthropic: 'ANTHROPIC_API_KEY',
+      openai: 'OPENAI_API_KEY',
+      google: 'GOOGLE_API_KEY',
+    }
+    const apiKey = Deno.env.get(apiKeyEnvMap[provider])
+    if (!apiKey) {
+      return jsonResponse({ success: false, error: `No API key configured for ${provider}` }, 500)
+    }
+
+    const allowedIds = new Set(blocks.map((b) => b.id))
+
+    const systemPrompt = `You are a search assistant for a single rich-text page. You are given a list of BLOCKS, each with an "id" and "text". The user will describe what they are looking for in natural language (not an exact string).
+
+Return the ids of the blocks whose text semantically matches the user's description. Match on meaning, not exact words. Be selective — only return blocks that genuinely fit. Return an empty array if nothing matches.
+
+You MUST use ONLY ids that appear in the BLOCKS list. Never invent ids.
+
+BLOCKS:
+${JSON.stringify(blocks)}`
+
+    const userMessage = `Find blocks matching: ${query}`
+
+    let fetchUrl = providerConfig.url
+    if (provider === 'google') {
+      fetchUrl = fetchUrl.replace('{model}', model) + `?key=${apiKey}`
+    }
+
+    const { headers, body: requestBody } = providerConfig.buildRequest(
+      model,
+      systemPrompt,
+      userMessage,
+      apiKey,
+    )
+    const response = await fetch(fetchUrl, { method: 'POST', headers, body: requestBody })
+    const responseData = await response.json()
+
+    if (!response.ok) {
+      console.error('LLM API error:', JSON.stringify(responseData))
+      return jsonResponse({ success: false, error: 'LLM API error. Check edge function logs.' }, 502)
+    }
+
+    const rawIds = providerConfig.extractMatchIds(responseData)
+    // Server-side validation: drop hallucinated ids and dedupe.
+    const matchIds = Array.from(new Set(rawIds.filter((id) => allowedIds.has(id))))
+
+    return jsonResponse({ success: true, data: { matchIds } })
+  } catch (err) {
+    console.error('ai-find error:', err)
+    return jsonResponse({ success: false, error: 'Internal error processing AI find request.' }, 500)
+  }
+})


### PR DESCRIPTION
## Summary

Adds an **AI mode (on by default)** layered over the literal Ctrl+F find bar. When the find bar is open, typing a *description* of what you're looking for highlights the matching bullet points / lines on the current page — using the same yellow-bg + orange-outline look as deep-link highlights — and lets you cycle through them with the existing next/prev counter.

Fast + cheap by design: instant literal substring matches while typing, debounced semantic search on pause, client cache, Haiku 4.5, and Anthropic prompt-caching of the block list.

## What's included

- **`supabase/functions/ai-find/index.ts`** — mirrors `ai-insert` (CORS/auth/provider map, `{success,data,error}` envelope). Block list in a `cache_control` system prompt, short query as the user message, structured tool-use output `{ matchIds }`. Validates query length + block count/chars and drops hallucinated ids server-side. Default model `claude-haiku-4-5-20251001`.
- **`src/utils/aiSearchHelpers.js`** (+ unit tests) — `extractSearchableBlocks`, `resolveBlockRanges` (real PM doc), `buildSearchCacheKey`.
- **`src/extensions/findInDoc.js`** — new `'ai'` plugin mode. `setAiMatches(ranges)` supplies whole-block ranges; decorations emit `Decoration.node` (`.ai-find-match` / `.current`); ranges remap on edits. Literal mode unchanged.
- **`src/components/editor/toolbar/useAiSearch.js`** — instant literal feedback + 600ms debounce, min length 3, per-`(docVersion,query)` cache, stale-request token guard, client-side id validation.
- **UI/store** — `aiSearchMode` (default true, session-persisted) + `aiSearchLoading`; AI toggle pill + thinking spinner in `FindBar`. Toggling off cancels in-flight requests and reverts to literal find (zero AI calls while off).
- **Mobile** — moved the `find` tool into the always-visible core toolbar group (same pattern as the recent strikethrough move) so search is one tap without expanding.
- **Styling** — AI toggle + spinner (DESIGN.md teal tokens); `.ai-find-match` reuses the deep-link palette.

## Trust boundary

Input validated server-side **and** returned ids validated client-side before highlighting.

## Test plan

- [x] **Unit (Vitest):** `aiSearchHelpers.test.js` — 14 cases for block extraction (nested lists, table cells, marks, whitespace/no-id skipping) and node-range resolution against a real ProseMirror doc. Full suite: 312 passing.
- [x] **Build:** `npm run build` green.
- [x] **Lint:** clean on changed files.
- [ ] **E2E (Playwright):** `e2e/ai-find.spec.js` — AI toggle present + on by default; semantic search highlights matched blocks via a route-stubbed `ai-find`, counter updates, next/prev cycles + wraps; toggling AI off reverts to literal find with zero AI calls. _(runs in CI)_
- [ ] **Edge function deploy:** `ai-find` is **not yet deployed** — needs `npx supabase functions deploy ai-find` before the real model works in the app.
- [ ] **Manual (real model):** on the June tracker, confirm ~1s latency, single-char refinement reuses cache, AI-off restores literal find.

🤖 Generated with [Claude Code](https://claude.com/claude-code)