### PR TITLE
feat: word-level cursor formatting for Bold, Italic, Underline, Text color

### DIFF
--- a/e2e/underline-toggle-cursor.spec.js
+++ b/e2e/underline-toggle-cursor.spec.js
@@ -1,0 +1,202 @@
+/**
+ * E2E regression test for word-level cursor formatting on Bold, Italic,
+ * Underline, and Text color — the same UX as Highlight
+ * (see highlight-toggle-cursor.spec.js).
+ *
+ * With a COLLAPSED caret inside a word (nothing selected), clicking each of
+ * these buttons formats the WHOLE word under the caret via a ProseMirror
+ * transaction, never touching the visible selection. So:
+ *   1. The whole word gets the mark (e.g. wrapped in <u>/<strong>/<em>, or the
+ *      <span style="color: …"> for text color).
+ *   2. The selection stays collapsed/empty (no leftover native blue overlay).
+ *   3. Clicking the same button again removes the mark.
+ *
+ * The text-color dropdown picker lives in the collapsed "extra" toolbar group on
+ * touch devices, so these run desktop-only (matching the highlight spec).
+ */
+
+import { test, expect } from './fixtures'
+import {
+  getSupabase,
+  createNotebook,
+  createSection,
+  createPage,
+  deleteNotebookById,
+  waitForApp,
+} from './test-helpers'
+
+const TEXT_BLUE_RGB = 'rgb(37, 99, 235)' // picked text color (#2563eb)
+
+const SEED_WORD = 'Background'
+
+const buildSeedContent = (id) => ({
+  type: 'doc',
+  content: [
+    {
+      type: 'paragraph',
+      attrs: { id },
+      content: [{ type: 'text', text: `${SEED_WORD} notes line` }],
+    },
+  ],
+})
+
+let seedIds = {}
+const seedLabel = `MARK-CURSOR-${Date.now()}`
+
+// Place a COLLAPSED caret in the middle of the seed word — no selection.
+const placeCaretInWord = async (page) => {
+  const line = page.locator('.ProseMirror p', { hasText: SEED_WORD }).first()
+  await expect(line).toBeVisible()
+  await line.evaluate((node, word) => {
+    const walker = document.createTreeWalker(node, NodeFilter.SHOW_TEXT)
+    let textNode = walker.nextNode()
+    while (textNode && !(textNode.textContent ?? '').includes(word)) {
+      textNode = walker.nextNode()
+    }
+    if (!textNode) throw new Error(`Could not find text node containing "${word}"`)
+    const idx = (textNode.textContent ?? '').indexOf(word)
+    const caretAt = idx + Math.floor(word.length / 2)
+    const range = document.createRange()
+    range.setStart(textNode, caretAt)
+    range.collapse(true)
+    const selection = window.getSelection()
+    selection?.removeAllRanges()
+    selection?.addRange(range)
+    node.closest('.ProseMirror')?.focus()
+  }, SEED_WORD)
+}
+
+// True when the seed word is fully wrapped by an element matching `selector`.
+const wordHasWrapper = (page, selector) =>
+  page.evaluate(
+    ({ word, sel }) => {
+      const els = Array.from(document.querySelectorAll(`.ProseMirror ${sel}`))
+      return els.some((el) => (el.textContent ?? '').includes(word))
+    },
+    { word: SEED_WORD, sel: selector },
+  )
+
+// Read the inline text color of the <span> wrapping the seed word, or null.
+const readWordTextColor = (page) =>
+  page.evaluate((word) => {
+    const spans = Array.from(document.querySelectorAll('.ProseMirror span[style*="color"]'))
+    const match = spans.find((s) => (s.textContent ?? '').includes(word))
+    return match ? getComputedStyle(match).color : null
+  }, SEED_WORD)
+
+// True when the native selection is collapsed with no selected text.
+const selectionIsCollapsed = (page) =>
+  page.evaluate(() => {
+    const selection = window.getSelection()
+    return Boolean(selection?.isCollapsed) && (selection?.toString() ?? '') === ''
+  })
+
+test.beforeAll(async () => {
+  const { client, userId } = await getSupabase()
+  const notebook = await createNotebook(client, userId, `${seedLabel} Notebook`)
+  const section = await createSection(client, userId, notebook.id, `${seedLabel} Section`, 0)
+  const boldPage = await createPage(
+    client, userId, section.id, `${seedLabel} Bold Page`, buildSeedContent('p-bold-1'), 0,
+  )
+  const italicPage = await createPage(
+    client, userId, section.id, `${seedLabel} Italic Page`, buildSeedContent('p-italic-1'), 1,
+  )
+  const underlinePage = await createPage(
+    client, userId, section.id, `${seedLabel} Underline Page`, buildSeedContent('p-underline-1'), 2,
+  )
+  const colorPage = await createPage(
+    client, userId, section.id, `${seedLabel} Color Page`, buildSeedContent('p-color-1'), 3,
+  )
+  seedIds = { notebook, section, boldPage, italicPage, underlinePage, colorPage }
+})
+
+test.afterAll(async () => {
+  const { client } = await getSupabase()
+  await deleteNotebookById(client, seedIds.notebook?.id)
+})
+
+const seedHash = (pageRow) =>
+  `#nb=${seedIds.notebook.id}&sec=${seedIds.section.id}&pg=${pageRow.id}`
+
+// Shared flow for a simple boolean inline mark (bold/italic/underline): the whole
+// word gets wrapped on click, the selection stays collapsed, and a second click
+// removes the wrapper.
+const runInlineMarkToggle = async ({ page, pageRow, buttonName, wrapperSelector }) => {
+  await waitForApp(page, seedHash(pageRow), { expectedText: SEED_WORD })
+  await page.waitForSelector('.ProseMirror[contenteditable="true"]', { timeout: 10000 })
+
+  await placeCaretInWord(page)
+  await page.getByRole('button', { name: buttonName, exact: true }).click()
+
+  await expect(async () => {
+    expect(await wordHasWrapper(page, wrapperSelector)).toBe(true)
+  }).toPass({ timeout: 5000 })
+
+  expect(await selectionIsCollapsed(page)).toBe(true)
+
+  await placeCaretInWord(page)
+  await page.getByRole('button', { name: buttonName, exact: true }).click()
+
+  await expect(async () => {
+    expect(await wordHasWrapper(page, wrapperSelector)).toBe(false)
+  }).toPass({ timeout: 5000 })
+}
+
+test('Underline on a collapsed caret marks the whole word without disturbing the selection', async ({
+  page,
+  isMobile,
+}) => {
+  test.skip(isMobile, 'Desktop-only: relies on a collapsed-caret word-format flow')
+  await runInlineMarkToggle({
+    page,
+    pageRow: seedIds.underlinePage,
+    buttonName: 'Underline',
+    wrapperSelector: 'u',
+  })
+})
+
+test('Bold on a collapsed caret marks the whole word and toggles off', async ({
+  page,
+  isMobile,
+}) => {
+  test.skip(isMobile, 'Desktop-only: relies on a collapsed-caret word-format flow')
+  await runInlineMarkToggle({
+    page,
+    pageRow: seedIds.boldPage,
+    buttonName: 'Bold',
+    wrapperSelector: 'strong',
+  })
+})
+
+test('Italic on a collapsed caret marks the whole word and toggles off', async ({
+  page,
+  isMobile,
+}) => {
+  test.skip(isMobile, 'Desktop-only: relies on a collapsed-caret word-format flow')
+  await runInlineMarkToggle({
+    page,
+    pageRow: seedIds.italicPage,
+    buttonName: 'Italic',
+    wrapperSelector: 'em',
+  })
+})
+
+test('Picking a text color with a collapsed caret colors the whole word and keeps it collapsed', async ({
+  page,
+  isMobile,
+}) => {
+  test.skip(isMobile, 'Desktop-only: dropdown picker lives in the collapsed extra group on touch')
+
+  await waitForApp(page, seedHash(seedIds.colorPage), { expectedText: SEED_WORD })
+  await page.waitForSelector('.ProseMirror[contenteditable="true"]', { timeout: 10000 })
+
+  await placeCaretInWord(page)
+  await page.getByRole('button', { name: 'Text colors' }).click()
+  await page.getByRole('button', { name: 'Blue', exact: true }).click()
+
+  await expect(async () => {
+    expect(await readWordTextColor(page)).toBe(TEXT_BLUE_RGB)
+  }).toPass({ timeout: 5000 })
+
+  expect(await selectionIsCollapsed(page)).toBe(true)
+})

