### PR TITLE
feat: move highlight button into collapsed mobile toolbar

### DIFF
--- a/src/components/editor/toolbar/toolRegistry.js
+++ b/src/components/editor/toolbar/toolRegistry.js
@@ -62,7 +62,7 @@ export const TOOL_DEFINITIONS = {
  * desktop by the renderer.
  */
 export const CORE_GROUPS = [
-  { id: 'core-inline', tools: ['bold', 'italic', 'strike', 'h1', 'bulletList', 'outdent', 'indent'] },
+  { id: 'core-inline', tools: ['bold', 'italic', 'strike', 'h1', 'highlight', 'bulletList', 'outdent', 'indent'] },
   { id: 'core-find-undo', tools: ['find', 'undo'] },
 ]
 
@@ -71,7 +71,7 @@ export const CORE_GROUPS = [
  * Order is verbatim from the legacy Toolbar.jsx render path.
  */
 export const EXTRA_GROUPS = [
-  { id: 'extra-text', tools: ['underline', 'highlight', 'textColor'] },
+  { id: 'extra-text', tools: ['underline', 'textColor'] },
   { id: 'extra-headings', tools: ['h2', 'orderedList', 'taskList'] },
   { id: 'extra-align', tools: ['alignLeft', 'alignCenter', 'alignRight'] },
   { separator: true, id: 'sep-1' },


### PR DESCRIPTION
## Summary

Highlighting is a frequent action for this workflow (see the date-highlight convention), but the highlight button lived in the hidden "extra" toolbar set. On a phone the toolbar collapses to a single core row, so users had to expand it just to highlight text.

This moves highlight into the always-visible core row, right after H1, so it's reachable without expanding.

## Changes

Single edit in `src/components/editor/toolbar/toolRegistry.js`:
- Added `'highlight'` to the `core-inline` group (immediately after `'h1'`) — rendered in `.toolbar-core`, which keeps `pointer-events: auto` even when collapsed, so no CSS change is needed.
- Removed `'highlight'` from the `extra-text` group so it doesn't render twice when the toolbar is expanded or on desktop.

The `HighlightTool` split button (with its color-picker caret) is reused unchanged.

## Test plan

- [x] `npm run test:unit` — 380 passed
- [ ] Mobile viewport: highlight appears in collapsed core row after H1; tapping highlights selection; color caret opens picker
- [ ] Expanded toolbar (`▾`): highlight not duplicated in extra rows
- [ ] Desktop: highlight works; underline/text-color still present
- [ ] E2E via CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)