### PR TITLE
fix: collapse sidebar and suppress keyboard on mobile new page

### DIFF
--- a/e2e/mobile-new-page-keyboard.spec.js
+++ b/e2e/mobile-new-page-keyboard.spec.js
@@ -1,0 +1,106 @@
+import { test, expect } from './fixtures'
+import {
+  createNotebook,
+  createSection,
+  deleteNotebookById,
+  ensureNavigationHidden,
+  ensureNavigationVisible,
+  getSupabase,
+  waitForApp,
+} from './test-helpers'
+
+const getEditorFocusState = async (page) =>
+  page.evaluate(() => {
+    const root = document.querySelector('.ProseMirror')
+    const selection = window.getSelection?.()
+    const anchorNode = selection?.anchorNode ?? null
+    const focusNode = selection?.focusNode ?? null
+    const anchorEl =
+      anchorNode && anchorNode.nodeType === 1 ? anchorNode : anchorNode?.parentElement ?? null
+    const focusEl =
+      focusNode && focusNode.nodeType === 1 ? focusNode : focusNode?.parentElement ?? null
+    const activeEl = document.activeElement
+
+    return {
+      activeInEditor: Boolean(root && activeEl && root.contains(activeEl)),
+      selectionInEditor: Boolean(root && ((anchorEl && root.contains(anchorEl)) || (focusEl && root.contains(focusEl)))),
+    }
+  })
+
+let seedIds = {}
+const seedLabel = `KB-NEW-PAGE-${Date.now()}`
+
+test.beforeAll(async () => {
+  const { client, userId } = await getSupabase()
+  const notebook = await createNotebook(client, userId, `${seedLabel} Notebook`)
+  const section = await createSection(client, userId, notebook.id, `${seedLabel} Section`, 0)
+  seedIds = { notebook, section }
+})
+
+test.afterAll(async () => {
+  const { client } = await getSupabase()
+  await deleteNotebookById(client, seedIds.notebook?.id)
+})
+
+const createNewPage = async (page) => {
+  await ensureNavigationVisible(page)
+  await page.getByRole('button', { name: '+ New page' }).click()
+}
+
+test('creating a new page collapses the drawer and shows a blank page', async ({ page, isMobile }) => {
+  test.skip(!isMobile, 'Mobile-only test')
+
+  const hash = `#nb=${seedIds.notebook.id}&sec=${seedIds.section.id}`
+  await waitForApp(page, hash, { waitForEditor: false })
+
+  await createNewPage(page)
+
+  // Drawer should collapse so the new page is not hidden behind it.
+  await expect(page.locator('.nav-tree-container.open')).toHaveCount(0, { timeout: 5000 })
+
+  // The freshly created page shows an empty editor.
+  const editor = page.locator('.ProseMirror')
+  await expect(editor).toBeVisible({ timeout: 10000 })
+  await expect(editor).toHaveText('')
+})
+
+test('creating a new page does NOT open the keyboard', async ({ page, isMobile }) => {
+  test.skip(!isMobile, 'Mobile-only test')
+
+  const hash = `#nb=${seedIds.notebook.id}&sec=${seedIds.section.id}`
+  await waitForApp(page, hash, { waitForEditor: false })
+
+  await createNewPage(page)
+
+  await expect(page.locator('.ProseMirror')).toBeVisible({ timeout: 10000 })
+
+  // Same signal as the page-switch test: no live DOM selection inside the
+  // editor means the virtual keyboard was not auto-opened.
+  const interactionState = await getEditorFocusState(page)
+  expect(interactionState.selectionInEditor).toBe(false)
+})
+
+test('tapping the editor after creating a new page DOES focus it', async ({ page, isMobile }) => {
+  test.skip(!isMobile, 'Mobile-only test')
+
+  const hash = `#nb=${seedIds.notebook.id}&sec=${seedIds.section.id}`
+  await waitForApp(page, hash, { waitForEditor: false })
+
+  await createNewPage(page)
+
+  await expect(page.locator('.ProseMirror')).toBeVisible({ timeout: 10000 })
+
+  // Drawer is already closed by the create flow; ensure it stays hidden.
+  await ensureNavigationHidden(page)
+
+  // Wait for the blur + suppressFocusRef timer to clear.
+  await page.waitForTimeout(600)
+
+  // Tap actual editor content so the guarded mobile flow restores editability.
+  await page.locator('.ProseMirror p').first().click({ position: { x: 8, y: 8 } })
+
+  await expect(async () => {
+    const state = await getEditorFocusState(page)
+    expect(state.activeInEditor || state.selectionInEditor).toBe(true)
+  }).toPass({ timeout: 5000 })
+})

--- a/e2e/test-helpers.js
+++ b/e2e/test-helpers.js
@@ -343,6 +343,26 @@ const waitForExpectedEditor = async (page, { expectedPageTitle = null, expectedT
   }
 }
 
