### PR TITLE
fix: stop page-switch scroll-to-top flash

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -967,6 +967,7 @@ function App() {
               notebookId={activeNotebookId}
               sectionId={activeSectionId}
               trackerId={activeTrackerId}
+              restorePageId={trackerSession.trackerId}
               onNavigateHash={handleInternalHashNavigate}
               allTrackers={trackers}
               trackerSourcePage={sectionTrackerPage}

--- a/src/components/EditorPanel.jsx
+++ b/src/components/EditorPanel.jsx
@@ -45,6 +45,7 @@ function EditorPanel({
   notebookId,
   sectionId,
   trackerId,
+  restorePageId = null,
   onNavigateHash,
   allTrackers,
   trackerSourcePage = null,
@@ -100,7 +101,12 @@ function EditorPanel({
   useScrollRestoration({
     containerRef: editorPanelRef,
     editor,
-    pageId: trackerId,
+    // Key restoration off the COMMITTED session's page id, not the live
+    // trackerId (= activeTrackerId, which flips the instant you click a new
+    // page — ~1s before the content actually swaps). Using the live id made the
+    // outgoing page's still-mounted panel restore the INCOMING page's saved
+    // offset, yanking it to the top. restorePageId lags until the content swaps.
+    pageId: restorePageId ?? trackerId,
     ready: hasTracker && !editorLocked,
     skip: deepLinkActive,
     zoomLevel,


### PR DESCRIPTION
## Problem

Switching pages briefly **scrolls the page you're leaving to its top** before the new page appears — a visible flash. Reported on desktop.

## Root cause

On a page switch, `activeTrackerId` flips **immediately**, but the editor content only swaps ~1s later (after hydration commits a new `sessionKey`). During that gap the outgoing page's panel is still mounted, and `useScrollRestoration` — keyed off `pageId={trackerId}` (= `activeTrackerId`) — looked up the **incoming** page's saved scroll offset and applied it to the **outgoing** content, yanking it to the top.

Caught with a `scrollTop`-setter stack-trace probe: the offending write traced to `useScrollRestoration.tryApply()` (via the ResizeObserver waiter) applying the wrong page's offset. Every sampling-based instrument (rAF loop, MutationObserver, screenshot filmstrip) missed it because the visible frame was ~50ms and the write goes straight to `scrollTop`.

## Fix

Key restoration off the **committed session's** page id instead of the live one:
- `EditorPanel` gains a `restorePageId` prop (falls back to `trackerId`) used as `useScrollRestoration({ pageId })`.
- `App` passes `restorePageId={trackerSession.trackerId}`, which lags until the content actually swaps.

Result: the outgoing panel keeps its own offset through the transition; the incoming panel restores correctly once its content is committed. No other uses of `trackerId` are touched.

## Verification

- Reproduced and then confirmed fixed in-browser via Chrome DevTools instrumentation: after the fix the outgoing tracker panel holds its scroll offset through the hash change (stack-probe hits = 0, no visible tall-page-at-top frames).
- User confirmed the flash is gone on desktop.

## Test plan

- [ ] CI unit tests pass
- [ ] CI E2E (desktop + mobile Chrome) pass
- [ ] Manual: scroll down on a long page, switch to another page — leaving page no longer flashes to top
- [ ] Manual: return to the long page — scroll position still restores

## Notes / out of scope

- The separate **scroll-position-not-restored-on-fast-hardware** bug is untouched here; to be handled separately.
- An opacity "hide-until-restored" gate was prototyped during debugging and intentionally **not** included, to keep this diff minimal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)