### PR TITLE
fix: re-assert caret correction over Chrome's native scroll on mobile

### DIFF
--- a/src/hooks/useKeepCaretAboveKeyboard.js
+++ b/src/hooks/useKeepCaretAboveKeyboard.js
@@ -1,6 +1,13 @@
 import { useEffect } from 'react'
 import { isKeyboardShown } from '../utils/keyboardShown'
 import { scrollSelectionIntoViewWithToolbar } from '../utils/scrollIntoViewWithToolbar'
+import { createSettleLoop } from '../utils/settleLoop'
+
+// How long to keep re-asserting the caret correction after a qualifying
+// keyboard-open resize. Covers the observed ~206 ms native "scroll caret into
+// view" override and the ~275 ms second viewport resize, with margin. Each new
+// resize refreshes this window (handles the two-phase keyboard open).
+const SETTLE_WINDOW_MS = 500
 
 /**
  * Pure decision: should we re-scroll the caret above the keyboard right now?
@@ -21,13 +28,22 @@ export function shouldKeepCaretAboveKeyboard({ keyboardShown, editorFocused }) {
  *
  * Opening the keyboard is a visualViewport *resize*, not a selection change, so
  * none of the selection-driven scroll paths fire. This hook listens to that
- * resize and re-runs the existing toolbar-aware caret scroll once the viewport
- * has settled — reusing the same math the selection paths use, no new geometry.
+ * resize and re-runs the existing toolbar-aware caret scroll — reusing the same
+ * math the selection paths use, no new geometry.
+ *
+ * A single correction is not enough: Chrome fires its own native "scroll caret
+ * into view" ~206 ms *after* our correction (content-dependent — it happens on
+ * plain/bullet text but not inside table cells), which drops the caret back
+ * behind the fixed toolbar. So instead of one run we drive a bounded settle
+ * loop that re-applies the *idempotent* correction every animation frame until
+ * a deadline. Because the correction only scrolls when the caret is actually
+ * hidden (delta !== 0), it overrides the late native scroll on the next frame,
+ * no-ops once the caret is in-band, and self-terminates at the deadline — it
+ * does not fight intentional user panning that keeps the caret visible.
  *
  * The toolbar lift (useMobileToolbarTransform) is also rAF-scheduled off the
- * same resize event; we use a second rAF before measuring so the toolbar's
- * transform write lands first and getToolbarSafeBounds reads its lifted rect.
- * This mirrors the double-rAF convention in useKeepCursorVisible / EditorPanel.
+ * same resize event; running every frame means the toolbar's lifted transform
+ * is read on subsequent ticks, so getToolbarSafeBounds sees its settled rect.
  *
  * No-ops on desktop / non-touch (`enabled` false) or where visualViewport is
  * absent.
@@ -47,10 +63,12 @@ export function useKeepCaretAboveKeyboard({
     const viewport = window.visualViewport
     if (!viewport) return
 
-    let rafId = null
+    let loop = null
 
-    const run = () => {
-      rafId = null
+    // One frame of work: re-measure the live toolbar + caret rects and scroll
+    // only if the caret is hidden. Idempotent, so re-running it across the
+    // settle window is safe (no-op once the caret is in-band).
+    const tick = () => {
       const editorFocused = Boolean(editor.view?.hasFocus?.())
       if (!shouldKeepCaretAboveKeyboard({ keyboardShown: isKeyboardShown(), editorFocused })) {
         return
@@ -68,19 +86,21 @@ export function useKeepCaretAboveKeyboard({
     }
 
     // Listen to resize only — `scroll` is the user panning, which we must not
-    // fight. Coalesce bursts with a first rAF; a second rAF lets the toolbar
-    // transform (also rAF-scheduled off this resize) settle before we measure.
+    // fight. Each qualifying resize opens (or refreshes) a settle window during
+    // which `tick` re-runs every frame, so a late native scroll gets corrected
+    // on the next frame.
     const schedule = () => {
-      if (rafId !== null) return
-      rafId = requestAnimationFrame(() => {
-        rafId = requestAnimationFrame(run)
-      })
+      if (loop) {
+        loop.refresh()
+        return
+      }
+      loop = createSettleLoop({ durationMs: SETTLE_WINDOW_MS, onTick: tick })
     }
 
     viewport.addEventListener('resize', schedule)
 
     return () => {
-      if (rafId !== null) cancelAnimationFrame(rafId)
+      if (loop) loop.cancel()
       viewport.removeEventListener('resize', schedule)
     }
   }, [enabled, editor, toolbarRef, editorPanelRef, padding])

--- a/src/utils/__tests__/scrollIntoViewWithToolbar.test.js
+++ b/src/utils/__tests__/scrollIntoViewWithToolbar.test.js
@@ -275,6 +275,94 @@ describe('scrollRectIntoViewWithToolbar', () => {
     }
   })
 
+  it('uses the visual viewport band (offset + height) for the window surface', () => {
+    const originalWindow = globalThis.window
+    const scrollCalls = []
+    // Keyboard open: layout innerHeight is still 852, but the visual viewport
+    // has shrunk to height 560 starting at offsetTop 0. The bottom toolbar sits
+    // at the top of the keyboard. The surface must follow the visual viewport,
+    // not innerHeight, so the toolbar lands in the lower half and is treated as
+    // a bottom obstruction.
+    globalThis.window = {
+      innerHeight: 852,
+      visualViewport: { offsetTop: 0, height: 560 },
+      scrollBy: (opts) => scrollCalls.push(opts),
+    }
+
+    try {
+      const toolbarEl = {
+        getBoundingClientRect: () => ({ top: 480, bottom: 560, height: 80 }),
+      }
+      // Caret tucked behind the toolbar (top 500 > safeBottom-padding).
+      const delta = scrollRectIntoViewWithToolbar({
+        rect: { top: 500, bottom: 520 },
+        toolbarEl,
+        padding: 16,
+      })
+
+      // surfaceBottom = 0 + 560 = 560; safeBottom = toolbar top 480;
+      // bottomEdge = 480 - 16 = 464; cursorBottom 520 > 464 → delta 520 - 464 = 56
+      expect(delta).toBe(56)
+      expect(scrollCalls).toEqual([{ top: 56, behavior: 'instant' }])
+    } finally {
+      globalThis.window = originalWindow
+    }
+  })
+
+  it('honors visualViewport offsetTop (pinch-zoom pan) as the surface top', () => {
+    const originalWindow = globalThis.window
+    const scrollCalls = []
+    globalThis.window = {
+      innerHeight: 852,
+      visualViewport: { offsetTop: 100, height: 600 },
+      scrollBy: (opts) => scrollCalls.push(opts),
+    }
+
+    try {
+      // No toolbar; a caret above the panned-in top edge (offsetTop 100) must
+      // scroll up into view.
+      const delta = scrollRectIntoViewWithToolbar({
+        rect: { top: 90, bottom: 110 },
+        toolbarEl: null,
+        padding: 16,
+      })
+
+      // safeTop = 100; topEdge = 116; cursorTop 90 < 116 → delta 90 - 116 = -26
+      expect(delta).toBe(-26)
+      expect(scrollCalls).toEqual([{ top: -26, behavior: 'instant' }])
+    } finally {
+      globalThis.window = originalWindow
+    }
+  })
+
+  it('falls back to innerHeight when visualViewport is absent', () => {
+    const originalWindow = globalThis.window
+    const scrollCalls = []
+    // No visualViewport on the mock → desktop / existing-test path.
+    globalThis.window = {
+      innerHeight: 900,
+      scrollBy: (opts) => scrollCalls.push(opts),
+    }
+
+    try {
+      const toolbarEl = {
+        getBoundingClientRect: () => ({ top: 720, bottom: 852, height: 132 }),
+      }
+      const delta = scrollRectIntoViewWithToolbar({
+        rect: { top: 762, bottom: 807 },
+        toolbarEl,
+        padding: 20,
+      })
+
+      // surfaceBottom = innerHeight 900; safeBottom = 720; bottomEdge = 700;
+      // cursorBottom 807 > 700 → delta 107
+      expect(delta).toBe(107)
+      expect(scrollCalls).toEqual([{ top: 107, behavior: 'instant' }])
+    } finally {
+      globalThis.window = originalWindow
+    }
+  })
+
   it('is a no-op when the target is already comfortably visible', () => {
     const originalWindow = globalThis.window
     const scrollCalls = []

--- a/src/utils/__tests__/settleLoop.test.js
+++ b/src/utils/__tests__/settleLoop.test.js
@@ -1,0 +1,146 @@
+import { describe, it, expect } from 'vitest'
+import { createSettleLoop } from '../settleLoop'
+
+// A fake clock + manual rAF queue so we can drive the bounded settle loop
+// deterministically: `now` is advanced by hand, `raf` records the next callback,
+// and `flush` runs the pending frame (optionally advancing the clock first).
+function makeHarness() {
+  let time = 0
+  let pending = null
+  let nextId = 1
+  const cancelled = []
+
+  const raf = (cb) => {
+    pending = cb
+    return nextId++
+  }
+  const caf = (id) => {
+    cancelled.push(id)
+    pending = null
+  }
+  const now = () => time
+
+  return {
+    now,
+    raf,
+    caf,
+    cancelled,
+    advance(ms) {
+      time += ms
+    },
+    // Run the currently-scheduled frame, advancing the clock by `dt` first.
+    flush(dt = 16) {
+      time += dt
+      const cb = pending
+      pending = null
+      if (cb) cb()
+    },
+    hasPending() {
+      return pending !== null
+    },
+  }
+}
+
+describe('createSettleLoop', () => {
+  it('ticks every frame across the window then stops at the deadline', () => {
+    const h = makeHarness()
+    let ticks = 0
+    createSettleLoop({
+      durationMs: 50,
+      onTick: () => ticks++,
+      now: h.now,
+      raf: h.raf,
+      caf: h.caf,
+    })
+
+    // Frames at t=16, 32, 48 are all before the 50ms deadline → keep going.
+    h.flush(16)
+    h.flush(16)
+    h.flush(16)
+    expect(ticks).toBe(3)
+    expect(h.hasPending()).toBe(true)
+
+    // Frame at t=64 runs its tick, then sees now >= deadline → stops.
+    h.flush(16)
+    expect(ticks).toBe(4)
+    expect(h.hasPending()).toBe(false)
+  })
+
+  it('refresh extends the deadline so ticking continues past the original window', () => {
+    const h = makeHarness()
+    let ticks = 0
+    const loop = createSettleLoop({
+      durationMs: 50,
+      onTick: () => ticks++,
+      now: h.now,
+      raf: h.raf,
+      caf: h.caf,
+    })
+
+    h.flush(16) // t=16
+    h.flush(16) // t=32
+
+    // A new resize at t=32 refreshes the deadline to t=82.
+    loop.refresh()
+
+    h.flush(16) // t=48 — would have been past old 50? no, but keeps going
+    h.flush(16) // t=64 — past original 50ms deadline, still ticks thanks to refresh
+    expect(ticks).toBe(4)
+    expect(h.hasPending()).toBe(true)
+
+    // Now let it run out the refreshed window (deadline t=82).
+    h.flush(16) // t=80 — still before 82
+    expect(ticks).toBe(5)
+    expect(h.hasPending()).toBe(true)
+    h.flush(16) // t=96 — past 82 → stops
+    expect(ticks).toBe(6)
+    expect(h.hasPending()).toBe(false)
+  })
+
+  it('refresh restarts the loop after it has already settled', () => {
+    const h = makeHarness()
+    let ticks = 0
+    const loop = createSettleLoop({
+      durationMs: 30,
+      onTick: () => ticks++,
+      now: h.now,
+      raf: h.raf,
+      caf: h.caf,
+    })
+
+    h.flush(40) // t=40 — past 30ms deadline → loop stops
+    expect(ticks).toBe(1)
+    expect(h.hasPending()).toBe(false)
+
+    // A later resize should kick the loop back off.
+    loop.refresh()
+    expect(h.hasPending()).toBe(true)
+    h.flush(16) // t=56 — before new deadline t=70
+    expect(ticks).toBe(2)
+    expect(h.hasPending()).toBe(true)
+  })
+
+  it('cancel stops the loop and cancels the pending frame', () => {
+    const h = makeHarness()
+    let ticks = 0
+    const loop = createSettleLoop({
+      durationMs: 100,
+      onTick: () => ticks++,
+      now: h.now,
+      raf: h.raf,
+      caf: h.caf,
+    })
+
+    h.flush(16)
+    expect(ticks).toBe(1)
+
+    loop.cancel()
+    expect(h.cancelled.length).toBe(1)
+    expect(h.hasPending()).toBe(false)
+
+    // refresh after cancel is a no-op; no further ticks.
+    loop.refresh()
+    expect(h.hasPending()).toBe(false)
+    expect(ticks).toBe(1)
+  })
+})

--- a/src/utils/scrollIntoViewWithToolbar.js
+++ b/src/utils/scrollIntoViewWithToolbar.js
@@ -73,7 +73,18 @@ export function pickScrollSurface(container) {
   }
   return {
     scrollBy: ({ top }) => window.scrollBy({ top, behavior: 'instant' }),
-    getRect: () => ({ top: 0, bottom: window.innerHeight }),
+    // Prefer the visual viewport so the surface shrinks to the keyboard's top
+    // edge: vv.offsetTop/height are in the same client-coordinate space as
+    // getBoundingClientRect() and coordsAtPos(), so caret, toolbar, and surface
+    // rects all agree (offsetTop also accounts for pinch-zoom pan). A shrunken
+    // surface keeps the bottom toolbar reliably in the lower half so the
+    // getToolbarSafeBounds center heuristic can't flip and misclassify it.
+    // Desktop / environments without visualViewport fall back to innerHeight.
+    getRect: () => {
+      const vv = typeof window !== 'undefined' ? window.visualViewport : null
+      if (vv) return { top: vv.offsetTop, bottom: vv.offsetTop + vv.height }
+      return { top: 0, bottom: window.innerHeight }
+    },
   }
 }
 

--- a/src/utils/settleLoop.js
+++ b/src/utils/settleLoop.js
@@ -1,0 +1,66 @@
+/**
+ * Bounded animation-frame loop with a refreshable deadline.
+ *
+ * Used to re-assert a correction (e.g. keeping the caret above the keyboard)
+ * every frame for a short settle window after a triggering event, so a late
+ * native browser scroll that fires *after* our first correction still gets
+ * overridden on the next frame.
+ *
+ * The loop runs `onTick` every animation frame until `now()` passes the
+ * deadline (`start + durationMs`). Calling `refresh()` pushes the deadline out
+ * by another `durationMs` from the current time — used when a new triggering
+ * event (e.g. a second viewport resize) arrives mid-settle. `cancel()` stops it.
+ *
+ * All timing primitives are injected so the loop can be unit-tested with a fake
+ * clock. Defaults wire up to the real browser globals.
+ *
+ * @param {{
+ *   durationMs: number,
+ *   onTick: () => void,
+ *   now?: () => number,
+ *   raf?: (cb: () => void) => number,
+ *   caf?: (id: number) => void,
+ * }} params
+ * @returns {{ refresh: () => void, cancel: () => void }}
+ */
+export function createSettleLoop({
+  durationMs,
+  onTick,
+  now = () => Date.now(),
+  raf = (cb) => requestAnimationFrame(cb),
+  caf = (id) => cancelAnimationFrame(id),
+}) {
+  let deadline = now() + durationMs
+  let frameId = null
+  let cancelled = false
+
+  const tick = () => {
+    frameId = null
+    if (cancelled) return
+    onTick()
+    // Re-check after the tick: onTick may have taken time, and refresh() may
+    // have extended the deadline. Stop once we're past it.
+    if (now() >= deadline) return
+    frameId = raf(tick)
+  }
+
+  frameId = raf(tick)
+
+  return {
+    refresh() {
+      if (cancelled) return
+      deadline = now() + durationMs
+      // Restart the frame loop if it had already settled and stopped.
+      if (frameId === null) {
+        frameId = raf(tick)
+      }
+    },
+    cancel() {
+      cancelled = true
+      if (frameId !== null) {
+        caf(frameId)
+        frameId = null
+      }
+    },
+  }
+}


