### PR TITLE
feat: default Telegram tracker adds to bullets at bottom of section

### DIFF
--- a/supabase/functions/telegram-bot/prompt.test.ts
+++ b/supabase/functions/telegram-bot/prompt.test.ts
@@ -34,6 +34,14 @@ describe('buildSystemPrompt', () => {
     expect(base).toContain('coming up very soon')
   })
 
+  it('defaults additions to plain bullets at the bottom of the section', () => {
+    const base = buildSystemPrompt(false)
+    // New items default to plain bullets, not checkboxes.
+    expect(base).toContain('Default to a plain bullet list')
+    // And land at the bottom of the section they belong to.
+    expect(base).toContain('BOTTOM of the section')
+  })
+
   it('omits the date anchor when no nowDisplay is given', () => {
     expect(buildSystemPrompt(true)).not.toContain('current local date and time')
     expect(buildSystemPrompt(false)).not.toContain('current local date and time')

--- a/supabase/functions/telegram-bot/prompt.ts
+++ b/supabase/functions/telegram-bot/prompt.ts
@@ -32,6 +32,16 @@ Adding things to the tracker:
   read_tracker_structure to see the tracker with {{id:…}} anchors, then call
   propose_tracker_addition with a real targetBlockId. That tool shows the user a preview
   screenshot of the new item highlighted in place — it does NOT save anything.
+- Default to a plain bullet list (format "bullet_list"). Only use a checkbox/task list when
+  the user explicitly asks for a checklist, to-do, or checkboxes — even if the target section
+  already uses checkboxes, a new plain item is a bullet unless they asked otherwise.
+- Place new items at the BOTTOM of the section they belong to. The user writes
+  chronologically, oldest at top / newest at bottom, so a new item goes at the end of its
+  category/section's list — not the top, and not blindly at the end of the whole tracker.
+  Only fall back to the end of the tracker when no section fits.
+- Some sections are an ongoing sequence of notes; "the bottom" means the bottom of that
+  sequence, which can sit mid-document. Picking the best-fitting spot is your job — read the
+  structure and choose where the item naturally continues.
 - When an added item has a key date worth flagging — a deadline, event, or time, the way you
   see the user's own dates highlighted as [date]{highlight:#67e8f9} when you read the tracker —
   wrap ONLY the date itself in a {{date:…}} token. Highlight just the date (a numeric M/D, plus a

--- a/supabase/functions/telegram-bot/tools.ts
+++ b/supabase/functions/telegram-bot/tools.ts
@@ -45,14 +45,27 @@ const PLACEMENT_RULES =
   'How to choose the anchor and placement (ported from the app\'s AI-insert rules):\n' +
   '- targetBlockId MUST be one of the {{id:…}} markers from read_tracker_structure. ' +
   'Never invent an id. If no good anchor exists, omit it (the items go at the end).\n' +
+  '- Default placement = the BOTTOM of the section the item belongs to. The user writes ' +
+  'oldest-at-top / newest-at-bottom, so a new item continues at the end of its section.\n' +
   '- placement "append_to_list": targetBlockId is a list (its {{id:…}} sits on its own ' +
-  'line right after the bullets/tasks). Use this to add lines to an EXISTING list — pick ' +
-  'the format (task_list vs bullet_list) that matches that list.\n' +
-  '- placement "after_block": targetBlockId is a heading, paragraph, or table cell line. ' +
-  'The new content is inserted right after it. Use this to start a new list/paragraph under ' +
-  'a category heading or after a specific line.\n' +
-  '- format: "task_list" for checklist/to-do items, "bullet_list" for plain bullets, ' +
-  '"paragraphs" for prose. items are concise plain-text lines (no markdown, no ids).'
+  'line right after the bullets/tasks). This appends to the BOTTOM of that list and keeps ' +
+  'one clean list. PREFER this when the section\'s existing list is already bullets — anchor ' +
+  'on that list so the new bullet lands at the bottom of the section.\n' +
+  '- Bullet-into-a-checkbox-section case: append_to_list forces new items to match the ' +
+  'target list\'s type, so appending into a task/checkbox list always yields checkboxes. ' +
+  'If the section\'s existing list is a checkbox/task list and the user did NOT ask for a ' +
+  'checkbox, use placement "after_block" anchored on the LAST line of that list with ' +
+  'format "bullet_list", so the bullet lands at the bottom of the section as its own plain ' +
+  'bullet. This is the one spot where after_block + bullet_list beats append_to_list.\n' +
+  '- placement "after_block": targetBlockId is a heading, paragraph, table cell, or list ' +
+  'line. The new content is inserted right after it. Use this to start a new list/paragraph ' +
+  'under a category heading, or (per the case above) to add a plain bullet after the last ' +
+  'line of a checkbox list.\n' +
+  '- format: default "bullet_list" for plain bullets, "task_list" only when the user ' +
+  'explicitly asks for a checklist/to-do/checkboxes, "paragraphs" for prose. items are ' +
+  'concise plain-text lines (no markdown, no ids).\n' +
+  '- Last resort: if no section fits, omit targetBlockId and the items go to the end of ' +
+  'the tracker.'
 
 /**
  * Build the tool registry bound to the single known user. The Supabase client
@@ -111,6 +124,11 @@ export function buildTools(
           format: {
             type: 'string',
             enum: ['bullet_list', 'task_list', 'paragraphs'],
+            description:
+              'Default to "bullet_list" — the user almost always adds plain bullets. Use ' +
+              '"task_list" ONLY when the user explicitly asks for a checklist, to-do, or ' +
+              'checkboxes (even if the target section already uses checkboxes). Use ' +
+              '"paragraphs" for prose.',
           },
           items: {
             type: 'array',


### PR DESCRIPTION
## Summary

Tunes the Telegram add-to-tracker prompt so the bot matches how the user actually writes their tracker:

- **Bullets by default** — new items are plain `bullet_list`; checkboxes (`task_list`) only when the user explicitly asks for a checklist/to-do, even if the target section already uses checkboxes.
- **Bottom-of-section placement** — the user writes chronologically (oldest at top / newest at bottom), so a new item lands at the bottom of the section it relates to, falling back to the end of the tracker only when no section fits.

This is a **prompt-only change** — no engine/logic changes. The insertion mechanics (`append_to_list`, `after_block`) already support all of this.

## Changes

- **`prompt.ts`** — Added bullet-default + bottom-of-section guidance (incl. the sequential-notes nuance) to the "Adding things to the tracker:" block.
- **`tools.ts`** —
  - `format` enum now documents `bullet_list` as the default; `task_list` is explicit opt-in.
  - `PLACEMENT_RULES` reframed around "bottom of the relevant section." Added the bullet-into-a-checkbox-section case: use `after_block` + `bullet_list` on the last list line, since `append_to_list` would coerce the new item into a checkbox (`coerceItemsToListType`). Kept omit-`targetBlockId` → end-of-tracker as last resort.
- **`prompt.test.ts`** — New assertion locking in the bullet default and bottom-of-section placement intent.

## Out of scope

No changes to `insertContent.ts`, `sectionTitle.ts`, `capture.ts`, the render pipeline, or date-highlighting rules.

## Test plan

- [x] `npm run test:unit` — 380 passing, including the new assertion
- [x] Edge function deployed to Supabase (`npx supabase functions deploy telegram-bot`)
- [ ] Manual end-to-end via Telegram (user drives):
  - "add buy more gels to running" → bullet at the bottom of Running
  - plain add into a checkbox section → previews as a bullet at the bottom (not a checkbox)
  - "add a checklist item …" / "add a to-do …" → checkbox (explicit opt-in still works)
  - item belonging to a sequential notes section → lands at the bottom of that sequence