### PR TITLE
fix: scroll find Next/Prev to the current match (desktop + mobile)

### DIFF
--- a/src/extensions/findInDoc.js
+++ b/src/extensions/findInDoc.js
@@ -1,10 +1,7 @@
 import { Extension } from '@tiptap/core'
 import { Plugin, PluginKey, Selection, TextSelection } from '@tiptap/pm/state'
 import { Decoration, DecorationSet } from '@tiptap/pm/view'
-import {
-  scrollElementIntoViewWithToolbar,
-  scrollRectIntoViewWithToolbar,
-} from '../utils/scrollIntoViewWithToolbar'
+import { scrollElementIntoViewWithToolbar } from '../utils/scrollIntoViewWithToolbar'
 
 export const findInDocPluginKey = new PluginKey('findInDoc')
 
@@ -24,79 +21,54 @@ const selectionForMatch = (doc, match, mode) => {
   return TextSelection.create(doc, match.from, match.to)
 }
 
-const scrollAiMatchIntoView = (view, match) => {
-  if (!view || !match) return
-  const resolveElement = () => {
-    const nodeDom = view.nodeDOM?.(match.from)
-    const elementNode = globalThis.Node?.ELEMENT_NODE ?? 1
-    if (nodeDom?.nodeType === elementNode) return nodeDom
+// Scroll the rendered current-match element to the vertical center of the
+// editor's safe band. Find navigation runs while the find input/button is
+// focused (the editor is blurred), so the editor's own handleScrollToSelection
+// override never fires for a dispatched .scrollIntoView(). This helper scrolls
+// the DOM element carrying the `.current` decoration directly — focus-
+// independent — routed through the same toolbar/keyboard-aware util the
+// deep-link feature uses (so mobile lands the match above the lifted toolbar).
+//
+// Mobile robustness: mirror scrollToBlock's settle pattern
+// (navigationHelpers.js) — schedule via double requestAnimationFrame, then
+// re-assert at ~80ms and ~200ms so our scroll wins against Chrome's late native
+// scroll when the keyboard is open. The decoration re-renders each navigation,
+// so we re-query the `.current` element on every attempt.
+const scrollCurrentMatchIntoView = (view) => {
+  if (!view?.dom) return
 
-    const inside = Math.min(match.from + 1, match.to - 1, view.state.doc.content.size)
-    const domAtPos = view.domAtPos?.(inside)?.node
-    if (domAtPos?.nodeType === elementNode) return domAtPos
-    return domAtPos?.parentElement ?? null
+  const runScroll = () => {
+    const element = view.dom.querySelector('.find-match.current, .ai-find-match.current')
+    if (!element?.getBoundingClientRect) return
+    const container = view.dom.closest('.editor-panel') ?? null
+    const toolbarEl =
+      container?.querySelector('.toolbar') ??
+      (typeof document !== 'undefined' ? document.querySelector('.toolbar') : null)
+    scrollElementIntoViewWithToolbar({
+      element,
+      container,
+      toolbarEl,
+      padding: 20,
+      align: 'center',
+    })
+  }
+
+  const safeRun = () => {
+    try {
+      runScroll()
+    } catch (error) {
+      // A transient DOM lookup failure must never break find navigation. Surface
+      // it in dev so unexpected failures don't stay silently swallowed.
+      if (import.meta.env?.DEV) {
+        console.error('[findInDoc] scrollCurrentMatchIntoView failed', error)
+      }
+    }
   }
 
   const schedule = globalThis.requestAnimationFrame ?? ((callback) => setTimeout(callback, 0))
-  schedule(() => {
-    try {
-      const element = resolveElement()
-      const target = element?.closest?.('[id]') ?? element
-      if (!target?.getBoundingClientRect) return
-
-      const container = view.dom?.closest?.('.editor-panel') ?? null
-      const toolbarEl =
-        container?.querySelector?.('.toolbar') ??
-        (typeof document !== 'undefined' ? document.querySelector('.toolbar') : null)
-      scrollElementIntoViewWithToolbar({
-        element: target,
-        container,
-        toolbarEl,
-        padding: 20,
-        align: 'center',
-      })
-    } catch {
-      // Selection-based scrolling has already run. This fallback must never
-      // break find state if a transient DOM lookup fails.
-    }
-  })
-}
-
-// Explicitly scroll a literal substring match to the vertical center of the
-// editor's safe band. Find navigation runs while the find button is focused
-// (the editor is blurred), so the editor's own handleScrollToSelection override
-// never fires for the dispatched .scrollIntoView(). This helper does the scroll
-// itself — focus-independent — using coordsAtPos for the match range. Scheduled
-// via requestAnimationFrame so it runs after the transaction has applied and
-// the decorations/selection are laid out.
-const scrollLiteralMatchIntoView = (view, match) => {
-  if (!view?.coordsAtPos || !match) return
-  const schedule = globalThis.requestAnimationFrame ?? ((callback) => setTimeout(callback, 0))
-  schedule(() => {
-    try {
-      const fromCoords = view.coordsAtPos(match.from)
-      const toCoords = view.coordsAtPos(match.to)
-      const rect = {
-        top: Math.min(fromCoords.top, toCoords.top),
-        bottom: Math.max(fromCoords.bottom, toCoords.bottom),
-      }
-
-      const container = view.dom?.closest?.('.editor-panel') ?? null
-      const toolbarEl =
-        container?.querySelector?.('.toolbar') ??
-        (typeof document !== 'undefined' ? document.querySelector('.toolbar') : null)
-      scrollRectIntoViewWithToolbar({
-        rect,
-        container,
-        toolbarEl,
-        padding: 20,
-        align: 'center',
-      })
-    } catch {
-      // The dispatched .scrollIntoView() has already run as a fallback. A
-      // transient coordsAtPos failure must never break find navigation.
-    }
-  })
+  schedule(() => schedule(safeRun))
+  setTimeout(safeRun, 80)
+  setTimeout(safeRun, 200)
 }
 
 const normalizeQuery = (input) => {
@@ -215,10 +187,10 @@ const FindInDoc = Extension.create({
           })
           if (matches.length > 0) {
             const { from, to } = matches[0]
-            nextTr.setSelection(TextSelection.create(state.doc, from, to)).scrollIntoView()
+            nextTr.setSelection(TextSelection.create(state.doc, from, to))
           }
           dispatch(nextTr)
-          if (matches.length > 0) scrollLiteralMatchIntoView(view, matches[0])
+          if (matches.length > 0) scrollCurrentMatchIntoView(view)
           return true
         },
       // AI find supplies whole-block ranges (resolved from matching block ids)
@@ -236,12 +208,10 @@ const FindInDoc = Extension.create({
             index,
           })
           if (matches.length > 0) {
-            nextTr
-              .setSelection(selectionForMatch(state.doc, matches[0], 'ai'))
-              .scrollIntoView()
+            nextTr.setSelection(selectionForMatch(state.doc, matches[0], 'ai'))
           }
           dispatch(nextTr)
-          scrollAiMatchIntoView(view, matches[0])
+          if (matches.length > 0) scrollCurrentMatchIntoView(view)
           return true
         },
       clearFind:
@@ -263,10 +233,8 @@ const FindInDoc = Extension.create({
           const nextTr = tr
             .setMeta(findInDocPluginKey, { index: nextIndex })
             .setSelection(selectionForMatch(state.doc, matches[nextIndex], pluginState?.mode))
-            .scrollIntoView()
           dispatch(nextTr)
-          if (pluginState?.mode === 'ai') scrollAiMatchIntoView(view, matches[nextIndex])
-          else scrollLiteralMatchIntoView(view, matches[nextIndex])
+          scrollCurrentMatchIntoView(view)
           return true
         },
       findPrev:
@@ -281,10 +249,8 @@ const FindInDoc = Extension.create({
           const nextTr = tr
             .setMeta(findInDocPluginKey, { index: nextIndex })
             .setSelection(selectionForMatch(state.doc, matches[nextIndex], pluginState?.mode))
-            .scrollIntoView()
           dispatch(nextTr)
-          if (pluginState?.mode === 'ai') scrollAiMatchIntoView(view, matches[nextIndex])
-          else scrollLiteralMatchIntoView(view, matches[nextIndex])
+          scrollCurrentMatchIntoView(view)
           return true
         },
     }


### PR DESCRIPTION
## Problem

Find-in-page highlighted matches and advanced the Prev/Next counter, but **the view never scrolled to the current match**. With the editor scrolled up, matches could sit thousands of px below the fold, so nothing appeared to move.

Root cause (confirmed via live trace last session): find runs while the find input/button holds focus (editor blurred), so the transaction's `.scrollIntoView()` → `handleScrollToSelection` path is intentionally dead. The only fallback — `scrollLiteralMatchIntoView` / `scrollAiMatchIntoView` — computed geometry via `coordsAtPos` / `domAtPos` inside an empty `catch {}`. That passed in headless CI but **silently failed on the live app**: `scrollBy` was never called and no error surfaced.

## Fix

Collapse the two fragile, focus-dependent helpers into **one DOM-element scroll** keyed off the rendered `.current` decoration — the same approach the docmost/notesnook reference editors use, and the same util the shipped deep-link feature already uses live.

- **New `scrollCurrentMatchIntoView(view)`** — queries `.find-match.current` / `.ai-find-match.current`, resolves container/toolbar exactly like the deep-link path, and scrolls centered via `scrollElementIntoViewWithToolbar`. Mirrors `scrollToBlock`'s settle pattern (double `rAF`, re-assert at 80ms and 200ms) so the scroll wins against Chrome's late native scroll on mobile. Failures now `console.error` in dev instead of being swallowed.
- **Rewired** `setFindQuery`, `setAiMatches`, `findNext`, `findPrev`: keep `setSelection`, drop the dead `.scrollIntoView()` chain, call `scrollCurrentMatchIntoView` after dispatch.
- **Deleted** `scrollLiteralMatchIntoView` and `scrollAiMatchIntoView`; dropped the unused `scrollRectIntoViewWithToolbar` import.
- `handleScrollToSelection` (typing/arrows/deep-link) untouched.

Net: **+49 / −83 lines** in `src/extensions/findInDoc.js`.

## Why this works on mobile

`scrollElementIntoViewWithToolbar` already branches correctly: on mobile `.editor-panel` is `overflow-y: visible`, so it falls back to the window + visualViewport safe band and treats the fixed bottom toolbar (lifted above the keyboard) as a bottom-obstruction. This is the identical call the deep-link feature makes — not native `scrollIntoView()`, which would drop matches behind the keyboard/toolbar.

## Test plan

- [x] `npm run test:unit` — 380 pass
- [x] ESLint clean on the edited file
- [x] Existing E2E in `e2e/ai-find.spec.js` already asserts the current match scrolls into the viewport after Next/Prev (literal top-only seed, mobile toolbar, desktop sticky toolbar, AI table-cell) — runs on both viewport projects in CI
- [ ] Live verify on phone: Next/Prev with keyboard open lands the match above the lifted toolbar
- [ ] Live verify on desktop: Next/Prev/wrap-around centers the match below the sticky toolbar

## Note on the silent-failure class

The previous attempt at this bug shipped its E2E test in the same commit as the broken fix; the test passed in headless CI while the live app stayed broken, and the empty `catch {}` hid it. This change removes that silent catch (dev `console.error`) and scrolls the real rendered element instead of recomputing geometry. A console-error guard in the find tests was considered as extra hardening but deferred — current behavioral assertions plus live verification cover it.