### PR TITLE
fix: keep caret above keyboard when it opens on mobile

### DIFF
--- a/src/components/EditorPanel.jsx
+++ b/src/components/EditorPanel.jsx
@@ -4,9 +4,10 @@ import { supabase } from '../lib/supabase'
 import { serializeDocToText } from '../lib/serializeDoc'
 import { isTouchOnlyDevice } from '../utils/device'
 import { buildHash } from '../utils/navigationHelpers'
-import { scrollElementIntoViewWithToolbar, scrollRectIntoViewWithToolbar } from '../utils/scrollIntoViewWithToolbar'
+import { scrollElementIntoViewWithToolbar } from '../utils/scrollIntoViewWithToolbar'
 import { useContentZoom } from '../hooks/useContentZoom'
 import { useMobileToolbarTransform } from '../hooks/useMobileToolbarTransform'
+import { useKeepCaretAboveKeyboard } from '../hooks/useKeepCaretAboveKeyboard'
 import { useEditorUIStore } from '../stores/editorUIStore'
 import EditorHeader from './editor/EditorHeader'
 import Toolbar from './editor/Toolbar'
@@ -84,6 +85,13 @@ function EditorPanel({
   const { zoomLevel, resetZoom, showHint, dismissHint, gestureRecent, isZoomSupported } =
     useContentZoom(editorShellRef, isTouchOnly)
   useMobileToolbarTransform({ enabled: isTouchOnly, toolbarRef })
+  useKeepCaretAboveKeyboard({
+    enabled: isTouchOnly,
+    editor,
+    toolbarRef,
+    editorPanelRef,
+    padding: 20,
+  })
 
   // On touch devices, avoid calling .focus() when the editor isn't already
   // focused — that would open the virtual keyboard.
@@ -93,35 +101,6 @@ function EditorPanel({
       ? editor.chain()
       : editor.chain().focus()
   }, [editor, isTouchOnly])
-
-  // Scroll cursor into view whenever the editor gains focus (keyboard open).
-  useEffect(() => {
-    if (!editor) return
-    const handleFocus = () => {
-      // Re-measure after the virtual keyboard opens: the viewport shrinks a frame
-      // or two later, so this is a legitimate settle re-scroll, not a competitor
-      // to the handleScrollToSelection override (which already fired on the
-      // selection change). It uses the same chrome-aware math.
-      requestAnimationFrame(() => {
-        requestAnimationFrame(() => {
-          try {
-            const { head } = editor.state.selection
-            const coords = editor.view.coordsAtPos(head)
-            scrollRectIntoViewWithToolbar({
-              rect: coords,
-              container: editorPanelRef.current,
-              toolbarEl: toolbarRef.current,
-              padding: 20,
-            })
-          } catch {
-            // ProseMirror may not have a measurable selection during teardown.
-          }
-        })
-      })
-    }
-    editor.on('focus', handleFocus)
-    return () => { editor.off('focus', handleFocus) }
-  }, [editor])
 
   useEffect(() => {
     if (!aiInsertOpen) return

--- a/src/hooks/__tests__/keepCaretAboveKeyboard.test.js
+++ b/src/hooks/__tests__/keepCaretAboveKeyboard.test.js
@@ -1,0 +1,20 @@
+import { describe, it, expect } from 'vitest'
+import { shouldKeepCaretAboveKeyboard } from '../useKeepCaretAboveKeyboard'
+
+describe('shouldKeepCaretAboveKeyboard', () => {
+  it('acts when the keyboard is shown and the editor is focused', () => {
+    expect(shouldKeepCaretAboveKeyboard({ keyboardShown: true, editorFocused: true })).toBe(true)
+  })
+
+  it('skips when the keyboard is not shown (close / chrome shrink)', () => {
+    expect(shouldKeepCaretAboveKeyboard({ keyboardShown: false, editorFocused: true })).toBe(false)
+  })
+
+  it('skips when the editor is not focused (no caret to keep)', () => {
+    expect(shouldKeepCaretAboveKeyboard({ keyboardShown: true, editorFocused: false })).toBe(false)
+  })
+
+  it('skips when neither condition holds', () => {
+    expect(shouldKeepCaretAboveKeyboard({ keyboardShown: false, editorFocused: false })).toBe(false)
+  })
+})

--- a/src/hooks/useKeepCaretAboveKeyboard.js
+++ b/src/hooks/useKeepCaretAboveKeyboard.js
@@ -1,0 +1,87 @@
+import { useEffect } from 'react'
+import { isKeyboardShown } from '../utils/keyboardShown'
+import { scrollSelectionIntoViewWithToolbar } from '../utils/scrollIntoViewWithToolbar'
+
+/**
+ * Pure decision: should we re-scroll the caret above the keyboard right now?
+ *
+ * We only act when the on-screen keyboard is actually up *and* the editor holds
+ * focus (there is a live caret to keep visible). This keeps us from fighting
+ * keyboard-close, address-bar shrink, or background viewport changes.
+ *
+ * @param {{ keyboardShown: boolean, editorFocused: boolean }} params
+ * @returns {boolean}
+ */
+export function shouldKeepCaretAboveKeyboard({ keyboardShown, editorFocused }) {
+  return Boolean(keyboardShown && editorFocused)
+}
+
+/**
+ * Keep the caret above the on-screen keyboard when it opens on mobile.
+ *
+ * Opening the keyboard is a visualViewport *resize*, not a selection change, so
+ * none of the selection-driven scroll paths fire. This hook listens to that
+ * resize and re-runs the existing toolbar-aware caret scroll once the viewport
+ * has settled — reusing the same math the selection paths use, no new geometry.
+ *
+ * The toolbar lift (useMobileToolbarTransform) is also rAF-scheduled off the
+ * same resize event; we use a second rAF before measuring so the toolbar's
+ * transform write lands first and getToolbarSafeBounds reads its lifted rect.
+ * This mirrors the double-rAF convention in useKeepCursorVisible / EditorPanel.
+ *
+ * No-ops on desktop / non-touch (`enabled` false) or where visualViewport is
+ * absent.
+ *
+ * @param {{ enabled: boolean, editor: object, toolbarRef: React.RefObject, editorPanelRef: React.RefObject, padding?: number }} opts
+ */
+export function useKeepCaretAboveKeyboard({
+  enabled,
+  editor,
+  toolbarRef,
+  editorPanelRef,
+  padding = 16,
+}) {
+  useEffect(() => {
+    if (!enabled) return
+    if (!editor) return
+    const viewport = window.visualViewport
+    if (!viewport) return
+
+    let rafId = null
+
+    const run = () => {
+      rafId = null
+      const editorFocused = Boolean(editor.view?.hasFocus?.())
+      if (!shouldKeepCaretAboveKeyboard({ keyboardShown: isKeyboardShown(), editorFocused })) {
+        return
+      }
+      try {
+        scrollSelectionIntoViewWithToolbar({
+          view: editor.view,
+          container: editorPanelRef?.current ?? null,
+          toolbarEl: toolbarRef?.current ?? null,
+          padding,
+        })
+      } catch {
+        // ProseMirror may not have a measurable selection during teardown.
+      }
+    }
+
+    // Listen to resize only — `scroll` is the user panning, which we must not
+    // fight. Coalesce bursts with a first rAF; a second rAF lets the toolbar
+    // transform (also rAF-scheduled off this resize) settle before we measure.
+    const schedule = () => {
+      if (rafId !== null) return
+      rafId = requestAnimationFrame(() => {
+        rafId = requestAnimationFrame(run)
+      })
+    }
+
+    viewport.addEventListener('resize', schedule)
+
+    return () => {
+      if (rafId !== null) cancelAnimationFrame(rafId)
+      viewport.removeEventListener('resize', schedule)
+    }
+  }, [enabled, editor, toolbarRef, editorPanelRef, padding])
+}


### PR DESCRIPTION
## Problem

On Android Chrome, tapping into the editor places the cursor, then the on-screen keyboard slides up and covers it — the page does **not** scroll the caret into view. Standard apps (OneNote, Docs) keep the caret above the keyboard automatically.

PR #170 routed every **selection-driven** scroll through one toolbar-aware function, which covers typing, arrows, find, and deep-links. But opening the keyboard is **not** a selection change — it's a `visualViewport` *resize*, so nothing re-scrolled the caret. The one piece that tried (the `editor.on('focus')` handler) re-measured after only ~32ms, before the Android keyboard finishes sliding up (~250–350ms), so it read a still-full viewport and never scrolled.

## Fix

Add a focused hook, `useKeepCaretAboveKeyboard`, that:
- Listens to `visualViewport` **`resize`** only (not `scroll` — that's the user panning).
- Gates on `isKeyboardShown()` (existing 150px-threshold tracker) **and** editor focus.
- Uses a double-rAF before measuring so `useMobileToolbarTransform`'s transform write lands first and the toolbar rect reflects its lifted position.
- Re-runs the existing `scrollSelectionIntoViewWithToolbar` — **no new scroll math**, same function the PR #170 paths use.

Replaces the brittle timing-guess `editor.on('focus')` handler in `EditorPanel.jsx` (net simplification: −27-line effect, +7-line hook call).

## Files
- **New:** `src/hooks/useKeepCaretAboveKeyboard.js`
- **New:** `src/hooks/__tests__/keepCaretAboveKeyboard.test.js`
- **Edit:** `src/components/EditorPanel.jsx`

## Test plan
- [x] Unit: new predicate test (keyboard shown + focused → act; not shown → skip; not focused → skip)
- [x] Full unit suite green (325 passed)
- [x] ESLint clean on changed files
- [ ] **Manual (Android Chrome):** open a long tracker, scroll a bottom bullet just above where the keyboard appears, tap into it → caret ends up comfortably above the keyboard/toolbar. Repeat for middle + bottom bullets. Regression: typing at the bottom with keyboard already open, find-next, and deep-link tap-to-edit still behave.

The keyboard-open behavior can't be exercised headless, so the existing E2E suite is unaffected.