### PR TITLE
fix: highlight toggle won't turn off at word edges (collapsed caret)

### DIFF
--- a/src/components/editor/toolbar/tools/textTools.jsx
+++ b/src/components/editor/toolbar/tools/textTools.jsx
@@ -9,6 +9,7 @@ import HighlightPicker from '../HighlightPicker'
 import { useOutsideClick } from '../useOutsideClick'
 import { cmd } from '../toolHelpers'
 import { getWordRangeAt } from '../../../../utils/wordRange'
+import { isHighlightActiveForToggle } from '../../../../utils/highlightState'
 import { HIGHLIGHT_COLORS, TEXT_COLORS } from '../toolConstants'
 import { Btn } from './ToolButton'
 
@@ -128,8 +129,17 @@ export function HighlightTool({ editor }) {
   const refs = useMemo(() => [wrapRef, pickerRef], [])
   useOutsideClick({ isOpen: open, onClose: () => setOpen(false), refs })
 
+  // Base the decision (and the button's active state) on whether the toggle
+  // target — the word under a collapsed caret, or the selection — already
+  // carries the highlight. isActive('highlight') reads caret-adjacency marks,
+  // which the inclusive:false mark gets wrong at word edges, so toggling off
+  // failed there.
+  const highlightActive = editor
+    ? isHighlightActiveForToggle(editor.state, editor.schema.marks.highlight)
+    : false
+
   const apply = () => {
-    const remove = editor?.isActive('highlight') || !highlightColor
+    const remove = highlightActive || !highlightColor
     setHighlightSmart(editor, remove ? null : highlightColor)
   }
 
@@ -142,7 +152,7 @@ export function HighlightTool({ editor }) {
   return (
     <div className="highlight-control" ref={wrapRef}>
       <Btn
-        active={editor?.isActive('highlight')}
+        active={highlightActive}
         onActivate={apply}
         title="Highlight"
       >

--- a/src/utils/__tests__/highlightState.test.js
+++ b/src/utils/__tests__/highlightState.test.js
@@ -1,0 +1,87 @@
+import { describe, it, expect } from 'vitest'
+import { Schema } from '@tiptap/pm/model'
+import { EditorState, TextSelection } from '@tiptap/pm/state'
+import { isHighlightActiveForToggle } from '../highlightState'
+
+// Minimal ProseMirror schema with a plain-text block plus a highlight mark.
+const schema = new Schema({
+  nodes: {
+    doc: { content: 'block+' },
+    paragraph: { group: 'block', content: 'inline*' },
+    text: { group: 'inline' },
+  },
+  marks: {
+    highlight: { inclusive: false },
+  },
+})
+
+const { doc, paragraph } = schema.nodes
+const highlight = schema.marks.highlight
+
+const p = (text) => paragraph.create(null, text ? schema.text(text) : null)
+
+// Build a base state, then mark [from, to] with highlight.
+const stateWithHighlight = (docNode, from, to) => {
+  let state = EditorState.create({ doc: docNode, schema })
+  if (from != null && to != null) {
+    state = state.apply(state.tr.addMark(from, to, highlight.create()))
+  }
+  return state
+}
+
+const withCursor = (state, pos) =>
+  state.apply(state.tr.setSelection(TextSelection.create(state.doc, pos)))
+
+const withSelection = (state, from, to) =>
+  state.apply(state.tr.setSelection(TextSelection.create(state.doc, from, to)))
+
+describe('isHighlightActiveForToggle', () => {
+  // doc: paragraph("hello world") -> text starts at doc pos 1.
+  // positions: h=1 e=2 l=3 l=4 o=5 (space)=6 w=7 o=8 r=9 l=10 d=11, end=12
+  // Highlight the first word "hello" = [1, 6].
+  const d = doc.create(null, [p('hello world')])
+
+  it('returns true with caret at the start of a highlighted word', () => {
+    const state = withCursor(stateWithHighlight(d, 1, 6), 1)
+    expect(isHighlightActiveForToggle(state, highlight)).toBe(true)
+  })
+
+  it('returns true with caret in the middle of a highlighted word', () => {
+    const state = withCursor(stateWithHighlight(d, 1, 6), 3)
+    expect(isHighlightActiveForToggle(state, highlight)).toBe(true)
+  })
+
+  it('returns true with caret at the end of a highlighted word', () => {
+    const state = withCursor(stateWithHighlight(d, 1, 6), 6)
+    expect(isHighlightActiveForToggle(state, highlight)).toBe(true)
+  })
+
+  it('returns false with caret anywhere in a non-highlighted word', () => {
+    const state = withCursor(stateWithHighlight(d, 1, 6), 9) // inside "world"
+    expect(isHighlightActiveForToggle(state, highlight)).toBe(false)
+  })
+
+  it('returns true for a non-empty selection over highlighted text', () => {
+    const state = withSelection(stateWithHighlight(d, 1, 6), 1, 6)
+    expect(isHighlightActiveForToggle(state, highlight)).toBe(true)
+  })
+
+  it('returns false for a non-empty selection over plain text', () => {
+    const state = withSelection(stateWithHighlight(d, 1, 6), 7, 12)
+    expect(isHighlightActiveForToggle(state, highlight)).toBe(false)
+  })
+
+  it('returns false for caret on whitespace between words', () => {
+    // "hi  there": h=1 i=2 (sp)=3 (sp)=4 t=5 ...; caret at pos 4 sits between
+    // two spaces (no word). No highlight applied -> false.
+    const dd = doc.create(null, [p('hi  there')])
+    const state = withCursor(stateWithHighlight(dd), 4)
+    expect(isHighlightActiveForToggle(state, highlight)).toBe(false)
+  })
+
+  it('returns false for an empty block', () => {
+    const empty = doc.create(null, [p()])
+    const state = withCursor(stateWithHighlight(empty), 1)
+    expect(isHighlightActiveForToggle(state, highlight)).toBe(false)
+  })
+})

--- a/src/utils/highlightState.js
+++ b/src/utils/highlightState.js
@@ -1,0 +1,30 @@
+// Pure ProseMirror-state helper: decide whether the highlight toggle should
+// remove (vs add). Mirrors setHighlightSmart's targeting so the toggle decision
+// matches the action — the word under a collapsed caret, or the current
+// selection — instead of relying on caret-adjacency marks (isActive), which the
+// inclusive:false highlight mark gets wrong at word edges.
+
+import { getWordRangeAt } from './wordRange'
+
+/**
+ * True when the highlight mark is present on the toggle target:
+ * the word under a collapsed caret, or the current non-empty selection.
+ *
+ * @param {import('@tiptap/pm/state').EditorState} state
+ * @param {import('@tiptap/pm/model').MarkType} markType
+ * @returns {boolean}
+ */
+export const isHighlightActiveForToggle = (state, markType) => {
+  if (!state || !markType) return false
+  const { selection } = state
+
+  if (selection.empty) {
+    const range = getWordRangeAt(state)
+    if (range) return state.doc.rangeHasMark(range.from, range.to, markType)
+    // Caret on whitespace / empty block: fall back to stored/adjacent marks.
+    const marks = state.storedMarks || selection.$from.marks()
+    return marks.some((m) => m.type === markType)
+  }
+
+  return state.doc.rangeHasMark(selection.from, selection.to, markType)
+}


### PR DESCRIPTION
## Problem

On the tracker editor, the Highlight toolbar button is a smart toggle: with a collapsed caret it highlights the whole word under the cursor. The bug: when the caret sat at the **start or end** of a word, the first tap applied the highlight but a second tap **wouldn't remove it** — it just re-applied.

## Root cause

`HighlightTool` decided remove-vs-add from `editor.isActive('highlight')`, which for a collapsed caret reads the marks adjacent to the cursor (`$from.marks()`). The highlight mark is configured `inclusive: false`, so at a word's start *and* end edge the adjacent character is the unmarked space and `$from.marks()` excludes the highlight. Result: `isActive` returned **false even when the word was fully highlighted**, so the toggle re-added instead of removing. The button's `active` prop had the same blind spot.

The action side (`setHighlightSmart`) already targeted the whole word range correctly — only the *decision* used the wrong signal.

## Fix

- **New pure helper** `src/utils/highlightState.js` — `isHighlightActiveForToggle(state, markType)` checks whether the actual toggle target carries the highlight (the word under a collapsed caret via `getWordRangeAt` + `rangeHasMark`, or the current selection), with a stored/adjacent-marks fallback for whitespace/empty blocks. Mirrors `setHighlightSmart`'s targeting so the decision matches the action.
- **`HighlightTool`** now computes `highlightActive` once from the helper and uses it for both the toggle decision and the button's `active` prop. `setHighlightSmart`, the `pick` color path, and the real-selection fallback are unchanged.

## Out of scope

The `Mod-Alt-h` keyboard shortcut (`linkShortcut.js`) also toggles via `isActive('highlight')` but uses selection-based `setHighlight`/`unsetHighlight` (not the word-range smart path), so it has different collapsed-caret semantics and was not part of the reported bug. Left unchanged; fixing it would mean extracting `setHighlightSmart` for reuse — a larger refactor.

## Test plan

- [x] **Unit:** new `src/utils/__tests__/highlightState.test.js` (8 cases) — caret at start/middle/end of a highlighted word (the regression), non-highlighted word, selections over highlighted vs plain text, whitespace, and empty block. Full suite green (388 passed).
- [ ] **Live repro:** with the caret at the start of a word, tap Highlight twice; with the caret at the end of another word, tap twice — second tap of each pair now removes the highlight. Tap-once-on / tap-once-off from the middle still works.
- [ ] **Button state:** Highlight button shows active when the caret is anywhere inside a highlighted word, including both edges.