### PR TITLE
Make AI the final judge for daily generation (full-tracker markdown)

### DIFF
--- a/supabase/functions/generate-daily/dailyHelpers.test.ts
+++ b/supabase/functions/generate-daily/dailyHelpers.test.ts
@@ -1,162 +1,263 @@
 import { describe, expect, it } from 'vitest'
 
 import {
-  buildCidBucketMap,
-  filterCandidatesForDaily,
-  routeTasksToBuckets,
+  buildDateHints,
+  buildTrackerContext,
+  mapTasksByBucket,
+  serializeTrackerToMarkdown,
+  type InlineSegment,
 } from './dailyHelpers.ts'
 
-describe('filterCandidatesForDaily', () => {
-  it('keeps only overdue, today, and soon candidates', () => {
-    const filtered = filterCandidatesForDaily([
-      {
-        cid: 'c1',
-        text: 'Overdue task',
-        due_bucket: 'overdue',
-        is_overdue: true,
-        has_explicit_date: true,
-      },
-      {
-        cid: 'c2',
-        text: 'Today task',
-        due_bucket: 'today',
-        is_overdue: false,
-        has_explicit_date: true,
-      },
-      {
-        cid: 'c3',
-        text: 'Soon task',
-        due_bucket: 'soon',
-        is_overdue: false,
-        has_explicit_date: true,
-      },
-      {
-        cid: 'c4',
-        text: 'Later task',
-        due_bucket: 'later',
-        is_overdue: false,
-        has_explicit_date: true,
-      },
-      {
-        cid: 'c5',
-        text: 'Backlog task',
-        due_bucket: 'none',
-        is_overdue: false,
-        has_explicit_date: false,
-      },
-    ])
+const hl = (text: string): InlineSegment => ({ text, highlighted: true })
+const plain = (text: string): InlineSegment => ({ text, highlighted: false })
 
-    expect(filtered.map((candidate) => candidate.cid)).toEqual(['c1', 'c2', 'c3'])
-  })
-})
-
-describe('buildCidBucketMap', () => {
-  it('routes overdue/today to asap, soon to fyi, and ignores later/none', () => {
-    const map = buildCidBucketMap([
-      { cid: 'c1', text: 'Overdue', due_bucket: 'overdue', is_overdue: true, has_explicit_date: true },
-      { cid: 'c2', text: 'Today', due_bucket: 'today', is_overdue: false, has_explicit_date: true },
-      { cid: 'c3', text: 'Soon', due_bucket: 'soon', is_overdue: false, has_explicit_date: true },
-      { cid: 'c4', text: 'Later', due_bucket: 'later', is_overdue: false, has_explicit_date: true },
-      { cid: 'c5', text: 'None', due_bucket: 'none', is_overdue: false, has_explicit_date: false },
-    ])
-
-    expect(map.get('c1')).toBe('asap')
-    expect(map.get('c2')).toBe('asap')
-    expect(map.get('c3')).toBe('fyi')
-    expect(map.has('c4')).toBe(false)
-    expect(map.has('c5')).toBe(false)
-  })
-})
-
-describe('routeTasksToBuckets', () => {
-  const cidToBucket = buildCidBucketMap([
-    { cid: 'c-today', text: 'Today task', due_bucket: 'today', is_overdue: false, has_explicit_date: true },
-    { cid: 'c-soon', text: 'Soon task', due_bucket: 'soon', is_overdue: false, has_explicit_date: true },
-  ])
-  // cidToBlockId intentionally also knows a "later" cid that was never sent to
-  // the model, mirroring production where the block map covers every next step.
-  const cidToBlockId = new Map([
-    ['c-today', 'block-today'],
-    ['c-soon', 'block-soon'],
-    ['c-later', 'block-later'],
-  ])
-  const cidToText = new Map([
-    ['c-today', 'Today task'],
-    ['c-soon', 'Soon task'],
-    ['c-later', 'Later task'],
-  ])
-
-  it('places correctly-bucketed tasks into their bucket', () => {
-    const routed = routeTasksToBuckets(
-      [{ task: 'Do today thing', cids: ['c-today'], priority: 'high' }],
-      cidToBucket,
-      cidToBlockId,
-      cidToText,
-    )
-
-    expect(routed.asap).toEqual([
-      { task: 'Do today thing', block_ids: ['block-today'], priority: 'high' },
-    ])
-    expect(routed.fyi).toEqual([])
-    expect(routed.droppedUnknownCids).toBe(0)
-  })
-
-  it('re-routes a mis-bucketed task to its correct bucket instead of dropping it', () => {
-    // The model wrongly put a "soon" item in the ASAP list. It should land in FYI.
-    const routed = routeTasksToBuckets(
-      [{ task: 'Misbucketed soon item', cids: ['c-soon'], priority: 'high' }],
-      cidToBucket,
-      cidToBlockId,
-      cidToText,
-    )
-
-    expect(routed.asap).toEqual([])
-    expect(routed.fyi).toEqual([
-      { task: 'Misbucketed soon item', block_ids: ['block-soon'], priority: 'high' },
-    ])
-    expect(routed.droppedUnknownCids).toBe(0)
-  })
-
-  it('silently drops unknown / out-of-scope cids without surfacing a task', () => {
-    const routed = routeTasksToBuckets(
-      [
-        // c-later was never sent to the model (far-future); cX is invented.
-        { task: '2027 taxes', cids: ['c-later'], priority: 'low' },
-        { task: 'Hallucinated', cids: ['cX'], priority: 'low' },
+describe('serializeTrackerToMarkdown', () => {
+  it('emits a stable cid anchor per block that has an id and resolves it to the block id', () => {
+    const content = {
+      type: 'doc',
+      content: [
+        {
+          type: 'heading',
+          attrs: { id: 'h1', level: 2 },
+          content: [{ type: 'text', text: 'Running' }],
+        },
+        {
+          type: 'paragraph',
+          attrs: { id: 'p1' },
+          content: [{ type: 'text', text: 'Book flights' }],
+        },
       ],
-      cidToBucket,
-      cidToBlockId,
-      cidToText,
-    )
+    }
 
-    expect(routed.asap).toEqual([])
-    expect(routed.fyi).toEqual([])
-    expect(routed.droppedUnknownCids).toBe(2)
+    const { markdown, cidToBlockId, cidToText } = serializeTrackerToMarkdown(content)
+
+    // One anchor per id-bearing block.
+    const anchors = [...markdown.matchAll(/⟦(c\d+)⟧/g)].map((m) => m[1])
+    expect(anchors).toEqual(['c1', 'c2'])
+    expect(cidToBlockId.get('c1')).toBe('h1')
+    expect(cidToBlockId.get('c2')).toBe('p1')
+    expect(cidToText.get('c2')).toBe('Book flights')
   })
 
-  it('falls back to candidate text when the model omits a task description', () => {
-    const routed = routeTasksToBuckets(
-      [{ task: '   ', cids: ['c-today'], priority: 'nonsense' }],
-      cidToBucket,
-      cidToBlockId,
-      cidToText,
-    )
+  it('preserves list nesting and highlight formatting', () => {
+    const content = {
+      type: 'doc',
+      content: [
+        {
+          type: 'bulletList',
+          attrs: { id: 'bl1' },
+          content: [
+            {
+              type: 'listItem',
+              content: [
+                {
+                  type: 'paragraph',
+                  attrs: { id: 'li-p1' },
+                  content: [
+                    { type: 'text', text: 'Pay taxes ' },
+                    { type: 'text', text: '4/15', marks: [{ type: 'highlight' }] },
+                  ],
+                },
+                {
+                  type: 'bulletList',
+                  attrs: { id: 'bl2' },
+                  content: [
+                    {
+                      type: 'listItem',
+                      content: [
+                        {
+                          type: 'paragraph',
+                          attrs: { id: 'li-p2' },
+                          content: [{ type: 'text', text: 'Gather receipts' }],
+                        },
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    }
 
-    expect(routed.asap).toEqual([
-      { task: 'Today task', block_ids: ['block-today'], priority: 'medium' },
+    const { markdown, cidToBlockId } = serializeTrackerToMarkdown(content)
+
+    // The anchored line carries the inner paragraph id (the deep-link target),
+    // not the list container id.
+    expect(cidToBlockId.get('c1')).toBe('li-p1')
+    expect(cidToBlockId.get('c2')).toBe('li-p2')
+
+    const lines = markdown.split('\n')
+    const topLine = lines.find((l) => l.includes('Pay taxes')) || ''
+    const nestedLine = lines.find((l) => l.includes('Gather receipts')) || ''
+    // Highlight rendered as [text]; nested item indented under the parent.
+    expect(topLine).toContain('- Pay taxes [4/15]')
+    expect(nestedLine.indexOf('-')).toBeGreaterThan(topLine.indexOf('-'))
+  })
+})
+
+describe('buildDateHints — year inference', () => {
+  const today = '2026-07-01'
+
+  it('uses a written year in the line for a bare highlighted date (4/15 of 2027 → later)', () => {
+    const cidSegments = new Map<string, InlineSegment[]>([
+      ['c1', [plain('They are due by '), hl('4/15'), plain(' (of 2027)')]],
     ])
+    const hints = buildDateHints(cidSegments, today)
+    expect(hints).toHaveLength(1)
+    expect(hints[0].cid).toBe('c1')
+    expect(hints[0].parsedIso).toBe('2027-04-15')
+    expect(hints[0].bucket).toBe('later')
   })
 
-  it('skips tasks without a usable cids array', () => {
-    const routed = routeTasksToBuckets(
-      [{ task: 'No cids here', priority: 'high' }],
-      cidToBucket,
-      cidToBlockId,
-      cidToText,
-    )
+  it('handles a far-future written year (7/1 of 2028 → later)', () => {
+    const cidSegments = new Map<string, InlineSegment[]>([
+      ['c2', [plain('might come up around '), hl('7/1'), plain(' (of 2028)')]],
+    ])
+    const hints = buildDateHints(cidSegments, today)
+    expect(hints).toHaveLength(1)
+    expect(hints[0].parsedIso).toBe('2028-07-01')
+    expect(hints[0].bucket).toBe('later')
+  })
 
-    expect(routed.asap).toEqual([])
-    expect(routed.fyi).toEqual([])
-    expect(routed.droppedUnknownCids).toBe(0)
+  it('defaults a bare highlighted date to the current year (7/1 → today)', () => {
+    const cidSegments = new Map<string, InlineSegment[]>([
+      ['c3', [plain('Bachelor party '), hl('7/1')]],
+    ])
+    const hints = buildDateHints(cidSegments, today)
+    expect(hints).toHaveLength(1)
+    expect(hints[0].parsedIso).toBe('2026-07-01')
+    expect(hints[0].bucket).toBe('today')
+  })
+
+  it('lets an explicit slash-year win over the written year', () => {
+    const cidSegments = new Map<string, InlineSegment[]>([
+      ['c4', [plain('Due '), hl('4/15/2030'), plain(' (of 2027)')]],
+    ])
+    const hints = buildDateHints(cidSegments, today)
+    expect(hints[0].parsedIso).toBe('2030-04-15')
+  })
+
+  it('emits no hint for lines without a highlighted date', () => {
+    const cidSegments = new Map<string, InlineSegment[]>([
+      ['c5', [plain('Background: written on 4/15 as a log note')]],
+      ['c6', [plain('No dates at all here')]],
+    ])
+    expect(buildDateHints(cidSegments, today)).toEqual([])
+  })
+})
+
+describe('mapTasksByBucket', () => {
+  const cidToBlockId = new Map<string, string>([
+    ['c1', 'block-1'],
+    ['c2', 'block-2'],
+    ['c3', 'block-3'],
+  ])
+  const cidToText = new Map<string, string>([
+    ['c1', 'First task'],
+    ['c2', 'Second task'],
+    ['c3', 'Third task'],
+  ])
+
+  it('honors the AI asap/fyi placement without re-routing', () => {
+    const parsed = {
+      asap: [{ task: 'Do first', cids: ['c1'], priority: 'high' }],
+      fyi: [{ task: 'Heads up on second', cids: ['c2'], priority: 'low' }],
+      format: 'asap_fyi' as const,
+    }
+    const { asap, fyi } = mapTasksByBucket(parsed, cidToBlockId, cidToText)
+    expect(asap).toEqual([{ task: 'Do first', block_ids: ['block-1'], priority: 'high' }])
+    expect(fyi).toEqual([{ task: 'Heads up on second', block_ids: ['block-2'], priority: 'low' }])
+  })
+
+  it('drops invented / unknown cids and skips tasks left with no real block', () => {
+    const parsed = {
+      asap: [{ task: 'Hallucinated', cids: ['cX', 'cY'], priority: 'high' }],
+      fyi: [],
+      format: 'asap_fyi' as const,
+    }
+    const { asap, fyi, droppedUnknownCids } = mapTasksByBucket(parsed, cidToBlockId, cidToText)
+    expect(asap).toEqual([])
+    expect(fyi).toEqual([])
+    expect(droppedUnknownCids).toBe(2)
+  })
+
+  it('falls back to candidate text and defaults priority when the AI omits them', () => {
+    const parsed = {
+      asap: [{ task: '   ', cids: ['c3'], priority: 'nonsense' }],
+      fyi: [],
+      format: 'asap_fyi' as const,
+    }
+    const { asap } = mapTasksByBucket(parsed, cidToBlockId, cidToText)
+    expect(asap).toEqual([{ task: 'Third task', block_ids: ['block-3'], priority: 'medium' }])
+  })
+
+  it('returns empty arrays when the AI returns nothing due', () => {
+    const parsed = { asap: [], fyi: [], format: 'empty' as const }
+    const { asap, fyi } = mapTasksByBucket(parsed, cidToBlockId, cidToText)
+    expect(asap).toEqual([])
+    expect(fyi).toEqual([])
+  })
+})
+
+describe('buildTrackerContext', () => {
+  const today = '2026-07-01'
+
+  it('serializes every page and only emits hints for highlighted dates', () => {
+    const trackerPages = [
+      {
+        title: 'July 2026 Tracker',
+        pageId: 'page-1',
+        content: {
+          type: 'doc',
+          content: [
+            {
+              type: 'paragraph',
+              attrs: { id: 'p-future' },
+              content: [
+                { type: 'text', text: 'File form ' },
+                { type: 'text', text: '4/15', marks: [{ type: 'highlight' }] },
+                { type: 'text', text: ' (of 2027)' },
+              ],
+            },
+            {
+              type: 'paragraph',
+              attrs: { id: 'p-note' },
+              content: [{ type: 'text', text: 'Background: nothing due here' }],
+            },
+          ],
+        },
+      },
+    ]
+
+    const { markdown, cidToBlockId, dateHints } = buildTrackerContext(trackerPages, today)
+    expect(markdown).toContain('JULY 2026 TRACKER')
+    expect(cidToBlockId.size).toBe(2)
+    // Only the highlighted-date line yields a hint, and year inference pushes it out.
+    expect(dateHints).toHaveLength(1)
+    expect(dateHints[0].bucket).toBe('later')
+    expect(cidToBlockId.get(dateHints[0].cid)).toBe('p-future')
+  })
+
+  it('yields empty hints for an all-undated tracker', () => {
+    const trackerPages = [
+      {
+        title: 'Empty',
+        pageId: 'page-1',
+        content: {
+          type: 'doc',
+          content: [
+            {
+              type: 'paragraph',
+              attrs: { id: 'p1' },
+              content: [{ type: 'text', text: 'Just a note' }],
+            },
+          ],
+        },
+      },
+    ]
+    const { dateHints } = buildTrackerContext(trackerPages, today)
+    expect(dateHints).toEqual([])
   })
 })

--- a/supabase/functions/generate-daily/dailyHelpers.ts
+++ b/supabase/functions/generate-daily/dailyHelpers.ts
@@ -1,30 +1,20 @@
 export type DueBucket = 'overdue' | 'today' | 'soon' | 'later' | 'none'
 
-export type NextStepItem = {
+export type InlineSegment = {
   text: string
-  blockId: string
-  dueBucket: DueBucket
-  isOverdue: boolean
-  hasExplicitDate: boolean
-  parentContext?: string
+  highlighted: boolean
 }
 
-export type CandidateForModel = {
+// One advisory hint per line that contains a highlighted (due-style) date. The
+// server no longer decides placement from these — the AI does — so a hint is
+// purely informational: "this line has a date; here's how the deterministic
+// pass reads it".
+export type DateHint = {
   cid: string
-  text: string
-  due_bucket: DueBucket
-  is_overdue: boolean
-  has_explicit_date: boolean
-  parent_context?: string
+  dateText: string
+  parsedIso: string
+  bucket: DueBucket
 }
-
-export const filterCandidatesForDaily = (candidates: CandidateForModel[]) =>
-  (candidates || []).filter(
-    (candidate) =>
-      candidate.due_bucket === 'overdue' ||
-      candidate.due_bucket === 'today' ||
-      candidate.due_bucket === 'soon',
-  )
 
 export type ParsedTaskBuckets = {
   asap: any[]
@@ -32,42 +22,41 @@ export type ParsedTaskBuckets = {
   format: 'empty' | 'asap_fyi'
 }
 
-type InlineSegment = {
-  text: string
-  highlighted: boolean
+export type MappedTask = {
+  task: string
+  block_ids: string[]
+  priority: string
 }
 
-type DueMetadata = {
-  dueBucket: DueBucket
-  isOverdue: boolean
-  hasExplicitDate: boolean
-  hasAnyDateText: boolean
-}
-
-type FlattenedBlock = {
-  kind: 'text' | 'list' | 'divider'
-  nodeType?: string
-  text?: string
-  inlineContent?: any[]
-  paragraphAttrs?: Record<string, any>
-  itemAttrs?: Record<string, any>
-  parentText?: string
+export type TrackerContext = {
+  markdown: string
+  cidToBlockId: Map<string, string>
+  cidToText: Map<string, string>
+  dateHints: DateHint[]
 }
 
 const DAY_MS = 24 * 60 * 60 * 1000
 const DATE_TOKEN_REGEX = /(\d{1,2})\/(\d{1,2})(?:\/(\d{2,4}))?/g
+const WRITTEN_YEAR_REGEX = /\b(20\d\d)\b/
 
 const toUtcDate = (value: string) => {
   const parsed = new Date(`${value}T00:00:00Z`)
   return Number.isNaN(parsed.getTime()) ? null : parsed
 }
 
+const toIsoDate = (date: Date) => date.toISOString().slice(0, 10)
+
 const normalizeText = (value: string) =>
   String(value || '')
     .replace(/\s+/g, ' ')
     .trim()
 
-const parseDateToken = (monthValue: string, dayValue: string, yearValue: string | undefined, defaultYear: number) => {
+const parseDateToken = (
+  monthValue: string,
+  dayValue: string,
+  yearValue: string | undefined,
+  defaultYear: number,
+) => {
   const month = Number(monthValue)
   const day = Number(dayValue)
 
@@ -92,69 +81,29 @@ const parseDateToken = (monthValue: string, dayValue: string, yearValue: string 
   return date
 }
 
-const parseDatesFromText = (text: string, defaultYear: number) => {
-  const results: Date[] = []
+type DateToken = { date: Date; raw: string }
+
+const extractDateTokens = (text: string, defaultYear: number): DateToken[] => {
+  const results: DateToken[] = []
   const normalized = String(text || '')
 
   DATE_TOKEN_REGEX.lastIndex = 0
   let match: RegExpExecArray | null = DATE_TOKEN_REGEX.exec(normalized)
   while (match) {
     const date = parseDateToken(match[1], match[2], match[3], defaultYear)
-    if (date) results.push(date)
+    if (date) results.push({ date, raw: match[0] })
     match = DATE_TOKEN_REGEX.exec(normalized)
   }
 
   return results
 }
 
-const buildDueMetadata = (highlightedDates: Date[], hasAnyDateText: boolean, todayDate: Date): DueMetadata => {
-  if (!highlightedDates.length) {
-    return {
-      dueBucket: 'none',
-      isOverdue: false,
-      hasExplicitDate: false,
-      hasAnyDateText,
-    }
-  }
-
-  const earliestDueDate = highlightedDates
-    .slice()
-    .sort((a, b) => a.getTime() - b.getTime())[0]
-
-  const diffDays = Math.floor((earliestDueDate.getTime() - todayDate.getTime()) / DAY_MS)
-  if (diffDays < 0) {
-    return {
-      dueBucket: 'overdue',
-      isOverdue: true,
-      hasExplicitDate: true,
-      hasAnyDateText,
-    }
-  }
-
-  if (diffDays === 0) {
-    return {
-      dueBucket: 'today',
-      isOverdue: false,
-      hasExplicitDate: true,
-      hasAnyDateText,
-    }
-  }
-
-  if (diffDays <= 2) {
-    return {
-      dueBucket: 'soon',
-      isOverdue: false,
-      hasExplicitDate: true,
-      hasAnyDateText,
-    }
-  }
-
-  return {
-    dueBucket: 'later',
-    isOverdue: false,
-    hasExplicitDate: true,
-    hasAnyDateText,
-  }
+const bucketForDate = (dueDate: Date, todayDate: Date): DueBucket => {
+  const diffDays = Math.floor((dueDate.getTime() - todayDate.getTime()) / DAY_MS)
+  if (diffDays < 0) return 'overdue'
+  if (diffDays === 0) return 'today'
+  if (diffDays <= 2) return 'soon'
+  return 'later'
 }
 
 const appendSegment = (segments: InlineSegment[], segment: InlineSegment) => {
@@ -167,6 +116,8 @@ const appendSegment = (segments: InlineSegment[], segment: InlineSegment) => {
   segments.push({ ...segment })
 }
 
+// Collect visible inline text as highlighted/plain runs. Struck-through
+// (completed) text is dropped so finished items don't resurface as due dates.
 const collectInlineSegments = (nodes: any[]): InlineSegment[] => {
   const segments: InlineSegment[] = []
 
@@ -175,11 +126,11 @@ const collectInlineSegments = (nodes: any[]): InlineSegment[] => {
 
     if (node.type === 'text') {
       const marks = Array.isArray(node.marks) ? node.marks : []
-      if (marks.some((mark) => mark?.type === 'strike')) return
+      if (marks.some((mark: any) => mark?.type === 'strike')) return
 
       appendSegment(segments, {
         text: String(node.text || ''),
-        highlighted: marks.some((mark) => mark?.type === 'highlight'),
+        highlighted: marks.some((mark: any) => mark?.type === 'highlight'),
       })
       return
     }
@@ -198,185 +149,313 @@ const collectInlineSegments = (nodes: any[]): InlineSegment[] => {
   return segments
 }
 
-const flattenBlocks = (node: any, into: FlattenedBlock[], parentText?: string) => {
-  if (!node || typeof node !== 'object') return
+// ---------------------------------------------------------------------------
+// Markdown serializer with per-line cid anchors
+//
+// Ported from src/lib/serializeDocForExport.js (pure/DOM-free) and extended so
+// every block that carries an id gets a stable `⟦c12⟧` anchor appended to its
+// line. The anchor's cid maps to that block's id (the deep-link target) and to
+// its plain text, and the block's inline runs are captured for the date pass.
+// ---------------------------------------------------------------------------
 
-  if (node.type === 'horizontalRule') {
-    into.push({ kind: 'divider' })
-    return
-  }
-
-  if (node.type === 'paragraph' || node.type === 'heading') {
-    const segments = collectInlineSegments(node.content || [])
-    into.push({
-      kind: 'text',
-      nodeType: node.type,
-      text: normalizeText(segments.map((segment) => segment.text).join('')),
-      inlineContent: node.content || [],
-      paragraphAttrs: node.attrs || {},
-      parentText,
-    })
-    return
-  }
-
-  if (node.type === 'listItem' || node.type === 'taskItem') {
-    const firstParagraph = (node.content || []).find((child: any) => child?.type === 'paragraph')
-    const inlineContent = firstParagraph?.content || []
-    const segments = collectInlineSegments(inlineContent)
-    const itemText = normalizeText(segments.map((segment) => segment.text).join(''))
-
-    into.push({
-      kind: 'list',
-      nodeType: node.type,
-      text: itemText,
-      inlineContent,
-      paragraphAttrs: firstParagraph?.attrs || {},
-      itemAttrs: node.attrs || {},
-      parentText,
-    })
-
-    // Chain parent context for nested children (e.g., "Wedding > Venue")
-    const childParent = parentText && itemText
-      ? `${parentText} > ${itemText}`
-      : itemText || parentText
-    ;(node.content || []).forEach((child: any) => {
-      if (child === firstParagraph) return
-      flattenBlocks(child, into, childParent)
-    })
-    return
-  }
-
-  if (Array.isArray(node.content)) {
-    node.content.forEach((child: any) => flattenBlocks(child, into, parentText))
-  }
+type SerializeCtx = {
+  counter: { value: number }
+  cidToBlockId: Map<string, string>
+  cidToText: Map<string, string>
+  cidSegments: Map<string, InlineSegment[]>
+  suppressAnchors: boolean
 }
 
-const isNextStepsHeader = (text: string) =>
-  /^next steps\b(?:\s*(?:[:\-].*|\(.*\)))?$/i.test(normalizeText(text))
-
-const isSectionBoundary = (block: FlattenedBlock) => {
-  if (block.kind !== 'text') return false
-
-  const text = normalizeText(block.text || '')
-  if (!text) return false
-
-  if (block.nodeType === 'heading') {
-    return !isNextStepsHeader(text)
-  }
-
-  const isGenericSectionLabel = /^[A-Za-z0-9][A-Za-z0-9\s/&'()\-]{0,80}:\s*$/.test(text)
-  if (isGenericSectionLabel && !isNextStepsHeader(text)) {
-    return true
-  }
-
-  return /^(background|recurring(?:\s+things?)?|notes?)\s*:?\s*$/i.test(text)
+function serializeInline(content: any[] | undefined): string {
+  if (!content) return ''
+  return content
+    .map((node) => {
+      if (node.type === 'text') {
+        let text = node.text || ''
+        const marks = node.marks || []
+        const hasBold = marks.some((m: any) => m.type === 'bold')
+        const hasItalic = marks.some((m: any) => m.type === 'italic')
+        const hasStrike = marks.some((m: any) => m.type === 'strike')
+        const hasHighlight = marks.some((m: any) => m.type === 'highlight')
+        if (hasBold) text = `**${text}**`
+        if (hasItalic) text = `_${text}_`
+        if (hasStrike) text = `~~${text}~~`
+        if (hasHighlight) text = `[${text}]`
+        return text
+      }
+      if (node.type === 'hardBreak') return '\n'
+      if (node.type === 'image') return '[image]'
+      return ''
+    })
+    .join('')
 }
 
-const getDueMetadataFromInline = (inlineContent: any[], todayDate: Date): DueMetadata => {
+// Register a cid for an id-bearing block and return the anchor suffix to append.
+function registerAnchor(
+  ctx: SerializeCtx,
+  id: string | undefined | null,
+  inlineContent: any[] | undefined,
+): string {
+  if (!id || ctx.suppressAnchors) return ''
+  const cid = `c${ctx.counter.value}`
+  ctx.counter.value += 1
+  ctx.cidToBlockId.set(cid, id)
   const segments = collectInlineSegments(inlineContent || [])
-  const text = segments.map((segment) => segment.text).join('')
-
-  const allDates = parseDatesFromText(text, todayDate.getUTCFullYear())
-  const highlightedDates = segments
-    .filter((segment) => segment.highlighted)
-    .flatMap((segment) => parseDatesFromText(segment.text, todayDate.getUTCFullYear()))
-
-  return buildDueMetadata(highlightedDates, allDates.length > 0, todayDate)
+  ctx.cidSegments.set(cid, segments)
+  ctx.cidToText.set(cid, normalizeText(segments.map((s) => s.text).join('')))
+  return ` ⟦${cid}⟧`
 }
 
-const extractNextStepsFromContent = (content: any, today: string): NextStepItem[] => {
+function serializeNode(
+  node: any,
+  lines: string[],
+  ctx: SerializeCtx,
+  indent = 0,
+  listIndex: any = null,
+) {
+  const prefix = '  '.repeat(indent)
+
+  switch (node.type) {
+    case 'doc':
+      node.content?.forEach((child: any) => serializeNode(child, lines, ctx, indent))
+      break
+
+    case 'paragraph': {
+      const text = serializeInline(node.content)
+      const anchor = registerAnchor(ctx, node.attrs?.id, node.content)
+      lines.push(prefix + text + anchor)
+      break
+    }
+
+    case 'heading': {
+      const text = serializeInline(node.content)
+      const anchor = registerAnchor(ctx, node.attrs?.id, node.content)
+      if (lines.length > 0) lines.push('')
+      lines.push(prefix + text.toUpperCase() + anchor)
+      lines.push('')
+      break
+    }
+
+    case 'bulletList':
+      node.content?.forEach((child: any) => serializeNode(child, lines, ctx, indent, 'bullet'))
+      break
+
+    case 'orderedList': {
+      let counter = 1
+      node.content?.forEach((child: any) => {
+        serializeNode(child, lines, ctx, indent, counter)
+        counter += 1
+      })
+      break
+    }
+
+    case 'taskList':
+      node.content?.forEach((child: any) => serializeNode(child, lines, ctx, indent, 'task'))
+      break
+
+    case 'listItem':
+    case 'taskItem': {
+      const marker =
+        listIndex === 'bullet'
+          ? '- '
+          : listIndex === 'task'
+            ? node.attrs?.checked
+              ? '[x] '
+              : '[ ] '
+            : `${listIndex}. `
+      const children = node.content || []
+      children.forEach((child: any, i: number) => {
+        if (i === 0 && child.type === 'paragraph') {
+          // The item's first paragraph holds the deep-link id, so anchor here.
+          const anchor = registerAnchor(ctx, child.attrs?.id, child.content)
+          lines.push(prefix + marker + serializeInline(child.content) + anchor)
+        } else {
+          serializeNode(child, lines, ctx, indent + 1)
+        }
+      })
+      break
+    }
+
+    case 'table': {
+      const rows = node.content || []
+      if (rows.length === 0) break
+
+      const columnCount = rows[0]?.content?.length || 0
+
+      if (columnCount === 1) {
+        // Single-column table: preserve inner structure (and its anchors).
+        rows.forEach((row: any, rowIdx: number) => {
+          const cell = row.content?.[0]
+          if (cell) {
+            cell.content?.forEach((child: any) => serializeNode(child, lines, ctx, indent))
+          }
+          if (rowIdx < rows.length - 1) {
+            lines.push('')
+            lines.push(prefix + '---')
+            lines.push('')
+          }
+        })
+      } else {
+        // Multi-column table: flatten to pipe rows. Anchoring individual cells
+        // inside a joined row would be noise, so suppress anchors here.
+        const previousSuppress = ctx.suppressAnchors
+        ctx.suppressAnchors = true
+        rows.forEach((row: any, rowIdx: number) => {
+          const cells = (row.content || []).map((cell: any) => {
+            const cellLines: string[] = []
+            cell.content?.forEach((child: any) => serializeNode(child, cellLines, ctx, 0))
+            return cellLines.join(' ').trim()
+          })
+          lines.push(prefix + '| ' + cells.join(' | ') + ' |')
+          if (rowIdx === 0) {
+            const separator = cells.map((c: string) => '-'.repeat(Math.max(c.length, 3))).join(' | ')
+            lines.push(prefix + '| ' + separator + ' |')
+          }
+        })
+        ctx.suppressAnchors = previousSuppress
+      }
+      break
+    }
+
+    case 'tableRow':
+    case 'tableCell':
+    case 'tableHeader':
+      node.content?.forEach((child: any) => serializeNode(child, lines, ctx, indent))
+      break
+
+    case 'blockquote':
+      node.content?.forEach((child: any) => serializeNode(child, lines, ctx, indent + 1))
+      break
+
+    case 'codeBlock': {
+      lines.push(prefix + '```')
+      const text = node.content?.map((n: any) => n.text || '').join('') || ''
+      text.split('\n').forEach((line: string) => lines.push(prefix + line))
+      lines.push(prefix + '```')
+      break
+    }
+
+    case 'horizontalRule':
+      lines.push(prefix + '---')
+      break
+
+    default:
+      if (node.content) {
+        node.content.forEach((child: any) => serializeNode(child, lines, ctx, indent))
+      }
+      break
+  }
+}
+
+const createCtx = (counter: { value: number }): SerializeCtx => ({
+  counter,
+  cidToBlockId: new Map<string, string>(),
+  cidToText: new Map<string, string>(),
+  cidSegments: new Map<string, InlineSegment[]>(),
+  suppressAnchors: false,
+})
+
+type SerializeResult = {
+  markdown: string
+  cidToBlockId: Map<string, string>
+  cidToText: Map<string, string>
+  cidSegments: Map<string, InlineSegment[]>
+}
+
+const serializeContentWithCtx = (content: any, ctx: SerializeCtx, title?: string): string => {
+  const lines: string[] = []
+  if (title) {
+    lines.push(normalizeText(title).toUpperCase())
+    lines.push('')
+  }
+  if (content && typeof content === 'object') {
+    serializeNode(content, lines, ctx)
+  }
+  return lines
+    .join('\n')
+    .replace(/\n{3,}/g, '\n\n')
+    .replace(/[ \t]+\n/g, '\n')
+    .trim()
+}
+
+// Serialize a single tracker doc to markdown, assigning a cid anchor to every
+// id-bearing block.
+export const serializeTrackerToMarkdown = (content: any, title?: string): SerializeResult => {
+  const ctx = createCtx({ value: 1 })
+  const markdown = serializeContentWithCtx(content, ctx, title)
+  return {
+    markdown,
+    cidToBlockId: ctx.cidToBlockId,
+    cidToText: ctx.cidToText,
+    cidSegments: ctx.cidSegments,
+  }
+}
+
+// Build one advisory hint per line that contains a highlighted date. Year
+// inference: when a highlighted date has no slash-year, a written year on the
+// same line (e.g. "(of 2027)") is used as the default; an explicit slash-year
+// always wins.
+export const buildDateHints = (
+  cidSegments: Map<string, InlineSegment[]>,
+  today: string,
+): DateHint[] => {
   const todayDate = toUtcDate(today)
-  if (!todayDate || !content || typeof content !== 'object') return []
+  if (!todayDate) return []
 
-  const blocks: FlattenedBlock[] = []
-  flattenBlocks(content, blocks)
+  const hints: DateHint[] = []
 
-  const nextSteps: NextStepItem[] = []
-  let inNextSteps = false
+  for (const [cid, segments] of cidSegments) {
+    const fullText = segments.map((s) => s.text).join('')
+    const writtenYearMatch = fullText.match(WRITTEN_YEAR_REGEX)
+    const defaultYear = writtenYearMatch
+      ? Number(writtenYearMatch[1])
+      : todayDate.getUTCFullYear()
 
-  for (const block of blocks) {
-    if (block.kind === 'divider') {
-      inNextSteps = false
-      continue
-    }
+    const highlightedTokens = segments
+      .filter((segment) => segment.highlighted)
+      .flatMap((segment) => extractDateTokens(segment.text, defaultYear))
 
-    if (block.kind === 'text') {
-      const text = normalizeText(block.text || '')
-      if (isNextStepsHeader(text)) {
-        inNextSteps = true
-        continue
-      }
+    if (!highlightedTokens.length) continue
 
-      if (inNextSteps && isSectionBoundary(block)) {
-        inNextSteps = false
-      }
-      continue
-    }
+    const earliest = highlightedTokens
+      .slice()
+      .sort((a, b) => a.date.getTime() - b.date.getTime())[0]
 
-    if (!inNextSteps) {
-      continue
-    }
-
-    if (block.itemAttrs?.checked) {
-      continue
-    }
-
-    const text = normalizeText(block.text || '')
-    if (!text) continue
-
-    const dueMeta = getDueMetadataFromInline(block.inlineContent || [], todayDate)
-
-    // Workflow rule: unhighlighted dates represent context/status notes, not due tasks.
-    if (dueMeta.hasAnyDateText && !dueMeta.hasExplicitDate) {
-      continue
-    }
-
-    const blockId = block.paragraphAttrs?.id || block.itemAttrs?.id
-    if (!blockId) continue
-
-    nextSteps.push({
-      text,
-      blockId,
-      dueBucket: dueMeta.dueBucket,
-      isOverdue: dueMeta.isOverdue,
-      hasExplicitDate: dueMeta.hasExplicitDate,
-      parentContext: block.parentText || undefined,
+    hints.push({
+      cid,
+      dateText: earliest.raw,
+      parsedIso: toIsoDate(earliest.date),
+      bucket: bucketForDate(earliest.date, todayDate),
     })
   }
 
-  return nextSteps
+  return hints
 }
 
-export const buildCandidatesForModel = (trackerPages: any[], today: string) => {
-  const nextSteps = (trackerPages || []).flatMap((page: any) =>
-    extractNextStepsFromContent(page?.content, today),
-  )
-
+// Build the full context sent to the model: whole-tracker markdown, the cid ->
+// block/text maps for mapping the response back, and the advisory date hints.
+export const buildTrackerContext = (trackerPages: any[], today: string): TrackerContext => {
+  const counter = { value: 1 }
   const cidToBlockId = new Map<string, string>()
   const cidToText = new Map<string, string>()
+  const cidSegments = new Map<string, InlineSegment[]>()
+  const sections: string[] = []
 
-  const candidates: CandidateForModel[] = nextSteps.map((item, idx) => {
-    const cid = `c${idx + 1}`
-    cidToBlockId.set(cid, item.blockId)
-    cidToText.set(cid, item.text)
-
-    const candidate: CandidateForModel = {
-      cid,
-      text: item.text,
-      due_bucket: item.dueBucket,
-      is_overdue: item.isOverdue,
-      has_explicit_date: item.hasExplicitDate,
-    }
-    if (item.parentContext) {
-      candidate.parent_context = item.parentContext
-    }
-    return candidate
-  })
+  for (const page of trackerPages || []) {
+    const ctx = createCtx(counter)
+    // Share the accumulating maps so cids stay globally unique across pages.
+    ctx.cidToBlockId = cidToBlockId
+    ctx.cidToText = cidToText
+    ctx.cidSegments = cidSegments
+    const markdown = serializeContentWithCtx(page?.content, ctx, page?.title)
+    if (markdown) sections.push(markdown)
+  }
 
   return {
-    candidates,
+    markdown: sections.join('\n\n'),
     cidToBlockId,
     cidToText,
+    dateHints: buildDateHints(cidSegments, today),
   }
 }
 
@@ -420,88 +499,63 @@ export const parseTaskBuckets = (text: string): ParsedTaskBuckets => {
   return { asap, fyi, format }
 }
 
-export type BucketName = 'asap' | 'fyi'
-
-export type MappedTask = {
-  task: string
-  block_ids: string[]
-  priority: string
-}
-
-// Each candidate has exactly one correct destination bucket, decided by the
-// server-computed due_bucket — overdue/today belong in ASAP, soon in FYI.
-// later/none candidates are never sent to the model, so they have no bucket.
-export const buildCidBucketMap = (candidates: CandidateForModel[]): Map<string, BucketName> => {
-  const cidToBucket = new Map<string, BucketName>()
-  for (const candidate of candidates || []) {
-    if (candidate.due_bucket === 'overdue' || candidate.due_bucket === 'today') {
-      cidToBucket.set(candidate.cid, 'asap')
-    } else if (candidate.due_bucket === 'soon') {
-      cidToBucket.set(candidate.cid, 'fyi')
-    }
-  }
-  return cidToBucket
-}
-
-// Routes the model's tasks into ASAP/FYI by each cid's *canonical* bucket rather
-// than the bucket the model chose. This recovers mis-bucketed real tasks (e.g. a
-// "today" item the model put in FYI) instead of dropping them, and silently
-// ignores cids the model invented or that were never sent (e.g. far-future
-// "later" items), which are safe to discard.
-export const routeTasksToBuckets = (
-  aiTasks: any[],
-  cidToBucket: Map<string, BucketName>,
+const mapBucket = (
+  tasks: any[],
   cidToBlockId: Map<string, string>,
   cidToText: Map<string, string>,
-) => {
-  const asap: MappedTask[] = []
-  const fyi: MappedTask[] = []
-  let droppedUnknownCids = 0
+): { tasks: MappedTask[]; dropped: number } => {
+  const mapped: MappedTask[] = []
+  let dropped = 0
 
-  for (const task of aiTasks || []) {
+  for (const task of tasks || []) {
     if (!Array.isArray(task?.cids)) continue
 
-    // Group this task's cids by where they actually belong. A single task can
-    // (rarely) reference cids spanning both buckets; each group becomes its own
-    // entry in the correct bucket.
-    const cidsByBucket = new Map<BucketName, string[]>()
+    const cids: string[] = []
     for (const cid of task.cids) {
-      const bucket = cidToBucket.get(cid)
-      if (!bucket) {
-        droppedUnknownCids += 1
-        continue
+      if (cidToBlockId.has(cid)) {
+        if (!cids.includes(cid)) cids.push(cid)
+      } else {
+        dropped += 1
       }
-      const group = cidsByBucket.get(bucket) || []
-      if (!group.includes(cid)) group.push(cid)
-      cidsByBucket.set(bucket, group)
     }
 
-    for (const [bucket, cids] of cidsByBucket) {
-      const blockIds = cids
-        .map((cid) => cidToBlockId.get(cid))
-        .filter((id): id is string => Boolean(id))
-      if (!blockIds.length) continue
+    const blockIds = cids
+      .map((cid) => cidToBlockId.get(cid))
+      .filter((id): id is string => Boolean(id))
+    if (!blockIds.length) continue
 
-      const fallbackTaskText = cids
-        .map((cid) => cidToText.get(cid))
-        .filter((value): value is string => Boolean(value))
-        .join(' + ')
+    const fallbackTaskText = cids
+      .map((cid) => cidToText.get(cid))
+      .filter((value): value is string => Boolean(value))
+      .join(' + ')
 
-      const nextTaskText = String(task?.task || '').trim() || fallbackTaskText
-      if (!nextTaskText) continue
+    const taskText = String(task?.task || '').trim() || fallbackTaskText
+    if (!taskText) continue
 
-      const nextPriority = ['high', 'medium', 'low'].includes(task?.priority)
-        ? task.priority
-        : 'medium'
+    const priority = ['high', 'medium', 'low'].includes(task?.priority)
+      ? task.priority
+      : 'medium'
 
-      const mappedTask: MappedTask = {
-        task: nextTaskText,
-        block_ids: blockIds,
-        priority: nextPriority,
-      }
-      ;(bucket === 'asap' ? asap : fyi).push(mappedTask)
-    }
+    mapped.push({ task: taskText, block_ids: blockIds, priority })
   }
 
-  return { asap, fyi, droppedUnknownCids }
+  return { tasks: mapped, dropped }
+}
+
+// Honor the AI's ASAP/FYI placement. The AI is the final judge now, so we keep
+// whichever bucket it chose, resolve cids to block ids for cross-off linking,
+// and silently drop cids the AI invented or that don't exist.
+export const mapTasksByBucket = (
+  parsed: ParsedTaskBuckets,
+  cidToBlockId: Map<string, string>,
+  cidToText: Map<string, string>,
+): { asap: MappedTask[]; fyi: MappedTask[]; droppedUnknownCids: number } => {
+  const asapResult = mapBucket(parsed.asap, cidToBlockId, cidToText)
+  const fyiResult = mapBucket(parsed.fyi, cidToBlockId, cidToText)
+
+  return {
+    asap: asapResult.tasks,
+    fyi: fyiResult.tasks,
+    droppedUnknownCids: asapResult.dropped + fyiResult.dropped,
+  }
 }

--- a/supabase/functions/generate-daily/index.ts
+++ b/supabase/functions/generate-daily/index.ts
@@ -2,11 +2,9 @@ import "jsr:@supabase/functions-js/edge-runtime.d.ts"
 import { createClient } from 'jsr:@supabase/supabase-js@2'
 
 import {
-  buildCandidatesForModel,
-  buildCidBucketMap,
-  filterCandidatesForDaily,
+  buildTrackerContext,
+  mapTasksByBucket,
   parseTaskBuckets,
-  routeTasksToBuckets,
 } from './dailyHelpers.ts'
 
 const ALLOWED_ORIGIN = Deno.env.get('ALLOWED_ORIGIN') || '*'
@@ -116,10 +114,11 @@ Deno.serve(async (req) => {
       return jsonResponse({ error: `No API key configured for ${provider}` }, 500)
     }
 
-    const { candidates, cidToBlockId, cidToText } = buildCandidatesForModel(trackerPages, today)
-    const modelCandidates = filterCandidatesForDaily(candidates)
+    const { markdown, cidToBlockId, cidToText, dateHints } = buildTrackerContext(trackerPages, today)
 
-    if (!modelCandidates.length) {
+    // Only bail out when there is genuinely nothing to reason about. Everything
+    // else — including "nothing is due" — is the model's call now.
+    if (!markdown.trim()) {
       return jsonResponse({
         asap: [],
         fyi: [],
@@ -130,33 +129,54 @@ Deno.serve(async (req) => {
 
     const systemPrompt = `You are a daily planner assistant. Today is ${today} (${dayOfWeek}).
 
-The user provides compact candidate tasks in JSON. Use only those candidates.
-Each candidate has metadata fields:
-- due_bucket: overdue | today | soon | later | none
-- is_overdue: boolean
-- has_explicit_date: boolean
+You are given the user's ENTIRE tracker as lightweight markdown. Every line that can be
+linked has a stable anchor like ⟦c12⟧ at the end. Highlighted text is written as [like this];
+the user highlights due dates in the tracker. You also get DATE_HINTS: a deterministic first
+pass over highlighted dates ("cid | raw date | parsed ISO date | bucket"). The hints are
+ADVISORY ONLY — you make the final decision about what belongs on today's list.
 
-Rules:
-- Metadata fields are deterministic server metadata. They are NOT literal due dates.
-- has_explicit_date=true means the source item contains a user-highlighted due date.
-- If has_explicit_date=false, treat date-like text as context/status notes, not due dates.
-- Use only candidate text + metadata to prioritize and bucket tasks.
-- ASAP is only due_bucket=overdue or due_bucket=today.
-- FYI is due_bucket=soon. For FYI items, always include the due date inline when the candidate text contains one (preserve the original format, e.g., "3/15"). Do not fabricate dates that aren't in the source text.
-- Do not include backlog, someday, or undated tasks.
-- If a candidate has parent_context, it is a sub-item nested under that parent. Use the parent context to make the task description self-contained (e.g., parent "Wedding planning" + task "Book photographer" → "Wedding: Book photographer").
+Decide which items belong on today's daily list:
+- ASAP: due today or overdue.
+- FYI: due within about the next 2 days, or a genuine heads-up worth surfacing today.
+
+Judgment principles (follow these carefully):
+- Only include items with a real, explicit due date. Leave undated items off entirely — do
+  NOT add tasks just to fill the list.
+- An EMPTY daily is a valid, good outcome. If nothing is genuinely due, return empty arrays.
+  Never pad the list; a tracker full of undated content must not spill in.
+- Distinguish a DUE date from a date used as CONTEXT. Journal/log-style dates (e.g. a date
+  tagged at the front of an update noting WHEN it was written) are NOT due dates. Judge how
+  the date is framed in the sentence.
+- Respect the intended year. Skip items clearly meant for a future year even if a bare date
+  matches today (e.g. "(of 2028)"). Trust DATE_HINTS' parsed ISO date and bucket for this.
+- Handle plain-language or slightly typo'd dates ("June 2nd", "Jun 2") using judgment, even if
+  they are not highlighted and not in DATE_HINTS.
+- Ignore background, recurring, notes, and status lines.
+- Make each task self-contained using its section/parent context (e.g. "Wedding: Book
+  photographer"). For FYI items, include the due date inline when the source has one, in its
+  original format.
 - Keep task text concise and actionable.
-- Use cids (not block IDs) in output.
+- Reference lines ONLY by the ⟦cid⟧ anchors that actually appear in the tracker. Never invent
+  anchors. Put the cids (without the ⟦⟧ brackets) in the "cids" array.
 
 Respond with ONLY a JSON object, no other text. Use this exact shape:
 {"asap":[{"task":"short task description","cids":["c1","c2"],"priority":"high"|"medium"|"low"}],"fyi":[{"task":"short task description","cids":["c1"],"priority":"high"|"medium"|"low"}]}
 
 If a bucket is empty, return an empty array.`
 
+    const hintLines = dateHints.map(
+      (hint) => `${hint.cid} | "${hint.dateText}" | parsed ${hint.parsedIso} | ${hint.bucket}`,
+    )
+
     const userMessage = [
       `TODAY: ${today}`,
       `DAY_OF_WEEK: ${dayOfWeek}`,
-      `CANDIDATES_JSON: ${JSON.stringify(modelCandidates)}`,
+      '',
+      'TRACKER_MARKDOWN:',
+      markdown,
+      '',
+      'DATE_HINTS:',
+      hintLines.length ? hintLines.join('\n') : '(none)',
     ].join('\n')
 
     let fetchUrl = providerConfig.url
@@ -177,17 +197,10 @@ If a bucket is empty, return an empty array.`
     const rawText = providerConfig.extractResponse(data)
     const parsed = parseTaskBuckets(rawText)
 
-    // The server, not the model, decides which bucket each task belongs in.
-    // Tasks the model mis-bucketed are re-routed to the correct bucket; cids the
-    // model invented or that were never sent (e.g. far-future items) are dropped
-    // silently because nothing real is lost.
-    const cidToBucket = buildCidBucketMap(modelCandidates)
-    const aiTasks = [
-      ...(Array.isArray(parsed.asap) ? parsed.asap : []),
-      ...(Array.isArray(parsed.fyi) ? parsed.fyi : []),
-    ]
-
-    const routed = routeTasksToBuckets(aiTasks, cidToBucket, cidToBlockId, cidToText)
+    // The model is the final judge of placement now. We honor its ASAP/FYI
+    // buckets, resolve cids to block ids for cross-off linking, and silently
+    // drop any cids it invented or that don't exist in the tracker.
+    const routed = mapTasksByBucket(parsed, cidToBlockId, cidToText)
     const asap = routed.asap
     const fyi = routed.fyi
 


### PR DESCRIPTION
## Problem

The **generate today's daily** feature was putting clearly future-year items into today's ASAP list. On a real 2026-07-01 run:

- `They are due by [4/15] (of 2027)` → landed in **ASAP**
- `...come up again ... around [7/1] (of 2028)` → landed in **ASAP**

**Root cause:** the flow was fully server-deterministic. `dailyHelpers.ts` parsed the cyan-highlighted date, computed a `due_bucket`, dropped anything it judged far-future/undated *before the AI saw it*, then *re-routed the AI's answer back to its own bucket*. The user writes the year in prose `(of 2027)` **outside** the highlight, and the parser only read the highlighted `4/15`/`7/1` with no year → defaulted to the current year (2026) → past/today → ASAP. A prompt-only change couldn't fix it.

## Approach

Flip the roles. The server does an **advisory** deterministic first pass; the AI receives the **whole tracker** as lightweight markdown plus the deterministic hints and makes the **final** ASAP/FYI/skip judgment. So plain-language dates, typos, and explicit future-year annotations are handled by judgment instead of hard-coded rules. Cross-off linking keeps working.

### New flow
1. **Full-tracker markdown serializer** with a stable per-line anchor (`⟦c12⟧`) on every id-bearing block. Port of `src/lib/serializeDocForExport.js` into Deno TS, extended to walk the whole doc and build `cidToBlockId` + `cidToText` maps. Anchors attach to the deep-link target (paragraph/heading id; list items anchor via their inner paragraph's id).
2. **Advisory date pass** with **year inference**: a bare highlighted date scans its line for a written year (`\b(20\d\d)\b`, catching `(of 2027)`); an explicit slash-year still wins. Emits compact hints (`cid | raw date | parsed ISO | bucket`) only for dated lines.
3. **AI is the judge.** New prompt: full tracker markdown + today's date + hints. Explicit judgment principles — only real explicit due dates, an empty daily is valid (never pad), distinguish a due date from a journal/log/context date, respect the intended year, handle plain-language/typo dates.
4. **Honor the AI's buckets.** Server maps cids → block_ids, keeps the AI's asap/fyi placement, drops invented/unknown cids. No more canonical re-routing.

### Output contract — unchanged
`{ asap: MappedTask[], fyi: MappedTask[], rawText, warning }`. No frontend changes needed.

## Test plan
- [x] `npm run test:unit` — 435 pass, incl. 13 new (year inference `4/15 (of 2027)`→later, `7/1 (of 2028)`→later, bare `7/1`→today; serializer anchoring/nesting/highlight; mapping honors AI buckets, drops invented cids, text fallback, default priority; empty-daily).
- [x] **Live replay** of the real failing 2026-07-01 payload: `4/15 (of 2027)`→`2027-04-15 later`, `7/1 (of 2028)`→`2028-07-01 later`, bare `7/1`→`2026-07-01 today`.
- [ ] **Manual (post-deploy):** regenerate the daily for 2026-07-01 in the live app; confirm the two future-year items are gone from ASAP and cross-off links `[1]` still resolve to the right blocks.

## Notes
- Single tracker page today; multi-tracker-page anchoring is out of scope.
- Sending the whole tracker grows the prompt, but markdown (~15KB for the real tracker) is far smaller than raw Tiptap JSON.

🤖 Generated with [Claude Code](https://claude.com/claude-code)