### PR TITLE
fix: preserve desktop toolbar selection + harden selection-based E2E tests

### DIFF
--- a/e2e/deep-link-selection-toggles.spec.js
+++ b/e2e/deep-link-selection-toggles.spec.js
@@ -116,7 +116,15 @@ test.describe('deep-link landing arms a real selection for toolbar toggles', () 
 
     // (a) Yellow box is shown and the armed class is on the ProseMirror root, which
     // is what hides the native blue ::selection while the line stays "selected".
-    await expect(targetBlock).toHaveClass(/deep-link-target/, { timeout: 5000 })
+    await expect(async () => {
+      const highlighted = await targetBlock.evaluate((el) => {
+        const hasClass = el.classList.contains('deep-link-target')
+        const styleNode = document.getElementById('deep-link-target-style')
+        const styleTargetsBlock = styleNode?.textContent?.includes(`[id="${el.id}"]`) ?? false
+        return hasClass || styleTargetsBlock
+      })
+      expect(highlighted).toBe(true)
+    }).toPass({ timeout: 5000 })
     await expect(async () => {
       const armed = await page.evaluate(
         (cls) => document.querySelector('.ProseMirror')?.classList.contains(cls) ?? false,

--- a/e2e/highlight-toggle-cursor.spec.js
+++ b/e2e/highlight-toggle-cursor.spec.js
@@ -54,7 +54,12 @@ const placeCaretInWord = async (page) => {
   await expect(line).toBeVisible()
   await line.evaluate((node, word) => {
     // Find the text node and a character offset inside the target word.
-    const textNode = node.firstChild
+    const walker = document.createTreeWalker(node, NodeFilter.SHOW_TEXT)
+    let textNode = walker.nextNode()
+    while (textNode && !(textNode.textContent ?? '').includes(word)) {
+      textNode = walker.nextNode()
+    }
+    if (!textNode) throw new Error(`Could not find text node containing "${word}"`)
     const idx = (textNode.textContent ?? '').indexOf(word)
     const caretAt = idx + Math.floor(word.length / 2)
     const range = document.createRange()

--- a/e2e/persist-toolbar-colors.spec.js
+++ b/e2e/persist-toolbar-colors.spec.js
@@ -110,14 +110,19 @@ const seedLabel = `COLOR-PERSIST-${Date.now()}`
 const selectSeedLine = async (page) => {
   const line = page.locator('.ProseMirror p', { hasText: 'Persisted color test line' }).first()
   await expect(line).toBeVisible()
-  await line.evaluate((node) => {
-    const range = document.createRange()
-    range.selectNodeContents(node)
-    const selection = window.getSelection()
-    selection?.removeAllRanges()
-    selection?.addRange(range)
-    node.closest('.ProseMirror')?.focus()
-  })
+  await page.evaluate((text) => {
+    const editor = window.__lifeTrackerEditor
+    if (!editor) throw new Error('Editor test hook is not available')
+    let range = null
+    editor.state.doc.descendants((node, pos) => {
+      if (range || !node.isTextblock || node.textContent !== text) return true
+      range = { from: pos + 1, to: pos + node.nodeSize - 1 }
+      return false
+    })
+    if (!range) throw new Error(`Could not find seed line "${text}"`)
+    editor.commands.setTextSelection(range)
+    editor.view.focus()
+  }, 'Persisted color test line')
 }
 
 // Read the inline color applied to the seed text, scoped to mark/span tags.
@@ -130,6 +135,22 @@ const readSeedColor = (page, tag, prop) =>
     },
     { tag, prop },
   )
+
+const clearSeedHighlight = async (page) => {
+  await page.evaluate((text) => {
+    const editor = window.__lifeTrackerEditor
+    if (!editor) throw new Error('Editor test hook is not available')
+    const markType = editor.schema.marks.highlight
+    let range = null
+    editor.state.doc.descendants((node, pos) => {
+      if (range || !node.isTextblock || node.textContent !== text) return true
+      range = { from: pos + 1, to: pos + node.nodeSize - 1 }
+      return false
+    })
+    if (!range) throw new Error(`Could not find seed line "${text}"`)
+    editor.view.dispatch(editor.state.tr.removeMark(range.from, range.to, markType))
+  }, 'Persisted color test line')
+}
 
 // Read the computed background color of the table cell (td/th) containing text.
 const readCellColor = (page, cellText) =>
@@ -232,6 +253,7 @@ test('highlight color picked via caret persists across reload and the main butto
   )
 
   // Clicking the main button applies the persisted color to the selection.
+  await clearSeedHighlight(page)
   await selectSeedLine(page)
   await page.getByRole('button', { name: 'Highlight', exact: true }).click()
 

--- a/src/components/EditorPanel.jsx
+++ b/src/components/EditorPanel.jsx
@@ -702,6 +702,16 @@ function EditorPanel({
     editor.storage.highlightColor = highlightColor ?? null
   }, [editor, highlightColor])
 
+  useEffect(() => {
+    if (!import.meta.env.DEV) return undefined
+    window.__lifeTrackerEditor = editor ?? null
+    return () => {
+      if (window.__lifeTrackerEditor === editor) {
+        window.__lifeTrackerEditor = null
+      }
+    }
+  }, [editor])
+
   // Reset state on tracker/page change, and pre-focus the editor so that
   // DOM-manipulation-based cursor placement in tests (and user interactions
   // that call editorRoot.focus()) doesn't trigger ProseMirror's focus handler

--- a/src/components/editor/ToolButton.jsx
+++ b/src/components/editor/ToolButton.jsx
@@ -6,15 +6,17 @@ import { isKeyboardShown } from '../../utils/keyboardShown'
 //
 // Pieces that keep the editor selection alive when a button is tapped:
 //   1. tabIndex={-1}             keep the button out of the focus order
-//   2. mousedown preventDefault  block focus transfer to the button, ONLY
-//                                while the on-screen keyboard is up. mousedown
-//                                also fires on touch (via the touch→mouse
-//                                compatibility sequence) before the synthetic
-//                                click, so a single capture-phase mousedown
-//                                handler covers both pointer and touch. Gating
-//                                on isKeyboardShown() mirrors notesnook and
-//                                stops ambient toolbar taps (e.g. the expand
-//                                toggle) from summoning the IME on Android.
+//   2. mousedown preventDefault  block focus transfer to the button so the
+//                                editor selection survives the click. On desktop
+//                                (non-touch) this always fires, which the
+//                                selection-based toolbar features (deep-link
+//                                armed selection, highlight-on-caret) rely on.
+//                                On touch it is gated on isKeyboardShown():
+//                                mousedown also fires on touch (via the
+//                                touch→mouse compatibility sequence) before the
+//                                synthetic click, and gating mirrors notesnook so
+//                                ambient toolbar taps (e.g. the expand toggle)
+//                                don't summon the IME on Android.
 //   3. plain onClick             runs the editor command (chain().focus().toggleX().run())
 //
 // Do NOT add a touchstart preventDefault here. On Android Chrome, canceling
@@ -54,7 +56,9 @@ function ToolButton({
       title={title}
       aria-label={ariaLabel ?? title}
       data-testid={testId}
-      onMouseDown={(e) => { if (isTouchOnly && isKeyboardShown()) e.preventDefault() }}
+      onMouseDown={(e) => {
+        if (!isTouchOnly || isKeyboardShown()) e.preventDefault()
+      }}
       onClick={(e) => {
         if (disabled) return
         e.preventDefault()

--- a/src/components/editor/toolbar/tools/textTools.jsx
+++ b/src/components/editor/toolbar/tools/textTools.jsx
@@ -1,4 +1,5 @@
 import { useMemo, useRef, useState } from 'react'
+import { TextSelection } from '@tiptap/pm/state'
 import {
   BoldIcon, ItalicIcon, UnderlineIcon, StrikethroughIcon,
   HighlightIcon,
@@ -96,8 +97,35 @@ export function H2Tool({ editor }) {
 // Apply (color) or remove (color === null) the highlight on the current selection.
 // With a collapsed caret, act on the whole word under the cursor WITHOUT changing
 // the visible selection, so the cursor stays put and no blue overlay hides the color.
+function syncSelectionFromDom(editor) {
+  const selection = window.getSelection?.()
+  const anchorNode = selection?.anchorNode
+  const focusNode = selection?.focusNode
+  if (!editor || !selection || selection.rangeCount === 0 || !anchorNode || !focusNode) return
+
+  const root = editor.view.dom
+  const anchorElement =
+    anchorNode.nodeType === Node.ELEMENT_NODE ? anchorNode : anchorNode.parentElement
+  const focusElement =
+    focusNode.nodeType === Node.ELEMENT_NODE ? focusNode : focusNode.parentElement
+  if (!anchorElement || !focusElement) return
+  if (!root.contains(anchorElement) || !root.contains(focusElement)) return
+
+  try {
+    const anchorPos = editor.view.posAtDOM(anchorNode, selection.anchorOffset)
+    const headPos = editor.view.posAtDOM(focusNode, selection.focusOffset)
+    const nextSelection = TextSelection.create(editor.state.doc, anchorPos, headPos)
+    if (!nextSelection.eq(editor.state.selection)) {
+      editor.view.dispatch(editor.state.tr.setSelection(nextSelection))
+    }
+  } catch {
+    // Ignore stale DOM selections; the ProseMirror state remains authoritative.
+  }
+}
+
 function setHighlightSmart(editor, color) {
   if (!editor) return
+  syncSelectionFromDom(editor)
   const markType = editor.schema.marks.highlight
   const { selection } = editor.state
 
@@ -115,7 +143,14 @@ function setHighlightSmart(editor, color) {
     }
   }
 
-  // Real selection (or caret on whitespace): keep today's behavior.
+  if (!selection.empty) {
+    const tr = editor.state.tr.removeMark(selection.from, selection.to, markType)
+    if (color) tr.addMark(selection.from, selection.to, markType.create({ color }))
+    editor.view.dispatch(tr)
+    return
+  }
+
+  // Caret on whitespace: keep today's stored-mark behavior.
   if (!color) editor.chain().focus().unsetHighlight().run()
   else editor.chain().focus().setHighlight({ color }).run()
 }
@@ -139,7 +174,11 @@ export function HighlightTool({ editor }) {
     : false
 
   const apply = () => {
-    const remove = highlightActive || !highlightColor
+    syncSelectionFromDom(editor)
+    const activeNow = editor
+      ? isHighlightActiveForToggle(editor.state, editor.schema.marks.highlight)
+      : false
+    const remove = activeNow || !highlightColor
     setHighlightSmart(editor, remove ? null : highlightColor)
   }
 

--- a/src/utils/deepLinkSelection.js
+++ b/src/utils/deepLinkSelection.js
@@ -3,6 +3,10 @@ import { TextSelection } from '@tiptap/pm/state'
 // While a deep-link landing is "armed", this class lives on the ProseMirror root
 // so CSS can hide the native blue selection (the yellow box stays as the visual).
 export const DEEP_LINK_SELECTION_ACTIVE_CLASS = 'deep-link-selection-active'
+// navigationHelpers owns the lifecycle of this class (apply on landing, clear on
+// teardown, re-apply on its 80/200/400ms retry loop). Kept as a local literal here
+// to avoid a circular import (navigationHelpers already imports from this file).
+const DEEP_LINK_TARGET_CLASS = 'deep-link-target'
 
 /**
  * Find the content text range of the block whose attrs.id === blockId.
@@ -62,5 +66,13 @@ export const applyDeepLinkSelection = (editor, blockId, { focus = false } = {}) 
   if (focus) {
     view.focus()
   }
+
+  // The selection transaction above can re-render the target node and strip the
+  // highlight class that navigationHelpers added before calling us. Re-add it
+  // immediately so the yellow box never flickers in the gap before the retry
+  // loop re-applies it.
+  const target = document.getElementById(blockId)
+  target?.classList.add(DEEP_LINK_TARGET_CLASS)
+
   return true
 }


### PR DESCRIPTION
## Summary

The selection-based toolbar features (deep-link armed selection, highlight-on-caret, persisted-color application) were dropping the editor selection when a toolbar button was clicked with a **mouse on desktop**. This fixes that and hardens the three E2E tests that guard those features.

### Behavior change (call-out)
Toolbar buttons now `preventDefault` on `mousedown` on **desktop (non-touch)**, so the editor selection survives the click — standard rich-text-toolbar behavior. **Touch is unchanged**: still gated on `isKeyboardShown()` so ambient taps (e.g. the expand toggle) don't summon the Android IME.

## Source changes
- **`ToolButton.jsx`** — invert the desktop `mousedown` gating; comment rewritten to match.
- **`textTools.jsx`** — `syncSelectionFromDom()` reconciles the ProseMirror selection from the DOM before highlighting; real (non-empty) selections apply via `removeMark`+`addMark` (clean color replace) **without** re-focusing, which would expose the native blue selection that a deep-link landing deliberately hides.
- **`deepLinkSelection.js`** — re-add the target highlight class after the selection transaction so the yellow box doesn't flicker before the retry loop re-applies it.
- **`EditorPanel.jsx`** — expose `window.__lifeTrackerEditor` in DEV only, for E2E selection setup.

## Test changes (no behavioral checks removed)
- **`highlight-toggle-cursor`** — locate the caret text node via `TreeWalker` instead of assuming `firstChild`.
- **`persist-toolbar-colors`** — drive the selection via the editor command and clear the seed highlight before asserting re-application, making the toggle deterministic.
- **`deep-link-selection-toggles`** — accept either highlight mechanism (the `.deep-link-target` class **or** the injected `<style>` rule), matching how the app actually paints the target.

## Test plan
- [ ] CI E2E suite green (desktop + mobile projects)
- [ ] Manual desktop pass: Bold/Italic, color dropdowns open, expand/collapse toggle, and highlight-on-selection all still behave with the new always-`preventDefault` on desktop
- [ ] Verify deep-link landing still shows the yellow box and toolbar toggles act on the armed line

## Notes
- `window.__lifeTrackerEditor` is gated on `import.meta.env.DEV`; E2E runs `npm run dev`, so it's present. If E2E is ever pointed at a preview/prod build, `persist-toolbar-colors` would throw "Editor test hook is not available".
- Origin: intern's E2E fix-up iterated directly on `main`; this PR lands that work on a branch with the production behavior change surfaced explicitly.