### PR TITLE
feat: arm deep-link target as a real text selection for toolbar toggles

### DIFF
--- a/e2e/deep-link-selection-toggles.spec.js
+++ b/e2e/deep-link-selection-toggles.spec.js
@@ -1,0 +1,175 @@
+import { test, expect } from './fixtures'
+import {
+  clickNavigationItem,
+  createNotebook,
+  createPage,
+  createSection,
+  deleteNotebookById,
+  ensureToolbarExpanded,
+  getSupabase,
+  waitForApp,
+} from './test-helpers'
+
+// The deep-link landing should arm the target block as a real text selection so
+// every toolbar toggle acts on the whole line — while showing only the yellow
+// box (no native blue) and, on touch, without opening the keyboard.
+const TARGET_BLOCK_ID = 'e2e-deeplink-armed-target'
+const TARGET_TEXT = 'Arm this whole line as a selection'
+const OTHER_BLOCK_ID = 'e2e-deeplink-other'
+const OTHER_TEXT = 'A different paragraph to click into'
+
+const ARMED_CLASS = 'deep-link-selection-active'
+
+// Whole-line mark coverage: the given tag wraps the entire block text.
+const wholeLineMark = (locator, tag) =>
+  locator.evaluate((el, t) => {
+    const marked = el.querySelector(t)
+    const all = el.textContent.trim()
+    return Boolean(marked) && marked.textContent.trim() === all && all.length > 0
+  }, tag)
+
+test.describe('deep-link landing arms a real selection for toolbar toggles', () => {
+  let notebookId = null
+  let pageA = null // source page with the internal link
+  let pageB = null // target page with the anchored block
+  let linkHref = null
+
+  test.beforeAll(async () => {
+    const { client, userId } = await getSupabase()
+    const nb = await createNotebook(client, userId, `DeepLinkSel Notebook ${Date.now()}`)
+    notebookId = nb.id
+    const sec = await createSection(client, userId, nb.id, 'DeepLinkSel Section')
+
+    pageB = await createPage(client, userId, sec.id, 'Target Page', {
+      type: 'doc',
+      content: [
+        {
+          type: 'heading',
+          attrs: { level: 2, id: 'h-deeplink-top' },
+          content: [{ type: 'text', text: 'Deep Link Selection Test' }],
+        },
+        {
+          type: 'paragraph',
+          attrs: { id: TARGET_BLOCK_ID },
+          content: [{ type: 'text', text: TARGET_TEXT }],
+        },
+        {
+          type: 'paragraph',
+          attrs: { id: OTHER_BLOCK_ID },
+          content: [{ type: 'text', text: OTHER_TEXT }],
+        },
+      ],
+    })
+
+    linkHref = `#pg=${pageB.id}&block=${TARGET_BLOCK_ID}`
+
+    pageA = await createPage(client, userId, sec.id, 'Source Page', {
+      type: 'doc',
+      content: [
+        {
+          type: 'paragraph',
+          attrs: { id: 'p-deeplink-link' },
+          content: [
+            { type: 'text', text: 'Jump to ' },
+            {
+              type: 'text',
+              marks: [{ type: 'link', attrs: { href: linkHref, target: '_self', class: null } }],
+              text: 'the target',
+            },
+          ],
+        },
+      ],
+    })
+  })
+
+  test.afterAll(async () => {
+    const { client } = await getSupabase()
+    await deleteNotebookById(client, notebookId)
+  })
+
+  // Land on the target block via the internal link, the same way a user would.
+  const landOnTarget = async (page) => {
+    await clickNavigationItem(
+      page,
+      page.locator('.tree-node-page', { hasText: 'Source Page' }).first(),
+    )
+    await expect(page.locator('.ProseMirror')).toContainText('Jump to', { timeout: 10000 })
+
+    const internalLink = page.locator('.ProseMirror a[href*="pg="]').first()
+    await expect(internalLink).toBeVisible({ timeout: 10000 })
+    await internalLink.click()
+
+    const targetBlock = page.locator(`[id="${TARGET_BLOCK_ID}"]`)
+    await expect(targetBlock).toBeVisible({ timeout: 10000 })
+    await expect(targetBlock).toContainText(TARGET_TEXT, { timeout: 10000 })
+    return targetBlock
+  }
+
+  test.beforeEach(async ({ page }) => {
+    await waitForApp(page, `/#pg=${pageA.id}`, { expectedText: 'Jump to' })
+  })
+
+  test('lands with yellow box + armed selection (blue hidden), toggles whole line', async ({
+    page,
+  }) => {
+    const targetBlock = await landOnTarget(page)
+
+    // (a) Yellow box is shown and the armed class is on the ProseMirror root, which
+    // is what hides the native blue ::selection while the line stays "selected".
+    await expect(targetBlock).toHaveClass(/deep-link-target/, { timeout: 5000 })
+    await expect(async () => {
+      const armed = await page.evaluate(
+        (cls) => document.querySelector('.ProseMirror')?.classList.contains(cls) ?? false,
+        ARMED_CLASS,
+      )
+      expect(armed).toBe(true)
+    }).toPass({ timeout: 5000 })
+
+    // (b) Strikethrough acts on the whole landed line, not a collapsed caret.
+    await ensureToolbarExpanded(page)
+    await page.getByTestId('toolbar-strikethrough').click()
+    await expect(async () => {
+      expect(await wholeLineMark(targetBlock, 's')).toBe(true)
+    }).toPass({ timeout: 3000 })
+
+    // (c) The armed selection survives the toolbar tap, so a second toggle (Bold)
+    // also applies to the whole line.
+    await expect(async () => {
+      const stillArmed = await page.evaluate(
+        (cls) => document.querySelector('.ProseMirror')?.classList.contains(cls) ?? false,
+        ARMED_CLASS,
+      )
+      expect(stillArmed).toBe(true)
+    }).toPass({ timeout: 3000 })
+
+    await ensureToolbarExpanded(page)
+    await page.getByRole('button', { name: 'Bold' }).click()
+    await expect(async () => {
+      expect(await wholeLineMark(targetBlock, 'strong')).toBe(true)
+    }).toPass({ timeout: 3000 })
+
+    // Clean up the marks so the shared page is left as seeded.
+    await ensureToolbarExpanded(page)
+    await page.getByRole('button', { name: 'Bold' }).click()
+    await ensureToolbarExpanded(page)
+    await page.getByTestId('toolbar-strikethrough').click()
+  })
+
+  test('clicking elsewhere in the doc clears the yellow + armed state', async ({ page }) => {
+    await landOnTarget(page)
+
+    const otherBlock = page.locator(`[id="${OTHER_BLOCK_ID}"]`)
+    await expect(otherBlock).toBeVisible({ timeout: 5000 })
+    await otherBlock.click({ position: { x: 8, y: 8 } })
+
+    await expect(async () => {
+      const cleared = await page.evaluate((cls) => {
+        const root = document.querySelector('.ProseMirror')
+        const armed = root?.classList.contains(cls) ?? false
+        const hasYellow = document.querySelector('.deep-link-target') != null
+        return !armed && !hasYellow
+      }, ARMED_CLASS)
+      expect(cleared).toBe(true)
+    }).toPass({ timeout: 5000 })
+  })
+})

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -12,6 +12,8 @@ import { useTrackerSession } from './hooks/useTrackerSession'
 import { useResumeRefresh } from './hooks/useResumeRefresh'
 import { clearNavHierarchyCache } from './utils/resolveNavHierarchy'
 import { isTouchOnlyDevice } from './utils/device'