+const waitForExpectedNavigationTarget = async (page, treeTitles) => {
+  if (!treeTitles) return
+
+  if (treeTitles.notebookTitle) {
+    await expect(page.locator('.tree-node-notebook', { hasText: treeTitles.notebookTitle }).first()).toBeVisible({
+      timeout: 10000,
+    })
+  }
+  if (treeTitles.sectionTitle) {
+    await expect(page.locator('.tree-node-section', { hasText: treeTitles.sectionTitle }).first()).toBeVisible({
+      timeout: 10000,
+    })
+  }
+  if (treeTitles.pageTitle) {
+    await expect(page.locator('.tree-node-page', { hasText: treeTitles.pageTitle }).first()).toBeVisible({
+      timeout: 10000,
+    })
+  }
+}
+
 /** Navigate to the app root (or a hash) and wait for auth + editor to be ready.
  *  Options:
  *    expectedText — if provided, also waits for this text to appear in the editor
@@ -355,7 +375,7 @@ const waitForExpectedEditor = async (page, { expectedPageTitle = null, expectedT
  *  same-hash re-navigation (Playwright treats page.goto to the same URL as
  *  a no-op) by clearing the hash first.
  */
-export const waitForApp = async (page, hash = '/', { expectedText } = {}) => {
+export const waitForApp = async (page, hash = '/', { expectedText, waitForEditor = true } = {}) => {
   let expectedPageTitle = null
   let treeTitles = null
   if (hash && hash !== '/') {
@@ -377,6 +397,10 @@ export const waitForApp = async (page, hash = '/', { expectedText } = {}) => {
   try {
     await loadRootWorkspace()
     await navigateViaHashChange(page, hash)
+    if (!waitForEditor) {
+      await waitForExpectedNavigationTarget(page, treeTitles)
+      return
+    }
     await waitForExpectedEditor(page, { expectedPageTitle, expectedText })
   } catch (error) {
     if (!hash || hash === '/') {
@@ -393,6 +417,10 @@ export const waitForApp = async (page, hash = '/', { expectedText } = {}) => {
     // loads can still miss page resolution while notebook data is warming up.
     await loadRootWorkspace()
     await navigateViaHashChange(page, hash)
+    if (!waitForEditor) {
+      await waitForExpectedNavigationTarget(page, treeTitles)
+      return
+    }
     try {
       await waitForExpectedEditor(page, { expectedPageTitle, expectedText })
     } catch {

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -507,6 +507,17 @@ function App() {
     }
   }
 
+  const handleCreatePage = () => {
+    if (settingsMode) {
+      setSettingsMode(null)
+    }
+    primeTouchNavigationGuard()
+    if (isMobileViewport) {
+      setMobileSidebarOpen(false)
+    }
+    createTracker(session, activeSectionId)
+  }
+
   const handleOpenTreeContextMenu = (event, type, item) => {
     event.preventDefault()
     setTreeContextMenu({ open: true, x: event.clientX, y: event.clientY, type, item })
@@ -727,7 +738,7 @@ function App() {
           onSelectPage={handlePageSelect}
           onCreateNotebook={() => createNotebook(session)}
           onCreateSection={() => createSection(session, activeNotebookId)}
-          onCreatePage={() => createTracker(session, activeSectionId)}
+          onCreatePage={handleCreatePage}
           onReorderNotebooks={reorderNotebooks}
           onReorderSections={reorderSections}
           onReorderPages={reorderSectionPages}


### PR DESCRIPTION
## Summary

On mobile, tapping **+ New page** behaved badly: the navigation drawer stayed open over the freshly created page, the page loaded "behind" it, and the virtual keyboard auto-popped.

Selecting an *existing* page already does the right thing via `handlePageSelect` — it primes the touch navigation guard (suppresses programmatic focus until the user taps editor content) and closes the drawer on mobile. New-page creation skipped that entirely, wiring `onCreatePage` straight to `createTracker`.

This routes new-page creation through the same priming/drawer-close path:

- **`src/App.jsx`** — add `handleCreatePage` next to `handlePageSelect`: clears settings mode, calls `primeTouchNavigationGuard()` (no-op on non-touch, so **desktop is unchanged** and still auto-focuses), closes the drawer on mobile, then calls `createTracker`. Priming runs synchronously before the async insert resolves, so the guard is active when the editor focus effect fires and the existing `useEditorFocusRecovery` path keeps the keyboard down until the user taps editor content. Re-wire `onCreatePage` to this wrapper.

No changes to `EditorPanel.jsx`, `useEditorFocusRecovery.js`, or `useTrackers.js` — the proven guard handles keyboard suppression.

## Tests

- **`e2e/mobile-new-page-keyboard.spec.js`** (new, mobile-only) — drawer collapses on create, keyboard does NOT open (`selectionInEditor === false`), and tap-to-focus works after the guard timer clears.
- **`e2e/test-helpers.js`** — extend `waitForApp` with a `waitForEditor` option so tests can land on a section hash (no page/editor yet) and wait on the nav tree instead.

## Test plan

- [ ] E2E (Desktop Chrome + Mobile Chrome) green in CI
- [ ] Existing `mobile-page-switch-keyboard.spec.js` and `issue-115-mobile-keyboard-section-switch.spec.js` still pass (same guard path)
- [ ] Manual mobile: open drawer → "+ New page" → drawer closes, blank page, keyboard stays down; tap editor → keyboard opens
- [ ] Desktop regression: "+ New page" still focuses the editor immediately

🤖 Generated with [Claude Code](https://claude.com/claude-code)