### PR TITLE
feat: toggle highlight on the word under the cursor

### DIFF
--- a/src/components/editor/toolbar/tools/textTools.jsx
+++ b/src/components/editor/toolbar/tools/textTools.jsx
@@ -8,6 +8,7 @@ import { useEditorUIStore } from '../../../../stores/editorUIStore'
 import HighlightPicker from '../HighlightPicker'
 import { useOutsideClick } from '../useOutsideClick'
 import { cmd } from '../toolHelpers'
+import { getWordRangeAt } from '../../../../utils/wordRange'
 import { HIGHLIGHT_COLORS, TEXT_COLORS } from '../toolConstants'
 import { Btn } from './ToolButton'
 
@@ -102,6 +103,18 @@ export function HighlightTool({ editor }) {
 
   const apply = () => {
     if (!editor) return
+    const { selection } = editor.state
+    if (selection.empty) {
+      const range = getWordRangeAt(editor.state)
+      if (range) {
+        const chain = editor.chain().focus().setTextSelection(range)
+        // Toggle: already highlighted -> remove; otherwise apply current color.
+        if (editor.isActive('highlight') || !highlightColor) chain.unsetHighlight().run()
+        else chain.setHighlight({ color: highlightColor }).run()
+        return
+      }
+    }
+    // Unchanged: explicit selection (or no word under cursor) keeps today's behavior.
     if (!highlightColor) cmd(editor)?.unsetHighlight().run()
     else cmd(editor)?.setHighlight({ color: highlightColor }).run()
   }

--- a/src/utils/__tests__/wordRange.test.js
+++ b/src/utils/__tests__/wordRange.test.js
@@ -1,0 +1,89 @@
+import { describe, it, expect } from 'vitest'
+import { Schema } from '@tiptap/pm/model'
+import { EditorState, TextSelection } from '@tiptap/pm/state'
+import { getWordRangeAt } from '../wordRange'
+
+// Minimal ProseMirror schema with a plain-text block.
+const schema = new Schema({
+  nodes: {
+    doc: { content: 'block+' },
+    paragraph: { group: 'block', content: 'inline*' },
+    text: { group: 'inline' },
+  },
+})
+
+const { doc, paragraph } = schema.nodes
+
+const p = (text) => paragraph.create(null, text ? schema.text(text) : null)
+
+// Build a state with a collapsed cursor at the given document position.
+const stateWithCursor = (docNode, pos) => {
+  const state = EditorState.create({ doc: docNode, schema })
+  const selection = TextSelection.create(state.doc, pos)
+  return state.apply(state.tr.setSelection(selection))
+}
+
+// Build a state with a non-empty selection.
+const stateWithSelection = (docNode, from, to) => {
+  const state = EditorState.create({ doc: docNode, schema })
+  const selection = TextSelection.create(state.doc, from, to)
+  return state.apply(state.tr.setSelection(selection))
+}
+
+describe('getWordRangeAt', () => {
+  // doc: paragraph("hello world") -> text starts at doc pos 1.
+  // positions: h=1 e=2 l=3 l=4 o=5 (space)=6 w=7 o=8 r=9 l=10 d=11, end=12
+  const d = doc.create(null, [p('hello world')])
+
+  it('spans the full word with the cursor in the middle', () => {
+    // Cursor after "hel" (pos 4) -> "hello" = [1, 6]
+    const state = stateWithCursor(d, 4)
+    expect(getWordRangeAt(state)).toEqual({ from: 1, to: 6 })
+  })
+
+  it('spans the full word with the cursor at the word start edge', () => {
+    // Cursor right before "world" (pos 7) -> "world" = [7, 12]
+    const state = stateWithCursor(d, 7)
+    expect(getWordRangeAt(state)).toEqual({ from: 7, to: 12 })
+  })
+
+  it('spans the full word with the cursor at the word end edge', () => {
+    // Cursor right after "hello" (pos 6) -> "hello" = [1, 6]
+    const state = stateWithCursor(d, 6)
+    expect(getWordRangeAt(state)).toEqual({ from: 1, to: 6 })
+  })
+
+  it('spans the first word of the block (boundary at block start)', () => {
+    // Cursor at very start (pos 1) -> "hello" = [1, 6]
+    const state = stateWithCursor(d, 1)
+    expect(getWordRangeAt(state)).toEqual({ from: 1, to: 6 })
+  })
+
+  it('spans the last word of the block (boundary at block end)', () => {
+    // Cursor at very end (pos 12) -> "world" = [7, 12]
+    const state = stateWithCursor(d, 12)
+    expect(getWordRangeAt(state)).toEqual({ from: 7, to: 12 })
+  })
+
+  it('returns null when the cursor sits on a space between words', () => {
+    // Cursor between "hello" and "world" (pos 6 is the end edge of hello —
+    // already covered above; pos for the space char itself is offset 5,
+    // i.e. cursor at pos 6 maps to hello). The space is at offset 5; a cursor
+    // surrounded by whitespace requires double spaces.
+    const dd = doc.create(null, [p('hi  there')])
+    // text: h=1 i=2 (sp)=3 (sp)=4 t=5 ...; cursor at pos 4 is between two spaces.
+    const state = stateWithCursor(dd, 4)
+    expect(getWordRangeAt(state)).toBeNull()
+  })
+
+  it('returns null for a non-empty selection', () => {
+    const state = stateWithSelection(d, 1, 6)
+    expect(getWordRangeAt(state)).toBeNull()
+  })
+
+  it('returns null for an empty block', () => {
+    const empty = doc.create(null, [p()])
+    const state = stateWithCursor(empty, 1)
+    expect(getWordRangeAt(state)).toBeNull()
+  })
+})

--- a/src/utils/wordRange.js
+++ b/src/utils/wordRange.js
@@ -1,0 +1,49 @@
+// Pure ProseMirror-state helper: find the whitespace-delimited word under a
+// collapsed cursor. Mirrors the pure-state pattern in
+// extensions/keyboard/blockSelectionHelper.js (getBlockTextRange) — read the
+// resolved position, work in the parent's text content, and map back to
+// document positions via $from.start().
+
+const isWhitespace = (char) => /\s/.test(char)
+
+/**
+ * Returns { from, to } document positions for the whitespace-delimited word
+ * under a collapsed cursor, or null when there's no word to act on.
+ *
+ * Returns null when:
+ *  - there's a real (non-empty) selection,
+ *  - the cursor isn't inside a text block,
+ *  - the cursor sits on whitespace (no word).
+ *
+ * Note: parent text offsets map cleanly to document positions for plain-text
+ * blocks (the normal tracker case). Inline atom nodes are out of scope.
+ *
+ * @param {import('@tiptap/pm/state').EditorState} state
+ * @returns {{ from: number, to: number } | null}
+ */
+export const getWordRangeAt = (state) => {
+  const { selection } = state
+  if (!selection.empty) return null
+
+  const { $from } = selection
+  const parent = $from.parent
+  if (!parent || !parent.isTextblock) return null
+
+  const text = parent.textContent
+  const offset = $from.parentOffset
+
+  // Scan left to the start of the word.
+  let start = offset
+  while (start > 0 && !isWhitespace(text[start - 1])) start -= 1
+
+  // Scan right to the end of the word.
+  let end = offset
+  while (end < text.length && !isWhitespace(text[end])) end += 1
+
+  // No word: cursor is on whitespace (or an empty block).
+  if (start === end) return null
+
+  // $from.start() is the document position at the start of the parent's content.
+  const base = $from.start()
+  return { from: base + start, to: base + end }
+}


### PR DESCRIPTION
## Context

The highlight toolbar button only acted on an explicit text **selection**. With a collapsed cursor sitting inside a word, clicking Highlight did nothing useful (Tiptap applied the mark to an empty cursor position, only affecting text typed next).

Now: with a collapsed cursor inside a word, clicking Highlight **toggles** the highlight on the whole whitespace-delimited word ("the word between the spaces"). Already highlighted → unhighlight; otherwise highlight with the currently-selected color. Existing selection behavior is unchanged.

## Changes

- **`src/utils/wordRange.js`** (new) — `getWordRangeAt(state)`, a pure ProseMirror-state helper that returns `{ from, to }` for the word under a collapsed cursor, or `null` for a real selection, a non-text-block, or a whitespace position. Mirrors the pure-state pattern in `blockSelectionHelper.js`.
- **`src/components/editor/toolbar/tools/textTools.jsx`** — `HighlightTool.apply()` is now word-aware: on an empty selection it selects the word and toggles via `editor.isActive('highlight')`. The explicit-selection path and the color-picker `pick()` path are untouched.
- **`src/utils/__tests__/wordRange.test.js`** (new) — 8 unit tests.

## Test plan

- [x] `npm run test:unit` — 372 passed (8 new for `wordRange`)
- [ ] Manual: place cursor (no selection) inside a word, click Highlight → whole word highlights; click again → unhighlights
- [ ] Manual: normal text selection still highlights as before
- [ ] Manual: clicking on blank space does nothing

🤖 Generated with [Claude Code](https://claude.com/claude-code)