### PR TITLE
feat: navigation UX overhaul — make movement around the app "just work"

### DIFF
--- a/e2e/navigation-ux-overhaul.spec.js
+++ b/e2e/navigation-ux-overhaul.spec.js
@@ -1,0 +1,207 @@
+/**
+ * Navigation UX overhaul — "movement just works".
+ *
+ * Covers the headline behaviors from the navigation overhaul:
+ *   - Per-page scroll restoration on the correct surface per viewport
+ *     (desktop `.editor-panel.scrollTop`, mobile `window.scrollY`); fresh pages
+ *     start at the top.
+ *   - Create → delete returns you to the page you were on before.
+ *   - Clicking a section opens its first page; an empty section shows the
+ *     contextual empty state.
+ *   - A deep link to a deleted page falls back gracefully with a notice instead
+ *     of a blank editor.
+ */
+import { test, expect } from './fixtures'
+import {
+  createNotebook,
+  createPage,
+  createSection,
+  deleteNotebookById,
+  ensureNavigationVisible,
+  getSupabase,
+  waitForApp,
+} from './test-helpers'
+
+const longContent = (lines) => ({
+  type: 'doc',
+  content: Array.from({ length: lines }, (_, i) => ({
+    type: 'paragraph',
+    content: [{ type: 'text', text: `Long page line ${i + 1}` }],
+  })),
+})
+
+const getScroll = (page, isMobile) =>
+  page.evaluate((mob) => {
+    if (mob) return window.scrollY
+    const el = document.querySelector('.editor-panel')
+    return el ? el.scrollTop : 0
+  }, isMobile)
+
+const setScroll = (page, isMobile, top) =>
+  page.evaluate(
+    ({ mob, value }) => {
+      if (mob) {
+        window.scrollTo(0, value)
+      } else {
+        const el = document.querySelector('.editor-panel')
+        if (el) el.scrollTop = value
+      }
+    },
+    { mob: isMobile, value: top },
+  )
+
+const gotoHash = async (page, hash) => {
+  await page.evaluate(() => {
+    window.location.hash = ''
+  })
+  await page.evaluate((h) => {
+    window.location.hash = h
+  }, hash)
+}
+
+test.describe('navigation UX overhaul', () => {
+  let notebook = null
+  let secMain = null
+  let secSecond = null
+  let secEmpty = null
+  let pageOne = null
+  let pageTwo = null
+  let pageThree = null
+  let longPage = null
+
+  test.beforeAll(async () => {
+    const { client, userId } = await getSupabase()
+    const stamp = Date.now()
+    notebook = await createNotebook(client, userId, `Nav UX ${stamp}`, -9500)
+    secMain = await createSection(client, userId, notebook.id, `Main ${stamp}`, 0)
+    secSecond = await createSection(client, userId, notebook.id, `Second ${stamp}`, 1)
+    secEmpty = await createSection(client, userId, notebook.id, `Empty ${stamp}`, 2)
+
+    pageOne = await createPage(client, userId, secMain.id, 'Page One', {
+      type: 'doc',
+      content: [{ type: 'paragraph', content: [{ type: 'text', text: 'one' }] }],
+    }, 0)
+    pageTwo = await createPage(client, userId, secMain.id, 'Page Two', {
+      type: 'doc',
+      content: [{ type: 'paragraph', content: [{ type: 'text', text: 'two' }] }],
+    }, 1)
+    pageThree = await createPage(client, userId, secMain.id, 'Page Three', {
+      type: 'doc',
+      content: [{ type: 'paragraph', content: [{ type: 'text', text: 'three' }] }],
+    }, 2)
+    longPage = await createPage(client, userId, secMain.id, 'Long Page', longContent(90), 3)
+    await createPage(client, userId, secSecond.id, 'Second First', {
+      type: 'doc',
+      content: [{ type: 'paragraph', content: [{ type: 'text', text: 'second first' }] }],
+    }, 0)
+  })
+
+  test.afterAll(async () => {
+    const { client } = await getSupabase()
+    await deleteNotebookById(client, notebook?.id)
+  })
+
+  const hashFor = (sectionId, pageId) => `#nb=${notebook.id}&sec=${sectionId}&pg=${pageId}`
+
+  test('restores per-page scroll position on the right surface; fresh pages start at top', async ({
+    page,
+    isMobile,
+  }) => {
+    await waitForApp(page, hashFor(secMain.id, longPage.id))
+    await expect(page.locator('.title-input')).toHaveValue('Long Page')
+
+    // Scroll the long page down and let the in-memory offset record.
+    await setScroll(page, isMobile, 700)
+    await page.waitForTimeout(600)
+    const saved = await getScroll(page, isMobile)
+    expect(saved).toBeGreaterThan(150)
+
+    // Switch away to a short page, then back.
+    await gotoHash(page, hashFor(secMain.id, pageOne.id))
+    await expect(page.locator('.title-input')).toHaveValue('Page One')
+    await gotoHash(page, hashFor(secMain.id, longPage.id))
+    await expect(page.locator('.title-input')).toHaveValue('Long Page')
+
+    // Offset is restored (not reset to the top).
+    await expect
+      .poll(() => getScroll(page, isMobile), { timeout: 5000 })
+      .toBeGreaterThan(saved - 80)
+
+    // A page with no scroll memory opens at the top.
+    await gotoHash(page, hashFor(secMain.id, pageThree.id))
+    await expect(page.locator('.title-input')).toHaveValue('Page Three')
+    await expect.poll(() => getScroll(page, isMobile), { timeout: 5000 }).toBeLessThan(40)
+  })
+
+  test('create then delete returns to the previously-open page', async ({ page }) => {
+    page.on('dialog', (dialog) => dialog.accept())
+
+    await waitForApp(page, hashFor(secMain.id, pageTwo.id))
+    await expect(page.locator('.title-input')).toHaveValue('Page Two')
+
+    // Create a new page in the same section.
+    await ensureNavigationVisible(page)
+    await page.getByRole('button', { name: '+ New page' }).click()
+    await expect(page.locator('.title-input')).toHaveValue('Untitled')
+
+    // Delete the freshly-created page → land back on Page Two.
+    await page.locator('.title-actions button.ghost', { hasText: 'Delete' }).click()
+    await expect(page.locator('.title-input')).toHaveValue('Page Two', { timeout: 10000 })
+  })
+
+  test('clicking a section opens its first page', async ({ page }) => {
+    await waitForApp(page, hashFor(secMain.id, pageOne.id))
+    await ensureNavigationVisible(page)
+
+    await page
+      .locator('.tree-node-section', { hasText: secSecond.title })
+      .first()
+      .click()
+
+    await expect(page.locator('.title-input')).toHaveValue('Second First', { timeout: 10000 })
+  })
+
+  test('clicking an empty section shows the contextual empty state', async ({ page }) => {
+    await waitForApp(page, hashFor(secMain.id, pageOne.id))
+    await ensureNavigationVisible(page)
+
+    await page
+      .locator('.tree-node-section', { hasText: secEmpty.title })
+      .first()
+      .click()
+
+    await expect(page.locator('.editor-empty')).toContainText('This section is empty', {
+      timeout: 10000,
+    })
+  })
+
+  test('deep link to a deleted page falls back with a notice instead of a blank editor', async ({
+    page,
+  }) => {
+    const { client, userId } = await getSupabase()
+    // A throwaway page reached directly by deep link, then deleted out from under us.
+    const doomed = await createPage(
+      client,
+      userId,
+      secSecond.id,
+      'Doomed Page',
+      { type: 'doc', content: [{ type: 'paragraph', content: [{ type: 'text', text: 'doomed' }] }] },
+      5,
+    )
+
+    await waitForApp(page, hashFor(secMain.id, pageOne.id))
+    await client.from('pages').delete().eq('id', doomed.id)
+
+    // Navigate to the now-dead deep link.
+    await gotoHash(page, hashFor(secSecond.id, doomed.id))
+
+    // Graceful notice, no blank dead-end, and the address bar is rewritten off
+    // the dead page id.
+    await expect(page.locator('.message-inline')).toContainText('no longer exists', {
+      timeout: 10000,
+    })
+    await expect
+      .poll(() => page.evaluate(() => window.location.hash), { timeout: 10000 })
+      .not.toContain(doomed.id)
+  })
+})

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -5,6 +5,7 @@ import { useSections } from './hooks/useSections'
 import { useTrackers } from './hooks/useTrackers'
 import { useSettings } from './hooks/useSettings'
 import { useNavigation } from './hooks/useNavigation'