+import { registerDeepLinkSelectionApplier } from './utils/navigationHelpers'
+import { applyDeepLinkSelection } from './utils/deepLinkSelection'
 import {
   readStoredSidebarCollapsed,
   readStoredSelection,
@@ -329,6 +331,14 @@ function App() {
   )
   const handleAppPointerUpCapture = useCallback(
     (event) => {
+      // Tapping a toolbar button must not clear the armed deep-link selection —
+      // a real mouse selection survives toolbar clicks too, so this lets you apply
+      // Bold, then Strike, then Highlight to the same landed line.
+      const eventTarget = event.target
+      if (eventTarget instanceof Element && eventTarget.closest('.toolbar')) {
+        pointerGestureRef.current = null
+        return
+      }
       const gesture = pointerGestureRef.current
       if (!gesture || gesture.pointerId !== event.pointerId) return
       pointerGestureRef.current = null
@@ -405,6 +415,17 @@ function App() {
   useEffect(() => {
     uploadImageRef.current = finalUploadImageAndInsert
   }, [finalUploadImageAndInsert])
+
+  // Drive the deep-link text selection from navigationHelpers' DOM-pure landing
+  // path. On touch we skip focus so the keyboard stays quiet; on desktop we focus
+  // so native Ctrl+C / shortcuts work immediately, like a real mouse selection.
+  useEffect(() => {
+    if (!editor) return undefined
+    registerDeepLinkSelectionApplier((blockId) => {
+      applyDeepLinkSelection(editor, blockId, { focus: !isTouchOnlyDevice() })
+    })
+    return () => registerDeepLinkSelectionApplier(null)
+  }, [editor])
 
   const primeTouchNavigationGuard = useCallback(() => {
     if (!isTouchOnlyDevice()) return

--- a/src/styles/editor.css
+++ b/src/styles/editor.css
@@ -174,6 +174,18 @@
   border-radius: 8px;
 }
 
+/* While a deep link is armed, the block carries a real text selection so toolbar
+   toggles work — but we hide the native blue so only the yellow box shows. */
+.editor-shell .ProseMirror.deep-link-selection-active ::selection {
+  background: transparent;
+  color: inherit;
+}
+
+.editor-shell .ProseMirror.deep-link-selection-active ::-moz-selection {
+  background: transparent;
+  color: inherit;
+}
+
 /* AI find matches reuse the deep-link palette as whole-block highlights. The
    current match is slightly stronger so the cycled-to block stands out. */
 .editor-shell .ProseMirror .ai-find-match {

--- a/src/utils/__tests__/deepLinkSelection.test.js
+++ b/src/utils/__tests__/deepLinkSelection.test.js
@@ -1,0 +1,105 @@
+import { describe, it, expect } from 'vitest'
+import { Schema } from '@tiptap/pm/model'
+import { EditorState, TextSelection } from '@tiptap/pm/state'
+import { findBlockRangeById } from '../deepLinkSelection'
+
+// Schema mirroring the editor's block types, with the `id` attr that deep links
+// anchor to. Only what findBlockRangeById needs to walk + measure.
+const schema = new Schema({
+  nodes: {
+    doc: { content: 'block+' },
+    paragraph: {
+      group: 'block',
+      content: 'inline*',
+      attrs: { id: { default: null } },
+    },
+    heading: {
+      group: 'block',
+      content: 'inline*',
+      attrs: { id: { default: null }, level: { default: 1 } },
+    },
+    text: { group: 'inline' },
+    bulletList: {
+      group: 'block',
+      content: 'listItem+',
+      attrs: { id: { default: null } },
+    },
+    listItem: { content: 'block+', defining: true },
+  },
+})
+
+const { doc, paragraph, heading, bulletList, listItem } = schema.nodes
+
+const t = (text) => schema.text(text)
+const p = (attrs, text) => paragraph.create(attrs, text ? t(text) : null)
+const h = (attrs, text) => heading.create(attrs, text ? t(text) : null)
+const li = (...blocks) => listItem.create(null, blocks)
+const ul = (attrs, ...items) => bulletList.create(attrs, items)
+
+const makeState = (docNode) => EditorState.create({ doc: docNode, schema })
+
+// The text content the resulting range should cover, used to assert correctness
+// independent of exact integer positions.
+const sliceText = (state, range) =>
+  state.doc.textBetween(range.from, range.to, '\n', '\n')
+
+describe('findBlockRangeById', () => {
+  it('returns the inner text range for a paragraph', () => {
+    const state = makeState(
+      doc.create(null, [p({ id: 'a' }, 'before'), p({ id: 'target' }, 'hello world')]),
+    )
+    const range = findBlockRangeById(state, 'target')
+    expect(range).not.toBeNull()
+    expect(sliceText(state, range)).toBe('hello world')
+  })
+
+  it('returns the inner text range for a heading', () => {
+    const state = makeState(
+      doc.create(null, [h({ id: 'head', level: 2 }, 'My Section'), p({ id: 'b' }, 'body')]),
+    )
+    const range = findBlockRangeById(state, 'head')
+    expect(range).not.toBeNull()
+    expect(sliceText(state, range)).toBe('My Section')
+  })
+
+  it('spans the full text of a list container', () => {
+    const state = makeState(
+      doc.create(null, [
+        ul({ id: 'list' }, li(p(null, 'one')), li(p(null, 'two'))),
+      ]),
+    )
+    const range = findBlockRangeById(state, 'list')
+    expect(range).not.toBeNull()
+    // Selection snaps to text positions; covers both list items.
+    expect(sliceText(state, range)).toContain('one')
+    expect(sliceText(state, range)).toContain('two')
+  })
+
+  it('returns a collapsed range for an empty block', () => {
+    const state = makeState(
+      doc.create(null, [p({ id: 'empty' }), p({ id: 'c' }, 'after')]),
+    )
+    const range = findBlockRangeById(state, 'empty')
+    expect(range).not.toBeNull()
+    expect(range.from).toBe(range.to)
+  })
+
+  it('returns null for a missing id', () => {
+    const state = makeState(doc.create(null, [p({ id: 'a' }, 'hello')]))
+    expect(findBlockRangeById(state, 'does-not-exist')).toBeNull()
+  })
+
+  it('returns null when blockId is falsy', () => {
+    const state = makeState(doc.create(null, [p({ id: 'a' }, 'hello')]))
+    expect(findBlockRangeById(state, null)).toBeNull()
+    expect(findBlockRangeById(state, '')).toBeNull()
+  })
+
+  it('produces a range usable as a real TextSelection', () => {
+    const state = makeState(doc.create(null, [p({ id: 'target' }, 'select me')]))
+    const range = findBlockRangeById(state, 'target')
+    const selection = TextSelection.create(state.doc, range.from, range.to)
+    expect(selection.empty).toBe(false)
+    expect(state.doc.textBetween(selection.from, selection.to)).toBe('select me')
+  })
+})

--- a/src/utils/deepLinkSelection.js
+++ b/src/utils/deepLinkSelection.js
@@ -1,0 +1,66 @@
+import { TextSelection } from '@tiptap/pm/state'
+
+// While a deep-link landing is "armed", this class lives on the ProseMirror root
+// so CSS can hide the native blue selection (the yellow box stays as the visual).
+export const DEEP_LINK_SELECTION_ACTIVE_CLASS = 'deep-link-selection-active'
+
+/**
+ * Find the content text range of the block whose attrs.id === blockId.
+ *
+ * Textblocks (paragraph/heading) span pos+1 .. pos+nodeSize-1; container blocks
+ * (bulletList/orderedList/taskList/table) span their inner content the same way.
+ * Endpoints are snapped to valid text positions via TextSelection.between, which
+ * also collapses empty blocks correctly.
+ *
+ * @returns {{ from: number, to: number } | null}
+ */
+export const findBlockRangeById = (state, blockId) => {
+  if (!state || !blockId) return null
+  const { doc } = state
+
+  let found = null
+  doc.descendants((node, pos) => {
+    if (found) return false
+    if (node.attrs?.id === blockId) {
+      found = { node, pos }
+      return false
+    }
+    return true
+  })
+  if (!found) return null
+
+  const docSize = doc.content.size
+  const rawFrom = Math.min(Math.max(found.pos + 1, 0), docSize)
+  const rawTo = Math.min(Math.max(found.pos + found.node.nodeSize - 1, rawFrom), docSize)
+
+  const selection = TextSelection.between(doc.resolve(rawFrom), doc.resolve(rawTo))
+  return { from: selection.from, to: selection.to }
+}
+
+/**
+ * Give the editor a real ProseMirror TextSelection spanning the target block, so
+ * every toolbar command, copy/paste, and shortcut operates on it as if the user
+ * had selected the line with the mouse. Selection-only transaction → does not
+ * mark the doc dirty, so autosave is untouched. Focus only when requested (desktop).
+ *
+ * @returns {boolean} whether a selection was applied
+ */
+export const applyDeepLinkSelection = (editor, blockId, { focus = false } = {}) => {
+  if (!editor || editor.isDestroyed) return false
+  const { state, view } = editor
+
+  const range = findBlockRangeById(state, blockId)
+  if (!range) return false
+
+  const selection = TextSelection.create(state.doc, range.from, range.to)
+  const tr = state.tr.setSelection(selection)
+  tr.setMeta('addToHistory', false)
+  view.dispatch(tr)
+
+  view.dom.classList.add(DEEP_LINK_SELECTION_ACTIVE_CLASS)
+
+  if (focus) {
+    view.focus()
+  }
+  return true
+}

--- a/src/utils/navigationHelpers.js
+++ b/src/utils/navigationHelpers.js
@@ -1,4 +1,13 @@
 import { scrollElementIntoViewWithToolbar } from './scrollIntoViewWithToolbar'
+import { DEEP_LINK_SELECTION_ACTIVE_CLASS } from './deepLinkSelection'
+
+// App.jsx registers a function that gives the editor a real text selection on the
+// landed block. navigationHelpers stays DOM-pure; the applier owns the editor.
+let deepLinkSelectionApplier = null
+
+export const registerDeepLinkSelectionApplier = (fn) => {
+  deepLinkSelectionApplier = typeof fn === 'function' ? fn : null
+}
 
 export const buildHash = ({ notebookId, sectionId, pageId, blockId }) => {
   const params = new URLSearchParams()
@@ -96,16 +105,27 @@ const scrollDeepLinkTargetIntoView = (target) => {
   })
 }
 
+const clearDeepLinkSelectionActiveClass = () => {
+  document.querySelectorAll(`.${DEEP_LINK_SELECTION_ACTIVE_CLASS}`).forEach((node) => {
+    node.classList.remove(DEEP_LINK_SELECTION_ACTIVE_CLASS)
+  })
+}
+
 export const clearDeepLinkHighlight = () => {
   activeDeepLinkBlockId = null
   clearDeepLinkHighlightInDocument()
   clearDeepLinkHighlightStyle()
+  clearDeepLinkSelectionActiveClass()
 }
 
 export const scrollToBlock = (blockId, attempts = 0) => {
   const target = applyDeepLinkHighlight(blockId)
   if (target) {
     activeDeepLinkBlockId = blockId
+    // Arm the block as a real text selection so toolbar toggles, copy/paste, and
+    // shortcuts act on it. Runs once per landing (the retry refreshes below call
+    // applyDeepLinkHighlight directly, not scrollToBlock).
+    deepLinkSelectionApplier?.(blockId)
     requestAnimationFrame(() => {
       requestAnimationFrame(() => {
         scrollDeepLinkTargetIntoView(target)


### PR DESCRIPTION
## Summary

When you click a "link to paragraph", the app jumps to the target block and paints it yellow so you can see where you landed. But that highlight was *purely cosmetic* — a DOM class keyed to the block's element `id`, with **no ProseMirror selection**. So landing on a linked line and hitting Strikethrough (or Bold, Highlight, etc.) did nothing — the toolbar toggles read `editor.state.selection`, which was empty.

This PR makes the yellow-highlighted line behave **exactly as if the user had selected that text with the mouse**: the landing now gives the editor a real ProseMirror `TextSelection` spanning the target block, so every toolbar button, copy/paste, and keyboard shortcut works on it automatically — **but without showing the blue selection** (yellow stays as the visual) and **without popping the phone keyboard on landing**.

## How it works

- **New `src/utils/deepLinkSelection.js`**
  - `findBlockRangeById(state, blockId)` — walks `doc.descendants`, matches `attrs.id`, computes the block's content range (`pos+1 .. pos+nodeSize-1`), clamps to doc size, and snaps endpoints via `TextSelection.between` (collapses empty blocks; returns `null` when missing).
  - `applyDeepLinkSelection(editor, blockId, { focus })` — dispatches a **selection-only** transaction (`addToHistory: false`, so autosave is untouched), adds the `deep-link-selection-active` class to the ProseMirror root, and focuses only when asked.
- **`src/utils/navigationHelpers.js`** — added `registerDeepLinkSelectionApplier`; `scrollToBlock` invokes it once per landing; `clearDeepLinkHighlight` strips the armed class so the yellow + hidden-blue live and die together.
- **`src/App.jsx`** — effect (keyed on `editor`) registers the applier with `focus: !isTouchOnlyDevice()` (focus on desktop for native `Ctrl+C`/shortcuts; no focus on touch so the keyboard stays quiet). Added an early `.toolbar` guard in `handleAppPointerUpCapture` so tapping a toolbar button **preserves** the armed selection — letting you apply Bold, then Strike, then Highlight to the same line, just like a real mouse selection survives toolbar clicks.
- **`src/styles/editor.css`** — `::selection`/`::-moz-selection` → `transparent` under `.ProseMirror.deep-link-selection-active`, so the real selection shows no blue.

No changes to the toolbar tools themselves — `cmd()`, `toggleLineStrike`, and `setHighlightSmart` already operate on the current selection, and active-states (`editor.isActive('bold')`) light up correctly because they read `state.selection`.

## Hotspot-file checklist
- **Concern added:** deep-link landing arms a real text selection + hidden-blue class; toolbar taps preserve it.
- **Extracted:** all selection logic lives in the new `deepLinkSelection.js`; App.jsx / navigationHelpers only register/invoke and toggle a DOM class — no responsibility sprawl added.
- **Regression checks:** `npm run test:unit` (404 pass), `eslint` on touched files (clean), `npm run build` (compiles). Verified the desktop focus path doesn't fight `useEditorFocusRecovery` (Effect 1 only blurs on touch) and that touch keeps `editable=false` while toggles still dispatch via state.

## Test plan
- [x] Unit: `deepLinkSelection.test.js` asserts `findBlockRangeById` for a paragraph, heading, list container, empty/collapsed block, missing id, and falsy id (uses real ProseMirror state).
- [x] `npm run test:unit` — 404 pass
- [x] `npm run build` — compiles
- [ ] E2E (CI, Desktop + Mobile Chrome): `deep-link-selection-toggles.spec.js` — lands with yellow box + armed class, Strikethrough strikes the whole line, armed state survives the tap so Bold also applies, clicking elsewhere clears the yellow and restores normal selection.
- [ ] Manual desktop: click a paragraph link → lands, no blue, `Ctrl+C` copies the line.
- [ ] Manual phone: lands quietly with no keyboard; tapping Strikethrough crosses off the line.