### PR TITLE
fix(ai-daily): re-bucket mis-sorted tasks instead of dropping them

### DIFF
--- a/supabase/functions/generate-daily/dailyHelpers.test.ts
+++ b/supabase/functions/generate-daily/dailyHelpers.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from 'vitest'
 
-import { filterCandidatesForDaily, mapTasksFromCids } from './dailyHelpers.ts'
+import {
+  buildCidBucketMap,
+  filterCandidatesForDaily,
+  routeTasksToBuckets,
+} from './dailyHelpers.ts'
 
 describe('filterCandidatesForDaily', () => {
   it('keeps only overdue, today, and soon candidates', () => {
@@ -44,28 +48,115 @@ describe('filterCandidatesForDaily', () => {
 
     expect(filtered.map((candidate) => candidate.cid)).toEqual(['c1', 'c2', 'c3'])
   })
+})
 
-  it('lets the server enforce bucket-specific cid allowlists after the model responds', () => {
-    const mapped = mapTasksFromCids(
-      [
-        {
-          task: 'Misbucketed soon item',
-          cids: ['c-soon'],
-          priority: 'high',
-        },
-      ],
-      new Set(['c-today']),
-      new Map([
-        ['c-today', 'block-today'],
-        ['c-soon', 'block-soon'],
-      ]),
-      new Map([
-        ['c-today', 'Today task'],
-        ['c-soon', 'Soon task'],
-      ]),
+describe('buildCidBucketMap', () => {
+  it('routes overdue/today to asap, soon to fyi, and ignores later/none', () => {
+    const map = buildCidBucketMap([
+      { cid: 'c1', text: 'Overdue', due_bucket: 'overdue', is_overdue: true, has_explicit_date: true },
+      { cid: 'c2', text: 'Today', due_bucket: 'today', is_overdue: false, has_explicit_date: true },
+      { cid: 'c3', text: 'Soon', due_bucket: 'soon', is_overdue: false, has_explicit_date: true },
+      { cid: 'c4', text: 'Later', due_bucket: 'later', is_overdue: false, has_explicit_date: true },
+      { cid: 'c5', text: 'None', due_bucket: 'none', is_overdue: false, has_explicit_date: false },
+    ])
+
+    expect(map.get('c1')).toBe('asap')
+    expect(map.get('c2')).toBe('asap')
+    expect(map.get('c3')).toBe('fyi')
+    expect(map.has('c4')).toBe(false)
+    expect(map.has('c5')).toBe(false)
+  })
+})
+
+describe('routeTasksToBuckets', () => {
+  const cidToBucket = buildCidBucketMap([
+    { cid: 'c-today', text: 'Today task', due_bucket: 'today', is_overdue: false, has_explicit_date: true },
+    { cid: 'c-soon', text: 'Soon task', due_bucket: 'soon', is_overdue: false, has_explicit_date: true },
+  ])
+  // cidToBlockId intentionally also knows a "later" cid that was never sent to
+  // the model, mirroring production where the block map covers every next step.
+  const cidToBlockId = new Map([
+    ['c-today', 'block-today'],
+    ['c-soon', 'block-soon'],
+    ['c-later', 'block-later'],
+  ])
+  const cidToText = new Map([
+    ['c-today', 'Today task'],
+    ['c-soon', 'Soon task'],
+    ['c-later', 'Later task'],
+  ])
+
+  it('places correctly-bucketed tasks into their bucket', () => {
+    const routed = routeTasksToBuckets(
+      [{ task: 'Do today thing', cids: ['c-today'], priority: 'high' }],
+      cidToBucket,
+      cidToBlockId,
+      cidToText,
     )
 
-    expect(mapped.mapped).toEqual([])
-    expect(mapped.removedForInvalidCids).toBe(1)
+    expect(routed.asap).toEqual([
+      { task: 'Do today thing', block_ids: ['block-today'], priority: 'high' },
+    ])
+    expect(routed.fyi).toEqual([])
+    expect(routed.droppedUnknownCids).toBe(0)
+  })
+
+  it('re-routes a mis-bucketed task to its correct bucket instead of dropping it', () => {
+    // The model wrongly put a "soon" item in the ASAP list. It should land in FYI.
+    const routed = routeTasksToBuckets(
+      [{ task: 'Misbucketed soon item', cids: ['c-soon'], priority: 'high' }],
+      cidToBucket,
+      cidToBlockId,
+      cidToText,
+    )
+
+    expect(routed.asap).toEqual([])
+    expect(routed.fyi).toEqual([
+      { task: 'Misbucketed soon item', block_ids: ['block-soon'], priority: 'high' },
+    ])
+    expect(routed.droppedUnknownCids).toBe(0)
+  })
+
+  it('silently drops unknown / out-of-scope cids without surfacing a task', () => {
+    const routed = routeTasksToBuckets(
+      [
+        // c-later was never sent to the model (far-future); cX is invented.
+        { task: '2027 taxes', cids: ['c-later'], priority: 'low' },
+        { task: 'Hallucinated', cids: ['cX'], priority: 'low' },
+      ],
+      cidToBucket,
+      cidToBlockId,
+      cidToText,
+    )
+
+    expect(routed.asap).toEqual([])
+    expect(routed.fyi).toEqual([])
+    expect(routed.droppedUnknownCids).toBe(2)
+  })
+
+  it('falls back to candidate text when the model omits a task description', () => {
+    const routed = routeTasksToBuckets(
+      [{ task: '   ', cids: ['c-today'], priority: 'nonsense' }],
+      cidToBucket,
+      cidToBlockId,
+      cidToText,
+    )
+
+    expect(routed.asap).toEqual([
+      { task: 'Today task', block_ids: ['block-today'], priority: 'medium' },
+    ])
+  })
+
+  it('skips tasks without a usable cids array', () => {
+    const routed = routeTasksToBuckets(
+      [{ task: 'No cids here', priority: 'high' }],
+      cidToBucket,
+      cidToBlockId,
+      cidToText,
+    )
+
+    expect(routed.asap).toEqual([])
+    expect(routed.fyi).toEqual([])
+    expect(routed.droppedUnknownCids).toBe(0)
   })
 })

--- a/supabase/functions/generate-daily/dailyHelpers.ts
+++ b/supabase/functions/generate-daily/dailyHelpers.ts
@@ -420,54 +420,88 @@ export const parseTaskBuckets = (text: string): ParsedTaskBuckets => {
   return { asap, fyi, format }
 }
 
-export const mapTasksFromCids = (
-  tasks: any[],
-  allowedCids: Set<string>,
+export type BucketName = 'asap' | 'fyi'
+
+export type MappedTask = {
+  task: string
+  block_ids: string[]
+  priority: string
+}
+
+// Each candidate has exactly one correct destination bucket, decided by the
+// server-computed due_bucket — overdue/today belong in ASAP, soon in FYI.
+// later/none candidates are never sent to the model, so they have no bucket.
+export const buildCidBucketMap = (candidates: CandidateForModel[]): Map<string, BucketName> => {
+  const cidToBucket = new Map<string, BucketName>()
+  for (const candidate of candidates || []) {
+    if (candidate.due_bucket === 'overdue' || candidate.due_bucket === 'today') {
+      cidToBucket.set(candidate.cid, 'asap')
+    } else if (candidate.due_bucket === 'soon') {
+      cidToBucket.set(candidate.cid, 'fyi')
+    }
+  }
+  return cidToBucket
+}
+
+// Routes the model's tasks into ASAP/FYI by each cid's *canonical* bucket rather
+// than the bucket the model chose. This recovers mis-bucketed real tasks (e.g. a
+// "today" item the model put in FYI) instead of dropping them, and silently
+// ignores cids the model invented or that were never sent (e.g. far-future
+// "later" items), which are safe to discard.
+export const routeTasksToBuckets = (
+  aiTasks: any[],
+  cidToBucket: Map<string, BucketName>,
   cidToBlockId: Map<string, string>,
   cidToText: Map<string, string>,
 ) => {
-  let removedForInvalidCids = 0
+  const asap: MappedTask[] = []
+  const fyi: MappedTask[] = []
+  let droppedUnknownCids = 0
 
-  const mapped = (tasks || [])
-    .map((task) => {
-      if (!Array.isArray(task?.cids)) {
-        removedForInvalidCids += 1
-        return null
+  for (const task of aiTasks || []) {
+    if (!Array.isArray(task?.cids)) continue
+
+    // Group this task's cids by where they actually belong. A single task can
+    // (rarely) reference cids spanning both buckets; each group becomes its own
+    // entry in the correct bucket.
+    const cidsByBucket = new Map<BucketName, string[]>()
+    for (const cid of task.cids) {
+      const bucket = cidToBucket.get(cid)
+      if (!bucket) {
+        droppedUnknownCids += 1
+        continue
       }
+      const group = cidsByBucket.get(bucket) || []
+      if (!group.includes(cid)) group.push(cid)
+      cidsByBucket.set(bucket, group)
+    }
 
-      const validCids = task.cids.filter((cid: string) => allowedCids.has(cid))
-      removedForInvalidCids += task.cids.length - validCids.length
-      if (!validCids.length) return null
-
-      const uniqueCids = Array.from(new Set(validCids))
-      const blockIds = uniqueCids
+    for (const [bucket, cids] of cidsByBucket) {
+      const blockIds = cids
         .map((cid) => cidToBlockId.get(cid))
         .filter((id): id is string => Boolean(id))
+      if (!blockIds.length) continue
 
-      if (!blockIds.length) return null
-
-      const fallbackTaskText = uniqueCids
+      const fallbackTaskText = cids
         .map((cid) => cidToText.get(cid))
         .filter((value): value is string => Boolean(value))
         .join(' + ')
 
       const nextTaskText = String(task?.task || '').trim() || fallbackTaskText
-      if (!nextTaskText) return null
+      if (!nextTaskText) continue
 
       const nextPriority = ['high', 'medium', 'low'].includes(task?.priority)
         ? task.priority
         : 'medium'
 
-      return {
+      const mappedTask: MappedTask = {
         task: nextTaskText,
         block_ids: blockIds,
         priority: nextPriority,
       }
-    })
-    .filter((task): task is { task: string, block_ids: string[], priority: string } => Boolean(task))
-
-  return {
-    mapped,
-    removedForInvalidCids,
+      ;(bucket === 'asap' ? asap : fyi).push(mappedTask)
+    }
   }
+
+  return { asap, fyi, droppedUnknownCids }
 }

--- a/supabase/functions/generate-daily/index.ts
+++ b/supabase/functions/generate-daily/index.ts
@@ -3,9 +3,10 @@ import { createClient } from 'jsr:@supabase/supabase-js@2'
 
 import {
   buildCandidatesForModel,
+  buildCidBucketMap,
   filterCandidatesForDaily,
-  mapTasksFromCids,
   parseTaskBuckets,
+  routeTasksToBuckets,
 } from './dailyHelpers.ts'
 
 const ALLOWED_ORIGIN = Deno.env.get('ALLOWED_ORIGIN') || '*'
@@ -74,8 +75,6 @@ const jsonResponse = (body: unknown, status = 200) =>
       'Content-Type': 'application/json',
     },
   })
-
-const appendWarning = (existing: string | null, next: string) => (existing ? `${existing} ${next}` : next)
 
 Deno.serve(async (req) => {
   if (req.method === 'OPTIONS') {
@@ -178,49 +177,27 @@ If a bucket is empty, return an empty array.`
     const rawText = providerConfig.extractResponse(data)
     const parsed = parseTaskBuckets(rawText)
 
-    const asapAllowedCids = new Set(
-      modelCandidates
-        .filter((candidate) => candidate.due_bucket === 'overdue' || candidate.due_bucket === 'today')
-        .map((candidate) => candidate.cid),
-    )
-    const fyiAllowedCids = new Set(
-      modelCandidates
-        .filter((candidate) => candidate.due_bucket === 'soon')
-        .map((candidate) => candidate.cid),
-    )
+    // The server, not the model, decides which bucket each task belongs in.
+    // Tasks the model mis-bucketed are re-routed to the correct bucket; cids the
+    // model invented or that were never sent (e.g. far-future items) are dropped
+    // silently because nothing real is lost.
+    const cidToBucket = buildCidBucketMap(modelCandidates)
+    const aiTasks = [
+      ...(Array.isArray(parsed.asap) ? parsed.asap : []),
+      ...(Array.isArray(parsed.fyi) ? parsed.fyi : []),
+    ]
 
-    const mappedAsap = mapTasksFromCids(parsed.asap, asapAllowedCids, cidToBlockId, cidToText)
-    const mappedFyi = mapTasksFromCids(parsed.fyi, fyiAllowedCids, cidToBlockId, cidToText)
+    const routed = routeTasksToBuckets(aiTasks, cidToBucket, cidToBlockId, cidToText)
+    const asap = routed.asap
+    const fyi = routed.fyi
 
-    const asap = mappedAsap.mapped
-    const fyi = mappedFyi.mapped
-
-    const totalParsedCount =
-      (parsed.asap?.length || 0) +
-      (parsed.fyi?.length || 0)
-    const totalMappedCount = asap.length + fyi.length
-
-    let warning =
+    // Only warn when the model failed to produce the expected ASAP/FYI shape at
+    // all — that genuinely means results may be incomplete. Dropped/re-routed
+    // cids are handled deterministically and need no user-facing warning.
+    const warning =
       parsed.format === 'asap_fyi'
         ? null
         : 'FYI: AI response did not follow the ASAP/FYI format. Results may be incomplete.'
-
-    if (totalParsedCount > totalMappedCount) {
-      warning = appendWarning(
-        warning,
-        'FYI: Some tasks were removed because AI returned missing or invalid candidate IDs.',
-      )
-    }
-
-    if (
-      mappedAsap.removedForInvalidCids > 0 ||
-      mappedFyi.removedForInvalidCids > 0
-    ) {
-      warning = appendWarning(
-        warning,
-        'FYI: AI output must use matching cids from CANDIDATES_JSON for each bucket. Invalid references were ignored.',
-      )
-    }
 
     return jsonResponse({
       asap,


### PR DESCRIPTION
## Problem

When generating the AI daily list, you'd intermittently see:

> FYI: Some tasks were removed because AI returned missing or invalid candidate IDs. FYI: AI output must use matching cids from CANDIDATES_JSON for each bucket. Invalid references were ignored.

The `generate-daily` edge function validated the model's output with **per-bucket cid allowlists** — a cid was only accepted if it appeared in the exact bucket (ASAP = `overdue`/`today`, FYI = `soon`) the model put it in. Anything else was dropped and triggered the warnings.

That lumped two very different situations together:

1. **Out-of-scope / hallucinated cid** (e.g. a far-future item) — safe to drop, nothing lost.
2. **A real due-today task the model misfiled into FYI** — silently **lost** from the daily list. The warning gave no way to tell which case occurred.

This was confirmed live: a real task (`c70`) was being dropped *and* warned about by the old code.

## Fix

The server — not the model — now decides each task's bucket from its own due metadata:

- **`buildCidBucketMap`** — canonical `cid → asap|fyi` derived from `due_bucket`.
- **`routeTasksToBuckets`** — routes the model's tasks by their canonical bucket, **recovering mis-bucketed real tasks** instead of discarding them, and **silently ignoring** cids that were never sent (nothing real is lost).

The two cid warnings are removed. Only the "AI didn't follow the ASAP/FYI format" warning remains, since that genuinely means results may be incomplete.

## Verification

- Unit tests: full suite green (345 tests). New tests cover correct placement, re-routing of mis-bucketed tasks, silent drop of unknown/out-of-scope cids, text fallback, and tasks missing a `cids` array.
- **Live**: deployed to the project and regenerated the daily list against real trackers. The task the old code dropped (and warned about) is now correctly routed into ASAP, and `warning` is `null`.

## Note

The edge function was already deployed during debugging, so production already runs this logic. This PR lands the source + tests.

## Test plan

- [x] `npm run test:unit` passes
- [ ] CI (unit + E2E) green