+import { useNavigationHistory } from './hooks/useNavigationHistory'
 import { useContentHydration } from './hooks/useContentHydration'
 import { useImageUpload } from './hooks/useImageUpload'
 import { useEditorSetup } from './hooks/useEditorSetup'
@@ -14,6 +15,8 @@ import { clearNavHierarchyCache } from './utils/resolveNavHierarchy'
 import { isTouchOnlyDevice } from './utils/device'
 import { registerDeepLinkSelectionApplier } from './utils/navigationHelpers'
 import { applyDeepLinkSelection } from './utils/deepLinkSelection'
+import { pickPostDeleteTarget } from './utils/navigationHistoryHelpers'
+import { SECTION_PAGE_STATUS, getSectionPageEntry } from './utils/sectionPages'
 import {
   readStoredSidebarCollapsed,
   readStoredSelection,
@@ -102,6 +105,48 @@ function App() {
     setTouchNavigationGuard(value)
   }, [])
 
+  // Visited-history → "back to previous" on delete. Each resolver returns where
+  // to land after deleting the open item: the most-recent surviving sibling,
+  // else the adjacent one, else the first remaining (else null).
+  const { recordVisit: recordNavVisit, getRecentExisting } = useNavigationHistory()
+  const getPostDeletePageTarget = useCallback(
+    (remainingItems, deletedId, deletedIndex) =>
+      pickPostDeleteTarget({
+        history: { getRecentExisting },
+        kind: 'pages',
+        remainingItems,
+        deletedId,
+        deletedIndex,
+      }),
+    [getRecentExisting],
+  )
+  const getPostDeleteSectionTarget = useCallback(
+    (remainingItems, deletedId, deletedIndex) =>
+      pickPostDeleteTarget({
+        history: { getRecentExisting },
+        kind: 'sections',
+        remainingItems,
+        deletedId,
+        deletedIndex,
+      }),
+    [getRecentExisting],
+  )
+  const getPostDeleteNotebookTarget = useCallback(
+    (remainingItems, deletedId, deletedIndex) =>
+      pickPostDeleteTarget({
+        history: { getRecentExisting },
+        kind: 'notebooks',
+        remainingItems,
+        deletedId,
+        deletedIndex,
+      }),
+    [getRecentExisting],
+  )
+  // Set when the user explicitly clicks a section, so the auto-open-first-page
+  // effect knows to act once that section's pages have loaded.
+  const autoOpenSectionRef = useRef(null)
+  const [autoOpenNonce, setAutoOpenNonce] = useState(0)
+
   const { session, loading, message: authMessage, setMessage: setAuthMessage, signIn, signOut, userId } = useAuth()
 
   const hydrateContentWithSignedUrls = useContentHydration(session)
@@ -136,7 +181,7 @@ function App() {
     renameNotebook,
     deleteNotebook,
     reorderNotebooks,
-  } = useNotebooks(userId)
+  } = useNotebooks(userId, getPostDeleteNotebookTarget)
 
   // Keep the boot splash up until BOTH auth and the initial notebooks fetch
   // resolve. Gating on auth alone tore the splash down before notebooks loaded,
@@ -156,7 +201,7 @@ function App() {
     moveSection,
     copySection,
     reorderSections,
-  } = useSections(userId, activeNotebookId)
+  } = useSections(userId, activeNotebookId, getPostDeleteSectionTarget)
 
   const {
     trackers,
@@ -187,7 +232,7 @@ function App() {
     flushAllPendingSaves,
     flushSaveForTracker,
     handleResume,
-  } = useTrackers(userId, activeSectionId)
+  } = useTrackers(userId, activeSectionId, getPostDeletePageTarget)
 
   const { session: trackerSession, sessionKey, bumpSessionNonce } = useTrackerSession({
     activeTrackerId,
@@ -198,6 +243,20 @@ function App() {
     templateContentRef,
     hydrateContentWithSignedUrls,
   })
+
+  // Broadcast a single message string to every feature hook's message channel.
+  // Defined here (before useNavigation) and memoized so nav can surface notices
+  // without re-attaching its hashchange listener every render.
+  const setMessage = useCallback(
+    (msg) => {
+      setAuthMessage(msg)
+      setNotebookMessage(msg)
+      setSectionMessage(msg)
+      setTrackerMessage(msg)
+      setSettingsMessage(msg)
+    },
+    [setAuthMessage, setNotebookMessage, setSectionMessage, setTrackerMessage, setSettingsMessage],
+  )
 
   const {
     navIntentRef,
@@ -224,6 +283,7 @@ function App() {
     setPendingNav,
     savedSelectionRef,
     setDeepLinkFocusGuard: setDeepLinkFocusGuardValue,
+    setMessage,
   })
 
   const message = authMessage || notebookMessage || sectionMessage || trackerMessage || settingsMessage
@@ -286,6 +346,55 @@ function App() {
       setMobileSidebarOpen(false)
     }
   }, [isMobileViewport])
+
+  // Record visits so post-delete navigation can return to where you were.
+  useEffect(() => {
+    if (activeNotebookId) recordNavVisit('notebooks', activeNotebookId)
+  }, [activeNotebookId, recordNavVisit])
+  useEffect(() => {
+    if (activeSectionId) recordNavVisit('sections', activeSectionId)
+  }, [activeSectionId, recordNavVisit])
+  useEffect(() => {
+    if (activeTrackerId) recordNavVisit('pages', activeTrackerId)
+  }, [activeTrackerId, recordNavVisit])
+
+  // Close the mobile drawer on hash/deep-link navigation (internal link taps and
+  // browser back both change the hash), mirroring the page-tap close.
+  useEffect(() => {
+    if (!isMobileViewport) return undefined
+    const handleHashChange = () => setMobileSidebarOpen(false)
+    window.addEventListener('hashchange', handleHashChange)
+    return () => window.removeEventListener('hashchange', handleHashChange)
+  }, [isMobileViewport])
+
+  // Auto-open a section's first page when the user clicks the section. Waits for
+  // the section's pages to load, then navigates to the first page — unless the
+  // currently-open page is already in that section (don't yank them away) or the
+  // section is empty (fall through to the contextual empty state).
+  useEffect(() => {
+    const sectionId = autoOpenSectionRef.current
+    if (!sectionId) return
+    if (sectionId !== activeSectionId) return
+    const entry = getSectionPageEntry(sectionPageCache, sectionId)
+    if (entry.status !== SECTION_PAGE_STATUS.LOADED) return
+    autoOpenSectionRef.current = null
+    const activeInSection = entry.pages.some((page) => page.id === activeTrackerId)
+    if (activeInSection) return
+    const firstPage = entry.pages[0]
+    if (!firstPage) return
+    selectNavigationTarget({
+      notebookId: activeNotebookId,
+      sectionId,
+      pageId: firstPage.id,
+    })
+  }, [
+    autoOpenNonce,
+    activeSectionId,
+    activeTrackerId,
+    activeNotebookId,
+    sectionPageCache,
+    selectNavigationTarget,
+  ])
 
   const handleCopyMoveConfirm = async () => {
     const { action, section, destId } = copyMoveModal
@@ -384,14 +493,6 @@ function App() {
     },
     [clearBlockAnchorIfPresent],
   )