### PR DESCRIPTION
## Problem

On mobile, tapping a bullet near the bottom of a plain/bullet page opens the keyboard and leaves the caret **behind the collapsed bottom toolbar**. The tracker page was unaffected.

An on-device Chrome DevTools trace (read-only, over ADB) proved the mechanism, and ruled out two earlier guesses:
- *Not* a lack of scroll room (`scrollHeight 1640` vs `clientHeight 821`).
- *Not* the toolbar-aware math — it computed the **correct** delta.

What actually happens on a plain page:
1. Keyboard opens → one `visualViewport` resize.
2. Our toolbar-aware correction runs → `scrollBy(+302.9)`; caret is correctly **above** the toolbar.
3. **~206 ms later, Chrome fires its own native "scroll caret into view"** (a plain `scroll`, not an API call) → scrollY `302.9 → 243`, dropping the caret behind our fixed toolbar.
4. The hook listened to viewport **resize only**, so the late native **scroll** never got a second correction.

The native scroll is **content-dependent** — Chrome does *not* fire it inside a table cell, which is why the tracker page was *accidentally* safe. We can't rely on its absence, so our correction must be authoritative.

## Fix

Two changes, both reusing the existing shared scroll math (`pickScrollSurface` + `getToolbarSafeBounds` + `computeScrollAdjustment`):

