### PR TITLE
fix: stop remembered toolbar colors reverting from cursor position

### DIFF
--- a/e2e/persist-toolbar-colors.spec.js
+++ b/e2e/persist-toolbar-colors.spec.js
@@ -29,6 +29,10 @@ const HIGHLIGHT_GREEN_RGB = 'rgb(134, 239, 172)'
 const TEXT_BLUE_RGB = 'rgb(37, 99, 235)'
 // First swatch under "Standard Colors" in the shading picker (#7f1d1d).
 const SHADING_MAROON_RGB = 'rgb(127, 29, 29)'
+// A yellow the tracker uses pervasively for cell shading (#fef08a). Seeded onto
+// a cell to reproduce the "remembered color reverts to the tracker yellow" bug.
+const SHADING_YELLOW_HEX = '#fef08a'
+const SHADING_YELLOW_RGB = 'rgb(254, 240, 138)'
 
 const buildSeedContent = () => ({
   type: 'doc',
@@ -62,6 +66,35 @@ const buildTableSeedContent = () => ({
               type: 'tableCell',
               attrs: { colspan: 1, rowspan: 1 },
               content: [{ type: 'paragraph', content: [{ type: 'text', text: 'Target cell' }] }],
+            },
+          ],
+        },
+      ],
+    },
+  ],
+})
+
+// A single-row, two-cell table where the first cell is already shaded yellow
+// (the color the user uses throughout their tracker) and the second is unshaded.
+const buildPreShadedTableSeedContent = () => ({
+  type: 'doc',
+  content: [
+    {
+      type: 'table',
+      attrs: { id: 'tbl-preshaded-1' },
+      content: [
+        {
+          type: 'tableRow',
+          content: [
+            {
+              type: 'tableCell',
+              attrs: { colspan: 1, rowspan: 1, backgroundColor: SHADING_YELLOW_HEX },
+              content: [{ type: 'paragraph', content: [{ type: 'text', text: 'Yellow cell' }] }],
+            },
+            {
+              type: 'tableCell',
+              attrs: { colspan: 1, rowspan: 1 },
+              content: [{ type: 'paragraph', content: [{ type: 'text', text: 'Empty cell' }] }],
             },
           ],
         },
@@ -147,7 +180,23 @@ test.beforeAll(async () => {
     buildTableSeedContent(),
     3,
   )
-  seedIds = { notebook, section, highlightPage, shortcutPage, textPage, shadingPage }
+  const preShadedPage = await createPage(
+    client,
+    userId,
+    section.id,
+    `${seedLabel} Pre-shaded Page`,
+    buildPreShadedTableSeedContent(),
+    4,
+  )
+  seedIds = {
+    notebook,
+    section,
+    highlightPage,
+    shortcutPage,
+    textPage,
+    shadingPage,
+    preShadedPage,
+  }
 })
 
 test.afterAll(async () => {
@@ -292,6 +341,40 @@ test('shading color persists across reload and the main button toggles a differe
   await expect(async () => {
     expect(await readCellColor(page, 'Target cell')).toBe('rgba(0, 0, 0, 0)')
   }).toPass({ timeout: 5000 })
+
+  await expect(page.locator('.shading-control .toolbar-color-bar')).toHaveCSS(
+    'background-color',
+    SHADING_MAROON_RGB,
+  )
+})
+
+test('remembered shading color is not clobbered by moving the cursor into a shaded cell', async ({
+  page,
+  isMobile,
+}) => {
+  test.skip(isMobile, 'Desktop-only: shading caret lives in the collapsed extra group on touch')
+
+  await waitForApp(page, seedHash(seedIds.preShadedPage), { expectedText: 'Yellow cell' })
+  await page.waitForSelector('.ProseMirror[contenteditable="true"]', { timeout: 10000 })
+
+  // The seed cell renders with its pervasive tracker yellow.
+  await expect(async () => {
+    expect(await readCellColor(page, 'Yellow cell')).toBe(SHADING_YELLOW_RGB)
+  }).toPass({ timeout: 5000 })
+
+  // From the *unshaded* cell, pick a different color (first Standard swatch).
+  await page.locator('.ProseMirror td', { hasText: 'Empty cell' }).first().click()
+  await page.getByRole('button', { name: 'Shading colors' }).click()
+  await page.getByRole('button', { name: 'Standard color 1', exact: true }).click()
+  await expect(page.locator('.shading-control .toolbar-color-bar')).toHaveCSS(
+    'background-color',
+    SHADING_MAROON_RGB,
+  )
+
+  // Move the cursor into the yellow cell. Regression (#154 gap): cursor position
+  // must NOT overwrite the remembered pick — the swatch should stay maroon, not
+  // revert to the tracker's yellow.
+  await page.locator('.ProseMirror td', { hasText: 'Yellow cell' }).first().click()
 
   await expect(page.locator('.shading-control .toolbar-color-bar')).toHaveCSS(
     'background-color',

--- a/src/components/EditorPanel.jsx
+++ b/src/components/EditorPanel.jsx
@@ -75,9 +75,7 @@ function EditorPanel({
     contextMenu, setContextMenu,
     submenuOpen, setSubmenuOpen,
     submenuDirection, setSubmenuDirection,
-    highlightColor, setHighlightColor,
-    setShadingColor,
-    setTextColor,
+    highlightColor,
     resetOnTrackerChange,
   } = useEditorUIStore()
 
@@ -689,15 +687,6 @@ function EditorPanel({
 
       const blockId = getActiveBlockId()
       setCurrentBlockId(blockId)
-
-      if (!nextInTable) return
-      // Only update the remembered shading color when the cell actually has a
-      // background. Mirrors the highlight/text-color guards so cursor movement
-      // into an unshaded cell does not clobber the remembered (persisted) color.
-      const headerColor = editor.getAttributes('tableHeader')?.backgroundColor
-      const cellColor = editor.getAttributes('tableCell')?.backgroundColor
-      const cellShading = headerColor || cellColor
-      if (cellShading) setShadingColor(cellShading)
     }
     syncEditorState()
     editor.on('selectionUpdate', syncEditorState)
@@ -706,38 +695,7 @@ function EditorPanel({
       editor.off('selectionUpdate', syncEditorState)
       editor.off('transaction', syncEditorState)
     }
-  }, [editor, getActiveBlockId, setInTable, setCurrentBlockId, setShadingColor])
-
-  // Sync highlight color from editor selection → store
-  useEffect(() => {
-    if (!editor) return
-    const syncHighlight = () => {
-      const color = editor.getAttributes('highlight')?.color
-      if (color) setHighlightColor(color)
-    }
-    editor.on('selectionUpdate', syncHighlight)
-    editor.on('transaction', syncHighlight)
-    return () => {
-      editor.off('selectionUpdate', syncHighlight)
-      editor.off('transaction', syncHighlight)
-    }
-  }, [editor, setHighlightColor])
-
-  // Sync text color from editor selection → store. The store's change-guard
-  // keeps this from spamming localStorage on every cursor move.
-  useEffect(() => {
-    if (!editor) return
-    const syncTextColor = () => {
-      const color = editor.getAttributes('textStyle')?.color
-      if (color) setTextColor(color)
-    }
-    editor.on('selectionUpdate', syncTextColor)
-    editor.on('transaction', syncTextColor)
-    return () => {
-      editor.off('selectionUpdate', syncTextColor)
-      editor.off('transaction', syncTextColor)
-    }
-  }, [editor, setTextColor])
+  }, [editor, getActiveBlockId, setInTable, setCurrentBlockId])
 
   useEffect(() => {
     if (!editor) return


### PR DESCRIPTION
## Summary

The user reported that the "remembered" cell-shading color (the one the main split-button re-applies) kept reverting to the **yellow** they use throughout their tracker.

**Root cause:** `EditorPanel.jsx` had three selection-sync effects that fired on every cursor move / transaction and overwrote the remembered shading / highlight / text color with whatever the *current* cell or selection was styled. Since tracker cells are shaded yellow, moving the caret into any of them clobbered the last-picked color back to yellow. A prior fix (#154) only guarded the *null* case (cursor in an unshaded cell), not the shaded-cell case.

**Fix:** Remove the three editor-selection → remembered-color sync effects. The remembered colors are already set by the explicit `pick()` handlers in the tool components and rehydrate from `localStorage` on load, so nothing else needs to populate them. They now change **only** when the user explicitly picks a color from a dropdown — never from cursor position.

The pressed/active button state still reflects the live selection (separate logic, untouched). `editor.storage.highlightColor` continues to track the **store value** for the `Ctrl+Alt+H` shortcut.

## Changes

- `src/components/EditorPanel.jsx`
  - Drop the shading-color block from the selection-sync effect; keep `setInTable` / `setCurrentBlockId`.
  - Delete the highlight-color and text-color sync effects.
  - Prune the now-unused `setShadingColor` / `setHighlightColor` / `setTextColor` store selectors (kept `highlightColor`, still read for the shortcut).
- `e2e/persist-toolbar-colors.spec.js`
  - New regression test: seed a cell already shaded the tracker yellow, pick a different color via the caret in an unshaded cell, move the cursor into the yellow cell, and assert `.shading-control .toolbar-color-bar` still shows the picked color — the exact gap #154's test left open.

## Test plan

- [x] ESLint clean on both modified files
- [ ] CI: existing `persist-toolbar-colors` specs (shading test moves into an *unshaded* cell; highlight/text are pick-then-reload) + new regression case
- [ ] Manual (user): in a tracker with yellow cells, pick a custom shading color, click around several yellow cells, confirm the swatch stays on the custom color and the main button applies it. Repeat for highlight and text color.

🤖 Generated with [Claude Code](https://claude.com/claude-code)