-  const setMessage = (msg) => {
-    setAuthMessage(msg)
-    setNotebookMessage(msg)
-    setSectionMessage(msg)
-    setTrackerMessage(msg)
-    setSettingsMessage(msg)
-  }
-
   const uploadImageRef = useRef(null)
 
   const { editor, suppressFocusRef } = useEditorSetup({
@@ -515,6 +616,15 @@ function App() {
     }
     primeTouchNavigationGuard()
     selectNavigationTarget(target)
+    // Arm auto-open of this section's first page (resolved once its pages load).
+    if (target?.sectionId) {
+      autoOpenSectionRef.current = target.sectionId
+      setAutoOpenNonce((n) => n + 1)
+    }
+    // Close the drawer on mobile so tapping a section lands on the opened page.
+    if (isMobileViewport) {
+      setMobileSidebarOpen(false)
+    }
   }
 
   const handlePageSelect = (target) => {
@@ -654,6 +764,27 @@ function App() {
     Boolean(activeTrackerId) ||
     navigationRequiresEditorTransition ||
     dataLoading
+  // A deep-link block jump owns scroll; scroll restoration must defer to it.
+  const deepLinkActive = Boolean(pendingTarget?.blockId)
+  // Contextual empty state: match the message to where the user actually is.
+  const editorEmptyState = (() => {
+    if (activeSectionId) {
+      const entry = getSectionPageEntry(sectionPageCache, activeSectionId)
+      if (entry.status === SECTION_PAGE_STATUS.LOADED && entry.pages.length === 0) {
+        return { kind: 'section', onCreatePage: handleCreatePage }
+      }
+    }
+    if (
+      activeNotebookId &&
+      sections.filter((s) => s.notebook_id === activeNotebookId).length === 0
+    ) {
+      return {
+        kind: 'notebook',
+        onCreateSection: () => createSection(session, activeNotebookId),
+      }
+    }
+    return { kind: 'none' }
+  })()
   const compactBadges = sidebarWidth < SIDEBAR_BADGE_COMPACT_WIDTH
   const isSidebarOpen = isMobileViewport ? mobileSidebarOpen : !sidebarCollapsed
   const workspaceClassName = [
@@ -753,6 +884,8 @@ function App() {
           loading={dataLoading}
           compactBadges={compactBadges}
           isRecipesNotebook={isRecipesNotebook}
+          isMobileViewport={isMobileViewport}
+          mobileSidebarOpen={mobileSidebarOpen}
           session={session}
           onSelectNotebook={handleNotebookSelect}
           onSelectSection={handleSectionSelect}
@@ -838,6 +971,8 @@ function App() {
               onSetTrackerPage={setTrackerPage}
               trackerPageSaving={trackerPageSaving}
               userId={userId}
+              deepLinkActive={deepLinkActive}
+              emptyState={editorEmptyState}
             />
           </>
         )}

--- a/src/components/EditorPanel.jsx
+++ b/src/components/EditorPanel.jsx
@@ -8,6 +8,7 @@ import { scrollElementIntoViewWithToolbar } from '../utils/scrollIntoViewWithToo
 import { useContentZoom } from '../hooks/useContentZoom'
 import { useMobileToolbarTransform } from '../hooks/useMobileToolbarTransform'
 import { useKeepCaretAboveKeyboard } from '../hooks/useKeepCaretAboveKeyboard'
+import { useScrollRestoration } from '../hooks/useScrollRestoration'
 import { useEditorUIStore } from '../stores/editorUIStore'
 import EditorHeader from './editor/EditorHeader'
 import Toolbar from './editor/Toolbar'
@@ -55,6 +56,8 @@ function EditorPanel({
   headerActions = null,
   showAiDaily = true,
   showAiInsert = true,
+  deepLinkActive = false,
+  emptyState = null,
 }) {
   const editorPanelRef = useRef(null)
   const editorShellRef = useRef(null)
@@ -89,6 +92,16 @@ function EditorPanel({
     toolbarRef,
     editorPanelRef,
     padding: 20,
+  })
+  // Remember each page's scroll position and restore it when you return. Gated
+  // on content being rendered; defers to deep-link block jumps and (inside the
+  // hook) to the keyboard / pinch-zoom on mobile.
+  useScrollRestoration({
+    containerRef: editorPanelRef,
+    pageId: trackerId,
+    ready: hasTracker && !editorLocked,
+    skip: deepLinkActive,
+    zoomLevel,
   })
 
   // On touch devices, avoid calling .focus() when the editor isn't already
@@ -720,9 +733,12 @@ function EditorPanel({
     resetOnTrackerChange()
     if (!editor || editorLocked) return
     requestAnimationFrame(() => {
-      editor.chain().focus().run()
+      // Use the touch-guarded command so navigating to a page doesn't pop the
+      // virtual keyboard on mobile (which would also fight scroll restoration).
+      // Desktop still focuses, preserving cursor-placement behavior.
+      editorCmd()?.run()
     })
-  }, [trackerId, editor, editorLocked, resetOnTrackerChange])
+  }, [trackerId, editor, editorLocked, resetOnTrackerChange, editorCmd])
 
   useEffect(() => {
     if (!editor) return
@@ -789,7 +805,12 @@ function EditorPanel({
       {editorLocked && hasTracker ? (
         <EditorSkeleton />
       ) : (
-        <EditorShell ref={editorShellRef} hasTracker={hasTracker} editor={editor} />
+        <EditorShell
+          ref={editorShellRef}
+          hasTracker={hasTracker}
+          editor={editor}
+          emptyState={emptyState}
+        />
       )}
 
       {isZoomSupported && zoomLevel !== 1.0 && (

--- a/src/components/app/NavigationTree.jsx
+++ b/src/components/app/NavigationTree.jsx
@@ -23,6 +23,8 @@ function NavigationTree({
   loading,
   compactBadges = false,
   isRecipesNotebook = false,
+  isMobileViewport = false,
+  mobileSidebarOpen = false,
   session,
   onSelectNotebook,
   onSelectSection,
@@ -75,6 +77,61 @@ function NavigationTree({
 
   const activeNotebook = notebooks.find((notebook) => notebook.id === activeNotebookId) ?? null
   const treeClassName = ['nav-tree-container', className].filter(Boolean).join(' ')
+  const navScrollRef = useRef(null)
+
+  // Auto-reveal the active item: scroll the highlighted (most specific) row into
+  // view inside the tree's own scroll container when the active id changes (deep
+  // links, browser back, boot restore, post-delete). `block: 'nearest'` keeps it
+  // from scrolling the page body / shifting the editor.
+  useEffect(() => {
+    // Don't scroll mid-drag — it would fight the @dnd-kit transform.
+    if (activeItem) return undefined
+    // On mobile the sidebar is an off-canvas drawer; scrolling while it's hidden
+    // is a no-op or janky, so wait until it's open and past the slide-in.
+    if (isMobileViewport && !mobileSidebarOpen) return undefined
+    const container = navScrollRef.current
+    if (!container) return undefined
+
+    const reveal = () => {
+      const activeNodes = container.querySelectorAll('.tree-node.active')
+      const target = activeNodes[activeNodes.length - 1]
+      if (target && typeof target.scrollIntoView === 'function') {
+        target.scrollIntoView({ block: 'nearest' })
+      }
+    }
+
+    let rafId = null
+    const delay = isMobileViewport ? 320 : 0
+    const timer = setTimeout(() => {
+      rafId = requestAnimationFrame(reveal)
+    }, delay)
+    return () => {
+      clearTimeout(timer)
+      if (rafId) cancelAnimationFrame(rafId)
+    }
+  }, [activeNotebookId, activeSectionId, activeTrackerId, activeItem, isMobileViewport, mobileSidebarOpen])
+
+  // Prune persisted expansion state when notebooks/sections are deleted so stale
+  // ids don't accumulate in localStorage.
+  useEffect(() => {
+    const validIds = new Set(notebooks.map((n) => n.id))
+    setExpandedNotebooks((prev) => {
+      const prevSet = prev instanceof Set ? prev : new Set(Array.isArray(prev) ? prev : [])
+      const next = [...prevSet].filter((id) => validIds.has(id))
+      return next.length === prevSet.size ? prev : next
+    })
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- setter is stable; prune only when notebook set changes
+  }, [notebooks])
+
+  useEffect(() => {
+    const validIds = new Set(sections.map((s) => s.id))
+    setExpandedSections((prev) => {
+      const prevSet = prev instanceof Set ? prev : new Set(Array.isArray(prev) ? prev : [])
+      const next = [...prevSet].filter((id) => validIds.has(id))
+      return next.length === prevSet.size ? prev : next
+    })
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- setter is stable; prune only when section set changes
+  }, [sections])
 
   const toggleNotebook = (id) => {
     setExpandedNotebooks((prev) => {
@@ -258,7 +315,7 @@ function NavigationTree({
           onDragEnd={onDragEnd}
           onDragCancel={onDragCancel}
         >
-          <div className="nav-tree-scroll" role="tree" aria-label="Notebook navigation">
+          <div ref={navScrollRef} className="nav-tree-scroll" role="tree" aria-label="Notebook navigation">
             <SortableContext
               items={notebooks.map((notebook) => notebook.id)}
               strategy={verticalListSortingStrategy}
@@ -282,6 +339,7 @@ function NavigationTree({
                         type="button"
                         role="treeitem"
                         aria-expanded={notebookExpanded}
+                        aria-current={notebookActive ? 'page' : undefined}
                         className={`tree-node tree-node-notebook ${notebookActive ? 'active' : ''}`}
                         onClick={() => handleSelectNotebook(notebook.id)}
                         onContextMenu={handleOpenContextMenu('notebook', notebook)}
@@ -341,6 +399,7 @@ function NavigationTree({
                                       type="button"
                                       role="treeitem"
                                       aria-expanded={sectionExpanded}
+                                      aria-current={sectionActive ? 'page' : undefined}
                                       className={`tree-node tree-node-section ${sectionActive ? 'active' : ''}`}
                                       onClick={() => handleSelectSection(section)}
                                       onContextMenu={handleOpenContextMenu('section', section)}

--- a/src/components/editor/EditorShell.jsx
+++ b/src/components/editor/EditorShell.jsx
@@ -1,15 +1,51 @@
 import { forwardRef } from 'react'
 import { EditorContent } from '@tiptap/react'
 
-const EditorShell = forwardRef(function EditorShell({ hasTracker, editor }, ref) {
+// Pick the empty-state message + action that matches where the user actually
+// is, so a blank editor never leaves them guessing what to do next.
+function ContextualEmpty({ emptyState }) {
+  const kind = emptyState?.kind ?? 'none'
+
+  if (kind === 'section') {
+    return (
+      <div className="editor-empty">
+        <p>This section is empty.</p>
+        {emptyState?.onCreatePage ? (
+          <button type="button" className="secondary" onClick={emptyState.onCreatePage}>
+            Create your first page
+          </button>
+        ) : null}
+      </div>
+    )
+  }
+
+  if (kind === 'notebook') {
+    return (
+      <div className="editor-empty">
+        <p>This notebook has no sections yet.</p>
+        {emptyState?.onCreateSection ? (
+          <button type="button" className="secondary" onClick={emptyState.onCreateSection}>
+            Create a section
+          </button>
+        ) : null}
+      </div>
+    )
+  }
+
+  return (
+    <div className="editor-empty">
+      <p>Select a tracker or create a new one to start writing.</p>
+    </div>
+  )
+}
+
+const EditorShell = forwardRef(function EditorShell({ hasTracker, editor, emptyState }, ref) {
   return (
     <div className="editor-shell" ref={ref}>
       {hasTracker ? (
         <EditorContent editor={editor} />
       ) : (
-        <div className="editor-empty">
-          <p>Select a tracker or create a new one to start writing.</p>
-        </div>
+        <ContextualEmpty emptyState={emptyState} />
       )}
     </div>
   )

--- a/src/hooks/useNavigation.js
+++ b/src/hooks/useNavigation.js
@@ -34,6 +34,7 @@ export const useNavigation = ({
   setPendingNav,
   savedSelectionRef,
   setDeepLinkFocusGuard,
+  setMessage,
 }) => {
   const navIntentRef = useRef(null)
   const ignoreHashChangeRef = useRef(null)
@@ -65,6 +66,33 @@ export const useNavigation = ({
     [clearPendingTarget, getPendingNav, setPendingNav],
   )
 
+  // When a hash/deep link resolves to a deleted/missing item, fall back to the
+  // deepest still-existing ancestor (section → notebook → last good selection)
+  // instead of stranding the user on a blank editor.
+  const pickNavFallback = useCallback(
+    (target) => {
+      if (!target) return null
+      if (target.sectionId) {
+        const sec = sections.find((s) => s.id === target.sectionId)
+        if (sec) return { notebookId: sec.notebook_id, sectionId: sec.id, pageId: null, blockId: null }
+      }
+      if (target.notebookId && notebooks.some((n) => n.id === target.notebookId)) {
+        return { notebookId: target.notebookId, sectionId: null, pageId: null, blockId: null }
+      }
+      const saved = savedSelectionRef?.current
+      if (saved?.notebookId && notebooks.some((n) => n.id === saved.notebookId)) {
+        return {
+          notebookId: saved.notebookId,
+          sectionId: saved.sectionId ?? null,
+          pageId: saved.pageId ?? null,
+          blockId: null,
+        }
+      }
+      return null
+    },
+    [notebooks, sections, savedSelectionRef],
+  )
+
   const queueResolvedTarget = useCallback(
     (target, { hashMode = null } = {}) => {
       if (!target?.notebookId) return
@@ -93,15 +121,23 @@ export const useNavigation = ({
       const resolved = await resolveNavHierarchy(parsed)
       if (navVersionRef.current !== version) return
       if (!resolved?.notebookId) {
-        console.warn('[nav] resolveNavHierarchy returned null for hash=%s — navigation dropped', hash)
+        const fallback = pickNavFallback(parsed)
         clearPendingTarget()
-        setInitialNavReady(true)
+        if (fallback) {
+          setMessage?.('That page no longer exists.')
+          // Rewrite the URL to the fallback (replace) so the address bar isn't
+          // left on a dead id and browser-back won't re-trigger it.
+          queueResolvedTarget(fallback, { hashMode: 'replace' })
+        } else {
+          console.warn('[nav] resolveNavHierarchy returned null for hash=%s — navigation dropped', hash)
+          setInitialNavReady(true)
+        }
         return
       }
 
       queueResolvedTarget(resolved)
     },
-    [clearPendingTarget, queueResolvedTarget, setDeepLinkFocusGuard],
+    [clearPendingTarget, queueResolvedTarget, setDeepLinkFocusGuard, pickNavFallback, setMessage],
   )
 
   const selectNavigationTarget = useCallback(
@@ -209,9 +245,14 @@ export const useNavigation = ({
     if (step.type === 'wait') return
 
     if (step.type === 'missing') {
+      const fallback = pickNavFallback(pendingTarget)
       // eslint-disable-next-line react-hooks/set-state-in-effect -- transition nav state when the resolved target is missing
       clearPendingTarget()
       setInitialNavReady(true)
+      if (fallback) {
+        setMessage?.('That page no longer exists.')
+        queueResolvedTarget(fallback, { hashMode: 'replace' })
+      }
       return
     }
 
@@ -260,6 +301,9 @@ export const useNavigation = ({
     setActiveTrackerId,
     flushSaveForTracker,
     clearPendingTarget,
+    pickNavFallback,
+    queueResolvedTarget,
+    setMessage,
   ])
 
   useEffect(() => {

--- a/src/hooks/useNavigationHistory.js
+++ b/src/hooks/useNavigationHistory.js
@@ -1,0 +1,48 @@
+import { useCallback, useRef } from 'react'
+
+// Bound each visit log so it can't grow without limit. Thirty is plenty to find
+// a recently-visited survivor after a delete.
+const MAX_HISTORY = 30
+
+const createVisitLog = () => []
+
+/**
+ * A small in-memory, session-lifetime visited-history for notebooks/sections/
+ * pages. Used to return the user to where they were after deleting the open
+ * item (see pickPostDeleteTarget). Lives in a ref — it never needs to trigger a
+ * re-render, and survives for the lifetime of the App component.
+ */
+export function useNavigationHistory() {
+  const logsRef = useRef({
+    pages: createVisitLog(),
+    sections: createVisitLog(),
+    notebooks: createVisitLog(),
+  })
+
+  // Push `id` as the most-recent visit for `kind`, removing any earlier
+  // occurrence so the latest visit always wins, then bound the log length.
+  const recordVisit = useCallback((kind, id) => {
+    if (!id) return
+    const log = logsRef.current[kind]
+    if (!log) return
+    const filtered = log.filter((entry) => entry !== id)
+    filtered.push(id)
+    logsRef.current[kind] = filtered.slice(-MAX_HISTORY)
+  }, [])
+
+  // Most-recent visited id (for `kind`) that is still present in `existingIds`
+  // and not the excluded id. Returns null when there's no surviving match.
+  const getRecentExisting = useCallback((kind, existingIds, excludeId = null) => {
+    const log = logsRef.current[kind]
+    if (!log) return null
+    const existing = existingIds instanceof Set ? existingIds : new Set(existingIds)
+    for (let i = log.length - 1; i >= 0; i -= 1) {
+      const id = log[i]
+      if (id === excludeId) continue
+      if (existing.has(id)) return id
+    }
+    return null
+  }, [])
+
+  return { recordVisit, getRecentExisting }
+}

--- a/src/hooks/useNotebooks.js
+++ b/src/hooks/useNotebooks.js
@@ -8,7 +8,7 @@ import { clearNavHierarchyCache } from '../utils/resolveNavHierarchy'
 import { runSupabaseQueryWithRetry } from '../utils/supabaseRetry'
 import { reindexSortOrder } from '../utils/sidebarReorder'
 
-export const useNotebooks = (userId) => {
+export const useNotebooks = (userId, getPostDeleteTarget = null) => {
   const [notebooks, setNotebooks] = useState([])
   const [activeNotebookId, setActiveNotebookId] = useState(null)
   const [message, setMessage] = useState('')
@@ -162,10 +162,16 @@ export const useNotebooks = (userId) => {
     }
 
     clearNavHierarchyCache()
+    const deletedIndex = notebooks.findIndex((item) => item.id === notebook.id)
     const nextNotebooks = notebooks.filter((item) => item.id !== notebook.id)
     setNotebooks(nextNotebooks)
     if (notebook.id === activeNotebookId) {
-      setActiveNotebookId(nextNotebooks[0]?.id ?? null)
+      // Land on the most-recent previous notebook (else the adjacent sibling).
+      setActiveNotebookId(
+        getPostDeleteTarget?.(nextNotebooks, notebook.id, deletedIndex) ??
+          nextNotebooks[0]?.id ??
+          null,
+      )
     }
   }
 

--- a/src/hooks/useScrollRestoration.js
+++ b/src/hooks/useScrollRestoration.js
@@ -161,18 +161,21 @@ export function useScrollRestoration({ containerRef, pageId, ready, skip = false
       }
     }
 
+    const getMaxScrollableOffset = (surface) =>
+      Math.max(0, surface.getScrollHeight() - surface.getClientHeight())
+
     const tryApply = () => {
       if (cancelled) return false
       if (mobileOwnsScroll()) return false
       const surface = getEditorScrollSurface(containerRef.current)
-      if (surface.getScrollHeight() >= saved) {
+      if (getMaxScrollableOffset(surface) >= saved) {
         surface.set(saved)
         return true
       }
       return false
     }
 
-    if (initialSurface.getScrollHeight() >= saved) {
+    if (getMaxScrollableOffset(initialSurface) >= saved) {
       // Already tall enough — apply on the next frame in a single pass.
       raf = requestAnimationFrame(() => {
         tryApply()
@@ -190,7 +193,7 @@ export function useScrollRestoration({ containerRef, pageId, ready, skip = false
         // Safety net: apply our best effort (clamped) and stop waiting.
         if (!cancelled && !mobileOwnsScroll()) {
           const surface = getEditorScrollSurface(containerRef.current)
-          surface.set(Math.min(saved, Math.max(0, surface.getScrollHeight())))
+          surface.set(Math.min(saved, getMaxScrollableOffset(surface)))
         }
         finish()
       }, RESTORE_TIMEOUT_MS)

--- a/src/hooks/useScrollRestoration.js
+++ b/src/hooks/useScrollRestoration.js
@@ -1,0 +1,209 @@
+import { useCallback, useEffect, useRef } from 'react'
+import { getEditorScrollSurface } from '../utils/scrollIntoViewWithToolbar'
+import { isKeyboardShown } from '../utils/keyboardShown'
+import { readStoredScrollPositions, saveStoredScrollPositions } from '../utils/storage'
+
+// Debounce only the sessionStorage write — the in-memory map updates on every
+// scroll so switching pages always has the latest offset to hand.
+const PERSIST_DEBOUNCE_MS = 350
+// If layout never grows tall enough for the saved offset, apply our best effort
+// after this long and stop waiting.
+const RESTORE_TIMEOUT_MS = 1500
+
+/**
+ * Per-page scroll restoration for the editor surface.
+ *
+ * - Save: an in-memory `Map<pageId, scrollTop>` records the active page's offset
+ *   on every scroll (cheap); the sessionStorage mirror is debounced.
+ * - Restore: on a page change (once content is `ready`) the saved offset is
+ *   re-applied, waiting via ResizeObserver for the content to grow tall enough
+ *   (images/tables load late) before scrolling — Notesnook's restoreScrollPosition
+ *   mechanism. Fresh pages (no memory) reset to the top.
+ *
+ * Surface detection (desktop `.editor-panel` vs mobile window) is delegated to
+ * `getEditorScrollSurface`. Restoration defers to the keyboard
+ * (`useKeepCaretAboveKeyboard`) and pinch-zoom (`useContentZoom`) on mobile, and
+ * to deep-link block scrolling via the `skip` flag.
+ *
+ * @param {object} params
+ * @param {React.RefObject<HTMLElement>} params.containerRef - the `.editor-panel`
+ * @param {string|null} params.pageId
+ * @param {boolean} params.ready - content rendered (not locked/transitioning)
+ * @param {boolean} [params.skip] - defer entirely (e.g. a deep-link block jump owns scroll)
+ * @param {number} [params.zoomLevel] - current pinch-zoom level; restore is skipped while !== 1
+ */
+export function useScrollRestoration({ containerRef, pageId, ready, skip = false, zoomLevel = 1 }) {
+  // Hydrate the in-memory map from sessionStorage exactly once.
+  const positionsRef = useRef(null)
+  if (positionsRef.current === null) {
+    positionsRef.current = new Map(Object.entries(readStoredScrollPositions()))
+  }
+
+  const persistTimerRef = useRef(null)
+  const restoringRef = useRef(false)
+  const pageIdRef = useRef(pageId)
+  const zoomRef = useRef(zoomLevel)
+  // The page whose scroll we've already settled this navigation, so that a
+  // `skip` toggle (e.g. a deep-link block jump finishing) doesn't re-run restore
+  // and yank the page back to the top.
+  const handledPageRef = useRef(null)
+
+  // Mirror the latest props into refs so the long-lived scroll listener and the
+  // restore guards read current values without re-subscribing every change.
+  useEffect(() => {
+    pageIdRef.current = pageId
+  }, [pageId])
+  useEffect(() => {
+    zoomRef.current = zoomLevel
+  }, [zoomLevel])
+
+  const persist = useCallback(() => {
+    saveStoredScrollPositions(Object.fromEntries(positionsRef.current))
+  }, [])
+
+  // While the keyboard is up or the content is zoomed, other hooks own the
+  // scroll — don't fight them.
+  const mobileOwnsScroll = useCallback(() => isKeyboardShown() || zoomRef.current !== 1, [])
+
+  // --- Save listener -------------------------------------------------------
+  useEffect(() => {
+    if (skip) return undefined
+    const container = containerRef.current
+
+    const recordOffset = () => {
+      if (restoringRef.current) return
+      if (mobileOwnsScroll()) return
+      const id = pageIdRef.current
+      if (!id) return
+      const surface = getEditorScrollSurface(containerRef.current)
+      const top = surface.get()
+      // Re-insert so this page becomes the most-recent (tail) entry.
+      positionsRef.current.delete(id)
+      positionsRef.current.set(id, top)
+      if (persistTimerRef.current) clearTimeout(persistTimerRef.current)
+      persistTimerRef.current = setTimeout(() => {
+        persistTimerRef.current = null
+        persist()
+      }, PERSIST_DEBOUNCE_MS)
+    }
+
+    // Whichever surface scrolls, recordOffset reads the correct one.
+    if (container) container.addEventListener('scroll', recordOffset, { passive: true })
+    window.addEventListener('scroll', recordOffset, { passive: true })
+    // Flush immediately when the page is being hidden/unloaded so a reload
+    // within the debounce window doesn't lose the latest offset.
+    const flush = () => {
+      if (persistTimerRef.current) {
+        clearTimeout(persistTimerRef.current)
+        persistTimerRef.current = null
+      }
+      persist()
+    }
+    window.addEventListener('pagehide', flush)
+
+    return () => {
+      if (container) container.removeEventListener('scroll', recordOffset)
+      window.removeEventListener('scroll', recordOffset)
+      window.removeEventListener('pagehide', flush)
+      if (persistTimerRef.current) {
+        clearTimeout(persistTimerRef.current)
+        persistTimerRef.current = null
+        persist()
+      }
+    }
+  }, [containerRef, skip, persist, mobileOwnsScroll])
+
+  // --- Restore on page change ---------------------------------------------
+  useEffect(() => {
+    if (!ready || !pageId) return undefined
+    if (skip) {
+      // A deep-link block jump owns scroll for this page; mark it handled so we
+      // don't reset it to the top once the deep link clears.
+      handledPageRef.current = pageId
+      return undefined
+    }
+    // Only settle each page once per navigation to it.
+    if (handledPageRef.current === pageId) return undefined
+    handledPageRef.current = pageId
+
+    const saved = positionsRef.current.get(pageId)
+    const initialSurface = getEditorScrollSurface(containerRef.current)
+
+    if (saved == null) {
+      // No memory for this page → start at the top. The scroll container is
+      // reused across page switches, so its scrollTop would otherwise carry over.
+      const raf = requestAnimationFrame(() => initialSurface.set(0))
+      return () => cancelAnimationFrame(raf)
+    }
+
+    // Mobile guards own scroll right now — leave the offset alone.
+    if (mobileOwnsScroll()) return undefined
+
+    restoringRef.current = true
+    let cancelled = false
+    let observer = null
+    let timer = null
+    let raf = null
+
+    const finish = () => {
+      restoringRef.current = false
+      if (observer) {
+        observer.disconnect()
+        observer = null
+      }
+      if (timer) {
+        clearTimeout(timer)
+        timer = null
+      }
+      if (raf) {
+        cancelAnimationFrame(raf)
+        raf = null
+      }
+    }
+
+    const tryApply = () => {
+      if (cancelled) return false
+      if (mobileOwnsScroll()) return false
+      const surface = getEditorScrollSurface(containerRef.current)
+      if (surface.getScrollHeight() >= saved) {
+        surface.set(saved)
+        return true
+      }
+      return false
+    }
+
+    if (initialSurface.getScrollHeight() >= saved) {
+      // Already tall enough — apply on the next frame in a single pass.
+      raf = requestAnimationFrame(() => {
+        tryApply()
+        finish()
+      })
+    } else if (typeof ResizeObserver !== 'undefined') {
+      // Wait for content to grow tall enough, then apply once and disconnect.
+      observer = new ResizeObserver(() => {
+        if (tryApply()) finish()
+      })
+      const observeTarget = containerRef.current?.firstElementChild ?? containerRef.current
+      if (observeTarget) observer.observe(observeTarget)
+      if (typeof document !== 'undefined' && document.body) observer.observe(document.body)
+      timer = setTimeout(() => {
+        // Safety net: apply our best effort (clamped) and stop waiting.
+        if (!cancelled && !mobileOwnsScroll()) {
+          const surface = getEditorScrollSurface(containerRef.current)
+          surface.set(Math.min(saved, Math.max(0, surface.getScrollHeight())))
+        }
+        finish()
+      }, RESTORE_TIMEOUT_MS)
+    } else {
+      raf = requestAnimationFrame(() => {
+        tryApply()
+        finish()
+      })
+    }
+
+    return () => {
+      cancelled = true
+      finish()
+    }
+  }, [pageId, ready, skip, containerRef, mobileOwnsScroll])
+}

--- a/src/hooks/useSections.js
+++ b/src/hooks/useSections.js
@@ -110,7 +110,7 @@ const fixForwardBlockRefs = (content, blockIdMap) => {
   return walk(content)
 }
 
-export const useSections = (userId, activeNotebookId) => {
+export const useSections = (userId, activeNotebookId, getPostDeleteTarget = null) => {
   const [sections, setSections] = useState([])
   const [activeSectionId, setActiveSectionId] = useState(null)
   const [sectionsLoading, setSectionsLoading] = useState(false)
@@ -250,10 +250,19 @@ export const useSections = (userId, activeNotebookId) => {
     }
 
     clearNavHierarchyCache()
+    const notebookSectionsBefore = sections.filter((s) => s.notebook_id === activeNotebookId)
+    const deletedIndex = notebookSectionsBefore.findIndex((s) => s.id === section.id)
     const nextSections = sections.filter((item) => item.id !== section.id)
     setSections(nextSections)
     const notebookSections = nextSections.filter((s) => s.notebook_id === activeNotebookId)
-    setActiveSectionId((prev) => (prev === section.id ? notebookSections[0]?.id ?? null : prev))
+    // Land on the most-recent previous section (else the adjacent sibling).
+    setActiveSectionId((prev) =>
+      prev === section.id
+        ? getPostDeleteTarget?.(notebookSections, section.id, deletedIndex) ??
+          notebookSections[0]?.id ??
+          null
+        : prev,
+    )
   }
 
   const moveSection = async (section, destNotebookId) => {

--- a/src/hooks/useTrackers.js
+++ b/src/hooks/useTrackers.js
@@ -14,7 +14,7 @@ import { useSectionPageCache } from './useSectionPageCache'
 import { usePageContentCache, PAGE_CONTENT_STATUS } from './usePageContentCache'
 import { usePageRealtime } from './sync/usePageRealtime'
 
-export const useTrackers = (userId, activeSectionId) => {
+export const useTrackers = (userId, activeSectionId, getPostDeleteTarget = null) => {
   const [trackers, setTrackers] = useState([])
   const [loadedTrackerSectionId, setLoadedTrackerSectionId] = useState(null)
   const [activeTrackerId, setActiveTrackerId] = useState(null)
@@ -812,12 +812,19 @@ export const useTrackers = (userId, activeSectionId) => {
     }
 
     clearNavHierarchyCache()
+    const deletedIndex = trackers.findIndex((item) => item.id === tracker.id)
     const nextTrackers = trackers.filter((item) => item.id !== tracker.id)
     setTrackers(nextTrackers)
     removeCachedPage(tracker.section_id ?? activeSectionId, tracker.id)
     delete pendingTitleByTrackerRef.current[tracker.id]
     clearPageDraft(tracker.id)
-    setActiveTrackerId((prev) => (prev === tracker.id ? nextTrackers[0]?.id ?? null : prev))
+    // When deleting the open page, land on the user's most-recent previous page
+    // (else the adjacent sibling) instead of always the first page.
+    setActiveTrackerId((prev) =>
+      prev === tracker.id
+        ? getPostDeleteTarget?.(nextTrackers, tracker.id, deletedIndex) ?? nextTrackers[0]?.id ?? null
+        : prev,
+    )
   }
 
   const resolveConflictWithServer = useCallback(() => {

--- a/src/utils/__tests__/navigationHistoryHelpers.test.js
+++ b/src/utils/__tests__/navigationHistoryHelpers.test.js
@@ -1,0 +1,104 @@
+import { describe, it, expect } from 'vitest'
+import { pickPostDeleteTarget } from '../navigationHistoryHelpers'
+
+// A minimal history stub whose getRecentExisting returns the first id in
+// `order` that is still present in existingIds and not excluded.
+function makeHistory(order) {
+  return {
+    getRecentExisting(_kind, existingIds, excludeId = null) {
+      const existing = new Set(existingIds)
+      for (const id of order) {
+        if (id === excludeId) continue
+        if (existing.has(id)) return id
+      }
+      return null
+    },
+  }
+}
+
+const items = (...ids) => ids.map((id) => ({ id }))
+
+describe('pickPostDeleteTarget', () => {
+  it('returns the most-recent visited survivor when history has one', () => {
+    const history = makeHistory(['c', 'b']) // b is most recent surviving
+    const target = pickPostDeleteTarget({
+      history,
+      kind: 'pages',
+      remainingItems: items('a', 'b', 'd'),
+      deletedId: 'c',
+      deletedIndex: 2,
+    })
+    expect(target).toBe('b')
+  })
+
+  it('falls back to the adjacent (next) sibling when history is empty', () => {
+    const history = makeHistory([])
+    // Original order: a, b(deleted), c, d → remaining a, c, d; deletedIndex 1.
+    const target = pickPostDeleteTarget({
+      history,
+      kind: 'pages',
+      remainingItems: items('a', 'c', 'd'),
+      deletedId: 'b',
+      deletedIndex: 1,
+    })
+    expect(target).toBe('c') // the item that followed the deleted one
+  })
+
+  it('falls back to the previous sibling when the deleted item was last', () => {
+    const history = makeHistory([])
+    // Original: a, b, c(deleted) → remaining a, b; deletedIndex 2 (no next).
+    const target = pickPostDeleteTarget({
+      history,
+      kind: 'pages',
+      remainingItems: items('a', 'b'),
+      deletedId: 'c',
+      deletedIndex: 2,
+    })
+    expect(target).toBe('b')
+  })
+
+  it('falls back to the first remaining item when no history and no index', () => {
+    const target = pickPostDeleteTarget({
+      history: makeHistory([]),
+      kind: 'sections',
+      remainingItems: items('x', 'y'),
+      deletedId: 'z',
+    })
+    expect(target).toBe('x')
+  })
+
+  it('returns null when nothing remains', () => {
+    const target = pickPostDeleteTarget({
+      history: makeHistory(['z']),
+      kind: 'notebooks',
+      remainingItems: [],
+      deletedId: 'z',
+      deletedIndex: 0,
+    })
+    expect(target).toBeNull()
+  })
+
+  it('never returns the deleted id', () => {
+    // History prefers the deleted id, but it must be excluded.
+    const history = makeHistory(['gone', 'keep'])
+    const target = pickPostDeleteTarget({
+      history,
+      kind: 'pages',
+      remainingItems: items('keep'),
+      deletedId: 'gone',
+      deletedIndex: 0,
+    })
+    expect(target).toBe('keep')
+  })
+
+  it('works with a null history (no recorded visits)', () => {
+    const target = pickPostDeleteTarget({
+      history: null,
+      kind: 'pages',
+      remainingItems: items('a', 'b', 'c'),
+      deletedId: 'd',
+      deletedIndex: 1,
+    })
+    expect(target).toBe('b')
+  })
+})

--- a/src/utils/__tests__/storage.test.js
+++ b/src/utils/__tests__/storage.test.js
@@ -1,5 +1,11 @@
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
-import { readStoredColor, saveStoredColor } from '../storage'
+import {
+  readStoredColor,
+  saveStoredColor,
+  readStoredScrollPositions,
+  saveStoredScrollPositions,
+} from '../storage'
+import { MAX_SCROLL_POSITIONS, SCROLL_POSITIONS_KEY } from '../constants'
 
 const KEY = 'life-tracker:test-color'
 
@@ -56,5 +62,60 @@ describe('readStoredColor / saveStoredColor', () => {
   it('returns the fallback when window is undefined (SSR-safe)', () => {
     delete globalThis.window
     expect(readStoredColor(KEY, '#fef08a')).toBe('#fef08a')
+  })
+})
+
+describe('readStoredScrollPositions / saveStoredScrollPositions', () => {
+  beforeEach(() => {
+    globalThis.window = { sessionStorage: createLocalStorageStub() }
+  })
+
+  afterEach(() => {
+    delete globalThis.window
+  })
+
+  it('round-trips a map of page offsets', () => {
+    saveStoredScrollPositions({ a: 120, b: 0, c: 999 })
+    expect(readStoredScrollPositions()).toEqual({ a: 120, b: 0, c: 999 })
+  })
+
+  it('returns an empty object when nothing is stored', () => {
+    expect(readStoredScrollPositions()).toEqual({})
+  })
+
+  it('guards against malformed JSON', () => {
+    globalThis.window.sessionStorage.setItem(SCROLL_POSITIONS_KEY, '{not json')
+    expect(readStoredScrollPositions()).toEqual({})
+  })
+
+  it('drops non-numeric / non-finite values on read', () => {
+    globalThis.window.sessionStorage.setItem(
+      SCROLL_POSITIONS_KEY,
+      JSON.stringify({ a: 10, b: 'nope', c: null, d: 42 }),
+    )
+    expect(readStoredScrollPositions()).toEqual({ a: 10, d: 42 })
+  })
+
+  it('drops non-numeric values on write', () => {
+    saveStoredScrollPositions({ a: 10, b: 'nope', c: 20 })
+    expect(readStoredScrollPositions()).toEqual({ a: 10, c: 20 })
+  })
+
+  it('caps storage to the most-recent MAX_SCROLL_POSITIONS entries', () => {
+    const positions = {}
+    for (let i = 0; i < MAX_SCROLL_POSITIONS + 10; i += 1) {
+      positions[`page-${i}`] = i
+    }
+    saveStoredScrollPositions(positions)
+    const read = readStoredScrollPositions()
+    expect(Object.keys(read)).toHaveLength(MAX_SCROLL_POSITIONS)
+    // The oldest (lowest-index) entries are evicted; the newest survive.
+    expect(read['page-0']).toBeUndefined()
+    expect(read[`page-${MAX_SCROLL_POSITIONS + 9}`]).toBe(MAX_SCROLL_POSITIONS + 9)
+  })
+
+  it('returns an empty object when window is undefined (SSR-safe)', () => {
+    delete globalThis.window
+    expect(readStoredScrollPositions()).toEqual({})
   })
 })

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -7,6 +7,12 @@ export const STORAGE_KEY = 'life-tracker:lastSelection'
 export const SIDEBAR_WIDTH_STORAGE_KEY = 'life-tracker:sidebarWidth'
 export const SIDEBAR_COLLAPSED_KEY = 'life-tracker:sidebarCollapsed'
 
+// Per-page scroll positions, session-scoped (sessionStorage) so they survive a
+// reload within the same tab but don't accumulate across sessions.
+export const SCROLL_POSITIONS_KEY = 'life-tracker:scrollPositions'
+// Keep only the most-recent N pages' scroll offsets so the store stays small.
+export const MAX_SCROLL_POSITIONS = 50
+
 // Last-used toolbar color tools, persisted across sessions.
 export const HIGHLIGHT_COLOR_KEY = 'life-tracker:highlightColor'
 export const TEXT_COLOR_KEY = 'life-tracker:textColor'

--- a/src/utils/navigationHistoryHelpers.js
+++ b/src/utils/navigationHistoryHelpers.js
@@ -1,0 +1,49 @@
+/**
+ * Pick where to land after deleting the currently-open item (page, section, or
+ * notebook). Mirrors the email-client convention used by Mail/Outlook and the
+ * "pop to previous tab" behavior in Notesnook's editor store:
+ *
+ *   1. The most-recently-visited surviving sibling (so create→delete returns you
+ *      to the page you were on before).
+ *   2. Otherwise the sibling adjacent to the deleted item's old slot — prefer the
+ *      next item, fall back to the previous (handles deleting an item reached
+ *      directly via deep link, with no visit history).
+ *   3. Otherwise the first remaining item.
+ *   4. Otherwise null (nothing left to select).
+ *
+ * Never returns `deletedId` — `remainingItems` already excludes it.
+ *
+ * @param {object} params
+ * @param {{ getRecentExisting: (kind: string, existingIds: string[], excludeId?: string|null) => string|null }|null} params.history
+ * @param {'pages'|'sections'|'notebooks'} params.kind
+ * @param {Array<{ id: string }>} params.remainingItems - items AFTER removing the deleted one, in display order
+ * @param {string} params.deletedId
+ * @param {number|null} [params.deletedIndex] - index of the deleted item in the ORIGINAL ordered list
+ * @returns {string|null}
+ */
+export function pickPostDeleteTarget({
+  history = null,
+  kind,
+  remainingItems = [],
+  deletedId,
+  deletedIndex = null,
+}) {
+  const existingIds = remainingItems.map((item) => item.id)
+
+  // 1. Most-recent visited survivor.
+  const recent = history?.getRecentExisting?.(kind, existingIds, deletedId) ?? null
+  if (recent) return recent
+
+  // 2. Sibling adjacent to the deleted item's old slot. After removal, the item
+  //    that followed the deleted one now sits at `deletedIndex`; prefer it, else
+  //    fall back to the item that preceded it.
+  if (deletedIndex != null && remainingItems.length > 0) {
+    const next = remainingItems[deletedIndex]
+    if (next) return next.id
+    const prev = remainingItems[deletedIndex - 1]
+    if (prev) return prev.id
+  }
+
+  // 3 & 4. First remaining item, else nothing.
+  return remainingItems[0]?.id ?? null
+}

--- a/src/utils/scrollIntoViewWithToolbar.js
+++ b/src/utils/scrollIntoViewWithToolbar.js
@@ -89,6 +89,46 @@ export function pickScrollSurface(container) {
 }
 
 /**
+ * Per-page scroll restoration needs to read and write a single scalar offset on
+ * whichever surface actually scrolls — the `.editor-panel` container on desktop,
+ * but the window on mobile (responsive.css overrides the panel to
+ * `overflow-y: visible`). This mirrors `pickScrollSurface`'s detection but
+ * exposes a simple get/set offset accessor plus the surface's scroll height so
+ * the restoration hook can wait for layout to grow tall enough.
+ *
+ * @param {HTMLElement | null | undefined} container
+ * @returns {{ get: () => number, set: (top: number) => void, getScrollHeight: () => number, target: EventTarget | null }}
+ */
+export function getEditorScrollSurface(container) {
+  const isScrollContainer =
+    container &&
+    container.scrollHeight > container.clientHeight &&
+    typeof window !== 'undefined' &&
+    getComputedStyle(container).overflowY !== 'visible'
+
+  if (isScrollContainer) {
+    return {
+      get: () => container.scrollTop,
+      set: (top) => {
+        container.scrollTop = top
+      },
+      getScrollHeight: () => container.scrollHeight,
+      target: container,
+    }
+  }
+
+  return {
+    get: () => (typeof window !== 'undefined' ? window.scrollY : 0),
+    set: (top) => {
+      if (typeof window !== 'undefined') window.scrollTo(0, top)
+    },
+    getScrollHeight: () =>
+      typeof document !== 'undefined' ? document.documentElement.scrollHeight : 0,
+    target: typeof window !== 'undefined' ? window : null,
+  }
+}
+
+/**
  * Decide how a toolbar (or any fixed/sticky chrome) shrinks the safe band of a
  * scroll surface. The toolbar can live at the *top* of the surface (desktop:
  * `position: sticky; top: 0`) or at the *bottom* (mobile: `position: fixed;

--- a/src/utils/scrollIntoViewWithToolbar.js
+++ b/src/utils/scrollIntoViewWithToolbar.js
@@ -97,7 +97,7 @@ export function pickScrollSurface(container) {
  * the restoration hook can wait for layout to grow tall enough.
  *
  * @param {HTMLElement | null | undefined} container
- * @returns {{ get: () => number, set: (top: number) => void, getScrollHeight: () => number, target: EventTarget | null }}
+ * @returns {{ get: () => number, set: (top: number) => void, getScrollHeight: () => number, getClientHeight: () => number, target: EventTarget | null }}
  */
 export function getEditorScrollSurface(container) {
   const isScrollContainer =
@@ -113,6 +113,7 @@ export function getEditorScrollSurface(container) {
         container.scrollTop = top
       },
       getScrollHeight: () => container.scrollHeight,
+      getClientHeight: () => container.clientHeight,
       target: container,
     }
   }
@@ -124,6 +125,11 @@ export function getEditorScrollSurface(container) {
     },
     getScrollHeight: () =>
       typeof document !== 'undefined' ? document.documentElement.scrollHeight : 0,
+    getClientHeight: () => {
+      if (typeof document !== 'undefined') return document.documentElement.clientHeight
+      if (typeof window !== 'undefined') return window.innerHeight
+      return 0
+    },
     target: typeof window !== 'undefined' ? window : null,
   }
 }

--- a/src/utils/storage.js
+++ b/src/utils/storage.js
@@ -1,4 +1,10 @@
-import { SIDEBAR_COLLAPSED_KEY, SIDEBAR_WIDTH_STORAGE_KEY, STORAGE_KEY } from './constants'
+import {
+  MAX_SCROLL_POSITIONS,
+  SCROLL_POSITIONS_KEY,
+  SIDEBAR_COLLAPSED_KEY,
+  SIDEBAR_WIDTH_STORAGE_KEY,
+  STORAGE_KEY,
+} from './constants'
 
 export const readStoredSelection = () => {
   if (typeof window === 'undefined') return null
@@ -60,6 +66,42 @@ export const saveStoredSidebarCollapsed = (collapsed) => {
   if (typeof window === 'undefined') return
   try {
     window.localStorage.setItem(SIDEBAR_COLLAPSED_KEY, `${collapsed}`)
+  } catch {
+    // Ignore storage errors
+  }
+}
+
+// Per-page scroll positions live in sessionStorage as a plain
+// `{ [pageId]: scrollTop }` map. Session scope means they survive a reload but
+// not a new tab/session, matching how scroll restoration is expected to behave.
+export const readStoredScrollPositions = () => {
+  if (typeof window === 'undefined') return {}
+  try {
+    const raw = window.sessionStorage.getItem(SCROLL_POSITIONS_KEY)
+    if (!raw) return {}
+    const parsed = JSON.parse(raw)
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) return {}
+    // Keep only finite numeric offsets; drop anything malformed.
+    const clean = {}
+    for (const [pageId, value] of Object.entries(parsed)) {
+      if (typeof value === 'number' && Number.isFinite(value)) clean[pageId] = value
+    }
+    return clean
+  } catch {
+    return {}
+  }
+}
+
+export const saveStoredScrollPositions = (positions) => {
+  if (typeof window === 'undefined') return
+  try {
+    const entries = Object.entries(positions || {}).filter(
+      ([, value]) => typeof value === 'number' && Number.isFinite(value),
+    )
+    // Object insertion order is preserved, so slicing the tail keeps the
+    // most-recently-written (most-recent) page offsets and evicts the oldest.
+    const capped = entries.slice(-MAX_SCROLL_POSITIONS)
+    window.sessionStorage.setItem(SCROLL_POSITIONS_KEY, JSON.stringify(Object.fromEntries(capped)))
   } catch {
     // Ignore storage errors
   }


### PR DESCRIPTION
## Summary

A broad sweep of navigation behaviors so the app moves the user where they'd expect, matching well-established conventions (scroll restoration, email-client delete-fallback, ARIA treeview auto-reveal, OneNote/Notion container→first-child, never strand on a blank screen). Prompted by two reported annoyances (scroll lost between pages; deleting a freshly-created page dumps you on the wrong page), expanded into the related cluster.

## What changed

**Per-page scroll restoration (desktop + mobile)**
- `getEditorScrollSurface()` reads/writes the correct surface per viewport — desktop `.editor-panel.scrollTop`, mobile `window` (responsive.css overrides the panel to `overflow-y: visible`).
- New `useScrollRestoration` hook: in-memory `Map<pageId,scrollTop>` mirrored to sessionStorage (debounced, capped at 50); restore waits for layout via `ResizeObserver` (content grows as images/tables load), deferring to the keyboard, pinch-zoom, and deep-link block jumps.
- Touch-guarded the page-switch `editor.focus()` so navigating to read a page no longer pops the mobile keyboard.

**Back-to-previous on delete (pages, sections, notebooks)**
- `useNavigationHistory` + pure `pickPostDeleteTarget`: most-recent visited survivor → adjacent sibling → first remaining → null. Threaded into `useTrackers`/`useSections`/`useNotebooks`, preserving every other delete side effect.

**Auto-reveal active item in the sidebar** — scrolls the highlighted row into view (`block:'nearest'`), guarded against mid-drag and gated on the open mobile drawer; adds `aria-current="page"`.

**Section click opens its first page** — resolves once the section's pages load; skips if a page in that section is already open; empty section falls through to the contextual empty state (no blank-then-jump flicker).

**No silent dead-ends** — a dead deep link falls back to the nearest existing ancestor (section → notebook → last selection) with a non-blocking notice and rewrites the URL hash.

**Mobile drawer + empty-state polish** — drawer auto-closes on hash/back navigation; contextual empty states ("This section is empty" / "This notebook has no sections yet" / "Select a tracker…") with create actions; orphaned `expanded*` localStorage entries pruned on delete.

## Test plan

- [x] `npm run test:unit` — 428 pass (incl. new `navigationHistoryHelpers` + scroll-position storage round-trip/cap/malformed-JSON tests)
- [x] `npm run build` — succeeds
- [x] `npx eslint src e2e` — clean
- [ ] CI E2E gate (both viewport projects), incl. new `navigation-ux-overhaul.spec.js`: scroll restore per surface, create→delete returns to previous, section opens first page, empty-section state, dead deep link → fallback + notice
- [ ] Manual mobile pass on Android (keyboard stays down on page switch; restore doesn't fight caret-above-keyboard or pinch-zoom; drawer closes onto the opened page)

## Deferred (separate task)

Cross-device realtime DELETE handling — `usePageRealtime.js` subscribes to UPDATE only, so a page deleted on another device shows stale content silently. Follow-up: subscribe to DELETE on the active page → notice + fallback navigation (reuse the new `pickNavFallback` pattern).

🤖 Generated with [Claude Code](https://claude.com/claude-code)