--- a/src/components/editor/toolbar/tools/textTools.jsx
+++ b/src/components/editor/toolbar/tools/textTools.jsx
@@ -1,5 +1,4 @@
 import { useMemo, useRef, useState } from 'react'
-import { TextSelection } from '@tiptap/pm/state'
 import {
   BoldIcon, ItalicIcon, UnderlineIcon, StrikethroughIcon,
   HighlightIcon,
@@ -9,18 +8,40 @@ import { useEditorUIStore } from '../../../../stores/editorUIStore'
 import HighlightPicker from '../HighlightPicker'
 import { useOutsideClick } from '../useOutsideClick'
 import { cmd } from '../toolHelpers'
-import { getWordRangeAt } from '../../../../utils/wordRange'
-import { isHighlightActiveForToggle } from '../../../../utils/highlightState'
+import {
+  applyMarkToTarget,
+  isMarkActiveForToggle,
+  syncSelectionFromDom,
+} from '../../../../utils/smartMark'
 import { HIGHLIGHT_COLORS, TEXT_COLORS } from '../toolConstants'
 import { Btn } from './ToolButton'
 
 // --- Inline marks ---------------------------------------------------------
 
+// Bold/Italic/Underline mirror Highlight: a collapsed caret in a word formats the
+// WHOLE word (via applyMarkToTarget). The button's active state reads the same
+// word/selection target so toggling off works at word edges. On a whitespace
+// caret, applyMarkToTarget returns false and we fall back to the standard
+// stored-mark command ("format the next typed characters").
+function toggleInlineMark(editor, markName, fallback) {
+  const markType = editor?.schema.marks[markName]
+  if (!editor || !markType) return
+  syncSelectionFromDom(editor)
+  const remove = isMarkActiveForToggle(editor.state, markType)
+  const acted = applyMarkToTarget(editor, markType, { remove })
+  if (!acted) fallback(cmd(editor)) // whitespace caret: stored-mark fallback
+}
+
+function isInlineMarkActive(editor, markName) {
+  const markType = editor?.schema.marks[markName]
+  return editor && markType ? isMarkActiveForToggle(editor.state, markType) : false
+}
+
 export function BoldTool({ editor }) {
   return (
     <Btn
-      active={editor?.isActive('bold')}
-      onActivate={() => cmd(editor)?.toggleBold().run()}
+      active={isInlineMarkActive(editor, 'bold')}
+      onActivate={() => toggleInlineMark(editor, 'bold', (c) => c?.toggleBold().run())}
       title="Bold"
     >
       <BoldIcon />
@@ -31,8 +52,8 @@ export function BoldTool({ editor }) {
 export function ItalicTool({ editor }) {
   return (
     <Btn
-      active={editor?.isActive('italic')}
-      onActivate={() => cmd(editor)?.toggleItalic().run()}
+      active={isInlineMarkActive(editor, 'italic')}
+      onActivate={() => toggleInlineMark(editor, 'italic', (c) => c?.toggleItalic().run())}
       title="Italic"
     >
       <ItalicIcon />
@@ -43,8 +64,8 @@ export function ItalicTool({ editor }) {
 export function UnderlineTool({ editor }) {
   return (
     <Btn
-      active={editor?.isActive('underline')}
-      onActivate={() => cmd(editor)?.toggleUnderline().run()}
+      active={isInlineMarkActive(editor, 'underline')}
+      onActivate={() => toggleInlineMark(editor, 'underline', (c) => c?.toggleUnderline().run())}
       title="Underline"
     >
       <UnderlineIcon />
@@ -94,61 +115,18 @@ export function H2Tool({ editor }) {
 
 // --- Highlight (with picker) ---------------------------------------------
 
-// Apply (color) or remove (color === null) the highlight on the current selection.
-// With a collapsed caret, act on the whole word under the cursor WITHOUT changing
-// the visible selection, so the cursor stays put and no blue overlay hides the color.
-function syncSelectionFromDom(editor) {
-  const selection = window.getSelection?.()
-  const anchorNode = selection?.anchorNode
-  const focusNode = selection?.focusNode
-  if (!editor || !selection || selection.rangeCount === 0 || !anchorNode || !focusNode) return
-
-  const root = editor.view.dom
-  const anchorElement =
-    anchorNode.nodeType === Node.ELEMENT_NODE ? anchorNode : anchorNode.parentElement
-  const focusElement =
-    focusNode.nodeType === Node.ELEMENT_NODE ? focusNode : focusNode.parentElement
-  if (!anchorElement || !focusElement) return
-  if (!root.contains(anchorElement) || !root.contains(focusElement)) return
-
-  try {
-    const anchorPos = editor.view.posAtDOM(anchorNode, selection.anchorOffset)
-    const headPos = editor.view.posAtDOM(focusNode, selection.focusOffset)
-    const nextSelection = TextSelection.create(editor.state.doc, anchorPos, headPos)
-    if (!nextSelection.eq(editor.state.selection)) {
-      editor.view.dispatch(editor.state.tr.setSelection(nextSelection))
-    }
-  } catch {
-    // Ignore stale DOM selections; the ProseMirror state remains authoritative.
-  }
-}
-
+// Apply (color) or remove (color === null) the highlight via the shared word-level
+// core. A collapsed caret in a word marks the WHOLE word without changing the
+// visible selection, so the cursor stays put and no blue overlay hides the color.
+// A whitespace caret falls back to today's stored-mark behavior.
 function setHighlightSmart(editor, color) {
   if (!editor) return
-  syncSelectionFromDom(editor)
   const markType = editor.schema.marks.highlight
-  const { selection } = editor.state
-
-  if (selection.empty) {
-    const range = getWordRangeAt(editor.state)
-    if (range) {
-      editor.chain().focus().command(({ tr, dispatch }) => {
-        if (dispatch) {
-          tr.removeMark(range.from, range.to, markType)
-          if (color) tr.addMark(range.from, range.to, markType.create({ color }))
-        }
-        return true
-      }).run()
-      return
-    }
-  }
-
-  if (!selection.empty) {
-    const tr = editor.state.tr.removeMark(selection.from, selection.to, markType)
-    if (color) tr.addMark(selection.from, selection.to, markType.create({ color }))
-    editor.view.dispatch(tr)
-    return
-  }
+  const acted = applyMarkToTarget(editor, markType, {
+    attrs: color ? { color } : null,
+    remove: !color,
+  })
+  if (acted) return
 
   // Caret on whitespace: keep today's stored-mark behavior.
   if (!color) editor.chain().focus().unsetHighlight().run()
@@ -170,13 +148,13 @@ export function HighlightTool({ editor }) {
   // which the inclusive:false mark gets wrong at word edges, so toggling off
   // failed there.
   const highlightActive = editor
-    ? isHighlightActiveForToggle(editor.state, editor.schema.marks.highlight)
+    ? isMarkActiveForToggle(editor.state, editor.schema.marks.highlight)
     : false
 
   const apply = () => {
     syncSelectionFromDom(editor)
     const activeNow = editor
-      ? isHighlightActiveForToggle(editor.state, editor.schema.marks.highlight)
+      ? isMarkActiveForToggle(editor.state, editor.schema.marks.highlight)
       : false
     const remove = activeNow || !highlightColor
     setHighlightSmart(editor, remove ? null : highlightColor)
@@ -230,21 +208,27 @@ export function TextColorTool({ editor }) {
   const refs = useMemo(() => [wrapRef, pickerRef], [])
   useOutsideClick({ isOpen: open, onClose: () => setOpen(false), refs })
 
-  const apply = () => {
+  // Text color is the attribute-mark sibling of Highlight: the textStyle mark
+  // carries a `color` attr. Route through the shared word-level core so a caret
+  // in a word recolors the WHOLE word; a whitespace caret falls back to the
+  // standard setColor/unsetColor stored-mark behavior.
+  const setColorSmart = (color) => {
     if (!editor) return
-    if (!textColor) cmd(editor)?.unsetColor().run()
-    else cmd(editor)?.setColor(textColor).run()
+    const markType = editor.schema.marks.textStyle
+    const acted = applyMarkToTarget(editor, markType, {
+      attrs: color ? { color } : null,
+      remove: !color,
+    })
+    if (acted) return
+    if (!color) cmd(editor)?.unsetColor().run()
+    else cmd(editor)?.setColor(color).run()
   }
 
+  const apply = () => setColorSmart(textColor || null)
+
   const pick = (color) => {
-    if (!editor) return
-    if (!color) {
-      setTextColor(null)
-      cmd(editor)?.unsetColor().run()
-    } else {
-      setTextColor(color)
-      cmd(editor)?.setColor(color).run()
-    }
+    setTextColor(color || null)
+    setColorSmart(color || null)
     setOpen(false)
   }
 

--- a/src/utils/__tests__/smartMark.test.js
+++ b/src/utils/__tests__/smartMark.test.js
@@ -1,0 +1,106 @@
+import { describe, it, expect } from 'vitest'
+import { Schema } from '@tiptap/pm/model'
+import { EditorState, TextSelection } from '@tiptap/pm/state'
+import { isMarkActiveForToggle } from '../smartMark'
+
+// Minimal ProseMirror schema with a plain-text block plus a couple of marks.
+// `underline` stands in for the inclusive Bold/Italic/Underline family; `em`
+// is a second mark to confirm targeting is mark-specific.
+const schema = new Schema({
+  nodes: {
+    doc: { content: 'block+' },
+    paragraph: { group: 'block', content: 'inline*' },
+    text: { group: 'inline' },
+  },
+  marks: {
+    underline: {},
+    em: {},
+  },
+})
+
+const { doc, paragraph } = schema.nodes
+const underline = schema.marks.underline
+const em = schema.marks.em
+
+const p = (text) => paragraph.create(null, text ? schema.text(text) : null)
+
+// Build a base state, then mark [from, to] with the given mark.
+const stateWithMark = (docNode, markType, from, to) => {
+  let state = EditorState.create({ doc: docNode, schema })
+  if (from != null && to != null) {
+    state = state.apply(state.tr.addMark(from, to, markType.create()))
+  }
+  return state
+}
+
+const withCursor = (state, pos) =>
+  state.apply(state.tr.setSelection(TextSelection.create(state.doc, pos)))
+
+const withSelection = (state, from, to) =>
+  state.apply(state.tr.setSelection(TextSelection.create(state.doc, from, to)))
+
+describe('isMarkActiveForToggle', () => {
+  // doc: paragraph("hello world") -> text starts at doc pos 1.
+  // positions: h=1 e=2 l=3 l=4 o=5 (space)=6 w=7 o=8 r=9 l=10 d=11, end=12
+  // Underline the first word "hello" = [1, 6].
+  const d = doc.create(null, [p('hello world')])
+
+  it('returns true with caret at the start of a marked word', () => {
+    const state = withCursor(stateWithMark(d, underline, 1, 6), 1)
+    expect(isMarkActiveForToggle(state, underline)).toBe(true)
+  })
+
+  it('returns true with caret in the middle of a marked word', () => {
+    const state = withCursor(stateWithMark(d, underline, 1, 6), 3)
+    expect(isMarkActiveForToggle(state, underline)).toBe(true)
+  })
+
+  it('returns true with caret at the end of a marked word', () => {
+    const state = withCursor(stateWithMark(d, underline, 1, 6), 6)
+    expect(isMarkActiveForToggle(state, underline)).toBe(true)
+  })
+
+  it('returns false with caret anywhere in an unmarked word', () => {
+    const state = withCursor(stateWithMark(d, underline, 1, 6), 9) // inside "world"
+    expect(isMarkActiveForToggle(state, underline)).toBe(false)
+  })
+
+  it('is mark-specific: an underlined word is not "italic active"', () => {
+    const state = withCursor(stateWithMark(d, underline, 1, 6), 3)
+    expect(isMarkActiveForToggle(state, em)).toBe(false)
+  })
+
+  it('returns true for a non-empty selection over marked text', () => {
+    const state = withSelection(stateWithMark(d, underline, 1, 6), 1, 6)
+    expect(isMarkActiveForToggle(state, underline)).toBe(true)
+  })
+
+  it('returns false for a non-empty selection over plain text', () => {
+    const state = withSelection(stateWithMark(d, underline, 1, 6), 7, 12)
+    expect(isMarkActiveForToggle(state, underline)).toBe(false)
+  })
+
+  it('reflects stored marks for a caret on whitespace between words', () => {
+    // "hi  there": h=1 i=2 (sp)=3 (sp)=4 t=5 ...; caret at pos 4 sits between
+    // two spaces (no word). With no stored mark applied -> false.
+    const dd = doc.create(null, [p('hi  there')])
+    const state = withCursor(stateWithMark(dd, underline), 4)
+    expect(isMarkActiveForToggle(state, underline)).toBe(false)
+
+    // With the mark in storedMarks, the whitespace caret reports active.
+    const stored = state.apply(state.tr.addStoredMark(underline.create()))
+    expect(isMarkActiveForToggle(stored, underline)).toBe(true)
+  })
+
+  it('returns false for an empty block', () => {
+    const empty = doc.create(null, [p()])
+    const state = withCursor(stateWithMark(empty, underline), 1)
+    expect(isMarkActiveForToggle(state, underline)).toBe(false)
+  })
+
+  it('returns false for null/missing args', () => {
+    expect(isMarkActiveForToggle(null, underline)).toBe(false)
+    const state = withCursor(stateWithMark(d, underline, 1, 6), 3)
+    expect(isMarkActiveForToggle(state, null)).toBe(false)
+  })
+})

--- a/src/utils/highlightState.js
+++ b/src/utils/highlightState.js
@@ -1,30 +1,6 @@
-// Pure ProseMirror-state helper: decide whether the highlight toggle should
-// remove (vs add). Mirrors setHighlightSmart's targeting so the toggle decision
-// matches the action — the word under a collapsed caret, or the current
-// selection — instead of relying on caret-adjacency marks (isActive), which the
-// inclusive:false highlight mark gets wrong at word edges.
+// Thin compatibility re-export. The highlight toggle decision was generalized
+// into the mark-agnostic isMarkActiveForToggle in ./smartMark, so Bold, Italic,
+// Underline, Text color, and Highlight share one implementation. Kept as an
+// alias so existing imports (and highlightState.test.js) keep working.
 
-import { getWordRangeAt } from './wordRange'
-
-/**
- * True when the highlight mark is present on the toggle target:
- * the word under a collapsed caret, or the current non-empty selection.
- *
- * @param {import('@tiptap/pm/state').EditorState} state
- * @param {import('@tiptap/pm/model').MarkType} markType
- * @returns {boolean}
- */
-export const isHighlightActiveForToggle = (state, markType) => {
-  if (!state || !markType) return false
-  const { selection } = state
-
-  if (selection.empty) {
-    const range = getWordRangeAt(state)
-    if (range) return state.doc.rangeHasMark(range.from, range.to, markType)
-    // Caret on whitespace / empty block: fall back to stored/adjacent marks.
-    const marks = state.storedMarks || selection.$from.marks()
-    return marks.some((m) => m.type === markType)
-  }
-
-  return state.doc.rangeHasMark(selection.from, selection.to, markType)
-}
+export { isMarkActiveForToggle as isHighlightActiveForToggle } from './smartMark'

--- a/src/utils/smartMark.js
+++ b/src/utils/smartMark.js
@@ -1,0 +1,112 @@
+// Shared, mark-agnostic helpers for "word-level" cursor formatting. These
+// generalize the highlight behavior so Bold, Italic, Underline, Text color, and
+// Highlight all act on the whole word under a collapsed caret WITHOUT moving the
+// caret or showing a native blue selection overlay.
+//
+// The single code path lives here; the toolbar tools and highlightState re-use
+// it so there is one implementation, not a parallel system per mark.
+
+import { TextSelection } from '@tiptap/pm/state'
+import { getWordRangeAt } from './wordRange'
+
+/**
+ * Sync the DOM selection into ProseMirror. On touch/mobile the editor selection
+ * often lives in the DOM only (no editor focus), so we map it back into the
+ * ProseMirror state before acting. The ProseMirror state stays authoritative if
+ * the DOM selection is stale or outside the editor.
+ *
+ * @param {import('@tiptap/core').Editor} editor
+ */
+export function syncSelectionFromDom(editor) {
+  const selection = window.getSelection?.()
+  const anchorNode = selection?.anchorNode
+  const focusNode = selection?.focusNode
+  if (!editor || !selection || selection.rangeCount === 0 || !anchorNode || !focusNode) return
+
+  const root = editor.view.dom
+  const anchorElement =
+    anchorNode.nodeType === Node.ELEMENT_NODE ? anchorNode : anchorNode.parentElement
+  const focusElement =
+    focusNode.nodeType === Node.ELEMENT_NODE ? focusNode : focusNode.parentElement
+  if (!anchorElement || !focusElement) return
+  if (!root.contains(anchorElement) || !root.contains(focusElement)) return
+
+  try {
+    const anchorPos = editor.view.posAtDOM(anchorNode, selection.anchorOffset)
+    const headPos = editor.view.posAtDOM(focusNode, selection.focusOffset)
+    const nextSelection = TextSelection.create(editor.state.doc, anchorPos, headPos)
+    if (!nextSelection.eq(editor.state.selection)) {
+      editor.view.dispatch(editor.state.tr.setSelection(nextSelection))
+    }
+  } catch {
+    // Ignore stale DOM selections; the ProseMirror state remains authoritative.
+  }
+}
+
+/**
+ * True when the mark is present on the toggle target: the word under a collapsed
+ * caret, or the current non-empty selection. Mirrors applyMarkToTarget's
+ * targeting so the toggle decision matches the action — instead of relying on
+ * caret-adjacency marks (isActive), which inclusive:false marks get wrong at
+ * word edges.
+ *
+ * @param {import('@tiptap/pm/state').EditorState} state
+ * @param {import('@tiptap/pm/model').MarkType} markType
+ * @returns {boolean}
+ */
+export const isMarkActiveForToggle = (state, markType) => {
+  if (!state || !markType) return false
+  const { selection } = state
+
+  if (selection.empty) {
+    const range = getWordRangeAt(state)
+    if (range) return state.doc.rangeHasMark(range.from, range.to, markType)
+    // Caret on whitespace / empty block: fall back to stored/adjacent marks.
+    const marks = state.storedMarks || selection.$from.marks()
+    return marks.some((m) => m.type === markType)
+  }
+
+  return state.doc.rangeHasMark(selection.from, selection.to, markType)
+}
+
+/**
+ * Apply (or remove) a mark on the word under a collapsed caret, or on the
+ * current selection. The caret stays collapsed — we never setTextSelection, so
+ * no blue overlay flashes over the formatted word.
+ *
+ * Returns false (without acting) when there is no word/selection target — a
+ * caret on whitespace or an empty block — so callers can fall back to the
+ * standard stored-mark command ("format the next typed characters").
+ *
+ * @param {import('@tiptap/core').Editor} editor
+ * @param {import('@tiptap/pm/model').MarkType} markType
+ * @param {{ attrs?: object | null, remove?: boolean }} [options]
+ * @returns {boolean} true when a word/selection target was acted on
+ */
+export function applyMarkToTarget(editor, markType, { attrs = null, remove = false } = {}) {
+  if (!editor || !markType) return false
+  syncSelectionFromDom(editor)
+
+  const { selection } = editor.state
+  let range = null
+  if (selection.empty) {
+    range = getWordRangeAt(editor.state)
+    if (!range) return false // whitespace caret: let the caller fall back
+  } else {
+    range = { from: selection.from, to: selection.to }
+  }
+
+  editor
+    .chain()
+    .focus()
+    .command(({ tr, dispatch }) => {
+      if (dispatch) {
+        tr.removeMark(range.from, range.to, markType)
+        if (!remove) tr.addMark(range.from, range.to, markType.create(attrs))
+      }
+      return true
+    })
+    .run()
+
+  return true
+}


### PR DESCRIPTION
## Summary

Makes **Bold, Italic, Underline, and Text color** consistent with the recent **Highlight** UX: with a collapsed caret inside a word (nothing selected), clicking the button now formats the **whole word** — no blue selection flash, caret stays put. Previously these four only armed a stored mark for the *next* typed characters.

**Strikethrough is unchanged** (still whole-line).

## Approach — consolidate, don't layer

The highlight word-targeting logic is extracted into a shared, mark-agnostic core and Highlight is refactored onto it, so there is a single code path rather than a parallel system per mark.

New `src/utils/smartMark.js`:
- `syncSelectionFromDom(editor)` — moved out of `textTools.jsx` (defined once now)
- `isMarkActiveForToggle(state, markType)` — generic version of the old `isHighlightActiveForToggle`; decides remove-vs-add by checking the word under the caret / the selection / stored marks
- `applyMarkToTarget(editor, markType, { attrs, remove })` — stamps a mark on the word under a collapsed caret (or the selection) via a ProseMirror transaction without moving the caret; returns `false` on a whitespace caret so callers fall back to the standard stored-mark command

`src/utils/highlightState.js` becomes a thin re-export for back-compat (keeps its existing test green).

In `textTools.jsx`:
- **Bold/Italic/Underline** — `active` + toggle route through the shared core, with the old `toggleBold/Italic/Underline` chain as the whitespace-caret fallback
- **Text color** — `textStyle` + `color` attr routed through `applyMarkToTarget`; `setColor`/`unsetColor` as fallback. Picker, store wiring, color bar unchanged
- **Highlight** — refactored onto the shared core; behavior identical

## Test plan

- [x] **Unit** — new `src/utils/__tests__/smartMark.test.js` (caret at word start/middle/end, unmarked word, mark-specificity, selection, whitespace caret with/without stored mark, empty block, null args). Full suite: **414 pass** (was 404)
- [x] **Build** passes; ESLint clean on changed files
- [x] **E2E** — new `e2e/underline-toggle-cursor.spec.js` (Underline/Bold/Italic toggle the whole word + collapsed-selection assertions; text-color pick case; desktop-only, mobile variants skip). Existing `highlight-toggle-cursor.spec.js` unchanged → relying on CI
- [ ] **Manual** — click into the middle of a word and hit Bold / Italic / Underline / Text color; whole word formats with no blue flash; strikethrough still takes the whole line

🤖 Generated with [Claude Code](https://claude.com/claude-code)