### PR TITLE
fix: reliably catch overdue deadlines in AI daily prompt

### DIFF
--- a/supabase/functions/generate-daily/index.ts
+++ b/supabase/functions/generate-daily/index.ts
@@ -136,10 +136,15 @@ pass over highlighted dates ("cid | raw date | parsed ISO date | bucket"). The h
 ADVISORY ONLY — you make the final decision about what belongs on today's list.
 
 Decide which items belong on today's daily list:
-- ASAP: due today or overdue.
+- ASAP: due today, or overdue — a real deadline whose date is already past and isn't done
+  yet. Overdue items are the highest priority; always surface them.
 - FYI: due within about the next 2 days, or a genuine heads-up worth surfacing today.
 
 Judgment principles (follow these carefully):
+- Catch overdue deadlines. If a DATE_HINT bucket is "overdue" (or a clear deadline's date is
+  before today) and the item isn't crossed off or checked, it is late — put it in ASAP. A
+  past date being old does NOT by itself make it context; only treat a past date as context
+  when the sentence frames it as a log/journal note rather than a deadline.
 - Only include items with a real, explicit due date. Leave undated items off entirely — do
   NOT add tasks just to fill the list.
 - An EMPTY daily is a valid, good outcome. If nothing is genuinely due, return empty arrays.
@@ -148,7 +153,8 @@ Judgment principles (follow these carefully):
   tagged at the front of an update noting WHEN it was written) are NOT due dates. Judge how
   the date is framed in the sentence.
 - Respect the intended year. Skip items clearly meant for a future year even if a bare date
-  matches today (e.g. "(of 2028)"). Trust DATE_HINTS' parsed ISO date and bucket for this.
+  matches today (e.g. "(of 2028)"). Trust DATE_HINTS' parsed ISO date and bucket: use it
+  both to skip future-year items and to catch overdue ones.
 - Handle plain-language or slightly typo'd dates ("June 2nd", "Jun 2") using judgment, even if
   they are not highlighted and not in DATE_HINTS.
 - Ignore background, recurring, notes, and status lines.


### PR DESCRIPTION
## Context

Follow-up to #196 (full-tracker / AI-as-judge rewrite). In a live run, **overdue deadlines were not captured** — clear deadlines whose dates had already passed did not show up in the daily.

**Why:** the `generate-daily` system prompt is heavily weighted toward *leaving items off* ("an EMPTY daily is valid," "never pad the list," "distinguish a DUE date from CONTEXT," "journal/log-style dates are NOT due dates," "skip future-year"). Overdue got a single passive mention. The model treated a deadline whose date is in the **past** as a stale log/context note and dropped it, instead of recognizing it as overdue-and-still-owed.

This is purely a **prompt-emphasis** fix — no logic/data change. The deterministic pass already emits an `overdue` bucket correctly; the new wording tells the model to catch overdue items both from `DATE_HINTS` *and* from reading the markdown (covering un-highlighted / plain-language past deadlines that get no hint).

## Change (prompt-only, one file)

`supabase/functions/generate-daily/index.ts` — the `systemPrompt` string only:

1. **Strengthened ASAP definition** so overdue is explicit and flagged highest-priority.
2. **New dedicated overdue rule** at the TOP of the judgment principles (before the "empty is valid" / "distinguish context" framing so it isn't mentally overridden). Covers the `DATE_HINT` "overdue" bucket *and* the no-hint case, and clarifies a past date is not automatically context.
3. **Bidirectional DATE_HINTS-trust line** — trust the parsed ISO/bucket both to skip future-year items and to catch overdue ones.

Completed/checked and true journal-date exceptions are preserved, so this does not reintroduce noise (aligns with "no guilt if you skip a week" — stale *completed* work still won't resurface).

## Non-goals

- No changes to `dailyHelpers.ts`, tests, serializer, date parsing, or the `{asap, fyi, rawText, warning}` contract.
- No staleness cutoff for how far back overdue reaches.

## Test plan

- [x] `npm run test:unit` — 435/435 passing (no logic changed; prompt text is not asserted).
- [x] Edge function redeployed: `npx supabase functions deploy generate-daily --project-ref ogzpgnxmcifaqliuxxzu`.
- [ ] **Manual (user):** regenerate the daily on a date with a clearly overdue highlighted deadline; confirm it now appears in **ASAP**, future-year items still stay out, and undated/journal lines still don't spill in.