### 1. Settle loop replacing the single run — `useKeepCaretAboveKeyboard.js`
On a qualifying resize (keyboard shown + editor focused), re-run the **idempotent** correction every animation frame until a ~500 ms deadline (each new resize refreshes it, handling the two-phase keyboard open). The correction only scrolls when the caret is actually hidden (`delta !== 0`), so it:
- overrides Chrome's late native scroll on the next frame, for *all* content types;
- self-terminates at the deadline;
- does not fight user panning that keeps the caret visible (no-op when in-band).

Because it re-runs every frame instead of hardcoding the observed 206 ms, it's robust to Chrome changing the timing and harmless if Chrome ever stops firing the override. Scheduling is extracted into `createSettleLoop` (`settleLoop.js`) and unit-tested with a fake clock.

### 2. visualViewport-aware window scroll surface — `scrollIntoViewWithToolbar.js`
`pickScrollSurface()`'s window fallback now uses the **visual viewport** (`offsetTop` / `height`) instead of full `innerHeight`, so the surface shrinks to the keyboard's top edge. This keeps the bottom toolbar reliably in the lower half so `getToolbarSafeBounds`' center heuristic can't flip and misclassify it on a tall keyboard / short phone / expanded toolbar (a secondary risk seen in the trace numbers). Desktop and environments without `visualViewport` fall back to `innerHeight` unchanged.

## Research note

No shipped browser standard solves the "caret behind a fixed toolbar after the keyboard opens" case — the relevant CSS WG issue ([w3c/csswg-drafts#7475](https://github.com/w3c/csswg-drafts/issues/7475)) is still open. Manual Visual Viewport handling is the documented current workaround. This implementation is deliberately defensive/idempotent so it self-neutralizes if Chrome ever fixes the root cause.

## Test plan

- [x] `npm run test:unit` — 379 passed, including new visualViewport-surface cases and the fake-clock settle-loop tests. Existing window-mock tests (no `visualViewport`) exercise the fallback branch and stay green.
- [x] ESLint clean on all changed files.
- [ ] **On-device (primary), user-driven, read-only instrumentation:**
  - Plain bullet page, scroll to top, tap a bottom bullet → caret lands and **stays** above the toolbar; trace shows the correction re-applied after the native scroll.
  - Repeat with the **toolbar expanded**.
  - Tracker/table page → still lands above the toolbar (no regression).
  - Tap-to-move caret with keyboard already open, plus a quick pan right after opening, to confirm we don't fight intentional scrolling.
  - Clean up instrumentation afterward.
- [ ] Desktop sanity: no behavior change (no visualViewport keyboard; hooks gated off).