### PR TITLE
Make the deterministic parser the judge for AI daily; demote AI to enrichment

### DIFF
--- a/supabase/functions/generate-daily/dailyHelpers.test.ts
+++ b/supabase/functions/generate-daily/dailyHelpers.test.ts
@@ -1,15 +1,26 @@
 import { describe, expect, it } from 'vitest'
 
 import {
-  buildDateHints,
+  buildCandidates,
+  buildDaily,
   buildTrackerContext,
-  mapTasksByBucket,
+  parseDateResolutions,
+  resolveFinalDate,
   serializeTrackerToMarkdown,
+  type DateCandidate,
+  type DateResolutions,
   type InlineSegment,
 } from './dailyHelpers.ts'
 
 const hl = (text: string): InlineSegment => ({ text, highlighted: true })
 const plain = (text: string): InlineSegment => ({ text, highlighted: false })
+
+// A DateResolutions with no AI enrichment — the deterministic list alone.
+const emptyResolutions = (): DateResolutions => ({
+  resolutions: new Map(),
+  flagged: [],
+  format: 'empty',
+})
 
 describe('serializeTrackerToMarkdown', () => {
   it('emits a stable cid anchor per block that has an id and resolves it to the block id', () => {
@@ -97,154 +108,110 @@ describe('serializeTrackerToMarkdown', () => {
   })
 })
 
-describe('buildDateHints — year inference', () => {
+describe('buildCandidates', () => {
   const today = '2026-07-01'
 
-  it('uses a written year in the line for a bare highlighted date (4/15 of 2027 → later)', () => {
+  it('only yields a candidate for a highlighted MM/DD token', () => {
+    const cidSegments = new Map<string, InlineSegment[]>([
+      ['c1', [plain('Bachelor party '), hl('7/1')]],
+      ['c2', [plain('Background: written on 4/15 as a log note')]],
+      ['c3', [plain('No dates at all here')]],
+    ])
+    const candidates = buildCandidates(cidSegments, today)
+    expect(candidates.map((c) => c.cid)).toEqual(['c1'])
+  })
+
+  it('drops struck / completed lines before they become candidates (via segment filter)', () => {
+    // collectInlineSegments removes struck text, so a struck date never reaches
+    // buildCandidates as a highlighted segment. Simulate the post-filter input.
+    const cidSegments = new Map<string, InlineSegment[]>([
+      ['c1', [plain('Done thing ')]], // date was struck out and dropped
+    ])
+    expect(buildCandidates(cidSegments, today)).toEqual([])
+  })
+
+  it('sets deterministicIso from an explicit slash-year and marks needsAiYear false', () => {
+    const cidSegments = new Map<string, InlineSegment[]>([
+      ['c1', [plain('Due '), hl('4/15/2030'), plain(' (of 2027)')]],
+    ])
+    const [candidate] = buildCandidates(cidSegments, today)
+    expect(candidate.deterministicIso).toBe('2030-04-15')
+    expect(candidate.month).toBe(4)
+    expect(candidate.day).toBe(15)
+    expect(candidate.needsAiYear).toBe(false)
+  })
+
+  it('uses a written digit year on the line and marks needsAiYear false (4/15 of 2027)', () => {
     const cidSegments = new Map<string, InlineSegment[]>([
       ['c1', [plain('They are due by '), hl('4/15'), plain(' (of 2027)')]],
     ])
-    const hints = buildDateHints(cidSegments, today)
-    expect(hints).toHaveLength(1)
-    expect(hints[0].cid).toBe('c1')
-    expect(hints[0].parsedIso).toBe('2027-04-15')
-    expect(hints[0].bucket).toBe('later')
+    const [candidate] = buildCandidates(cidSegments, today)
+    expect(candidate.deterministicIso).toBe('2027-04-15')
+    expect(candidate.needsAiYear).toBe(false)
   })
 
-  it('handles a far-future written year (7/1 of 2028 → later)', () => {
+  it('defaults a bare highlighted date to the current year and marks needsAiYear true', () => {
     const cidSegments = new Map<string, InlineSegment[]>([
-      ['c2', [plain('might come up around '), hl('7/1'), plain(' (of 2028)')]],
+      ['c1', [plain('Bachelor party '), hl('7/1')]],
     ])
-    const hints = buildDateHints(cidSegments, today)
-    expect(hints).toHaveLength(1)
-    expect(hints[0].parsedIso).toBe('2028-07-01')
-    expect(hints[0].bucket).toBe('later')
-  })
-
-  it('defaults a bare highlighted date to the current year (7/1 → today)', () => {
-    const cidSegments = new Map<string, InlineSegment[]>([
-      ['c3', [plain('Bachelor party '), hl('7/1')]],
-    ])
-    const hints = buildDateHints(cidSegments, today)
-    expect(hints).toHaveLength(1)
-    expect(hints[0].parsedIso).toBe('2026-07-01')
-    expect(hints[0].bucket).toBe('today')
-  })
-
-  it('lets an explicit slash-year win over the written year', () => {
-    const cidSegments = new Map<string, InlineSegment[]>([
-      ['c4', [plain('Due '), hl('4/15/2030'), plain(' (of 2027)')]],
-    ])
-    const hints = buildDateHints(cidSegments, today)
-    expect(hints[0].parsedIso).toBe('2030-04-15')
-  })
-
-  it('emits no hint for lines without a highlighted date', () => {
-    const cidSegments = new Map<string, InlineSegment[]>([
-      ['c5', [plain('Background: written on 4/15 as a log note')]],
-      ['c6', [plain('No dates at all here')]],
-    ])
-    expect(buildDateHints(cidSegments, today)).toEqual([])
+    const [candidate] = buildCandidates(cidSegments, today)
+    expect(candidate.deterministicIso).toBe('2026-07-01')
+    expect(candidate.needsAiYear).toBe(true)
   })
 })
 
-describe('mapTasksByBucket', () => {
-  const cidToBlockId = new Map<string, string>([
-    ['c1', 'block-1'],
-    ['c2', 'block-2'],
-    ['c3', 'block-3'],
-  ])
-  const cidToText = new Map<string, string>([
-    ['c1', 'First task'],
-    ['c2', 'Second task'],
-    ['c3', 'Third task'],
-  ])
-
-  it('honors the AI asap/fyi placement without re-routing', () => {
-    const parsed = {
-      asap: [{ task: 'Do first', cids: ['c1'], priority: 'high' }],
-      fyi: [{ task: 'Heads up on second', cids: ['c2'], priority: 'low' }],
-      format: 'asap_fyi' as const,
-    }
-    const { asap, fyi } = mapTasksByBucket(parsed, cidToBlockId, cidToText)
-    expect(asap).toEqual([{ task: 'Do first', block_ids: ['block-1'], priority: 'high' }])
-    expect(fyi).toEqual([{ task: 'Heads up on second', block_ids: ['block-2'], priority: 'low' }])
-  })
-
-  it('drops invented / unknown cids and skips tasks left with no real block', () => {
-    const parsed = {
-      asap: [{ task: 'Hallucinated', cids: ['cX', 'cY'], priority: 'high' }],
-      fyi: [],
-      format: 'asap_fyi' as const,
-    }
-    const { asap, fyi, droppedUnknownCids } = mapTasksByBucket(parsed, cidToBlockId, cidToText)
-    expect(asap).toEqual([])
-    expect(fyi).toEqual([])
-    expect(droppedUnknownCids).toBe(2)
-  })
-
-  it('falls back to candidate text and defaults priority when the AI omits them', () => {
-    const parsed = {
-      asap: [{ task: '   ', cids: ['c3'], priority: 'nonsense' }],
-      fyi: [],
-      format: 'asap_fyi' as const,
-    }
-    const { asap } = mapTasksByBucket(parsed, cidToBlockId, cidToText)
-    expect(asap).toEqual([{ task: 'Third task', block_ids: ['block-3'], priority: 'medium' }])
-  })
-
-  it('returns empty arrays when the AI returns nothing due', () => {
-    const parsed = { asap: [], fyi: [], format: 'empty' as const }
-    const { asap, fyi } = mapTasksByBucket(parsed, cidToBlockId, cidToText)
-    expect(asap).toEqual([])
-    expect(fyi).toEqual([])
-  })
-})
-
-describe('buildTrackerContext', () => {
+describe('buildTrackerContext — highlightedCids', () => {
   const today = '2026-07-01'
 
-  it('serializes every page and only emits hints for highlighted dates', () => {
+  it('includes highlighted lines (incl. a highlighted typo) and excludes plain lines', () => {
     const trackerPages = [
       {
         title: 'July 2026 Tracker',
-        pageId: 'page-1',
         content: {
           type: 'doc',
           content: [
             {
               type: 'paragraph',
-              attrs: { id: 'p-future' },
+              attrs: { id: 'p-cand' },
               content: [
                 { type: 'text', text: 'File form ' },
                 { type: 'text', text: '4/15', marks: [{ type: 'highlight' }] },
-                { type: 'text', text: ' (of 2027)' },
               ],
             },
             {
               type: 'paragraph',
-              attrs: { id: 'p-note' },
-              content: [{ type: 'text', text: 'Background: nothing due here' }],
+              attrs: { id: 'p-typo' },
+              content: [
+                { type: 'text', text: 'Renew pass ' },
+                { type: 'text', text: '4/l5', marks: [{ type: 'highlight' }] },
+              ],
+            },
+            {
+              type: 'paragraph',
+              attrs: { id: 'p-plain' },
+              content: [{ type: 'text', text: 'Background note' }],
             },
           ],
         },
       },
     ]
 
-    const { markdown, cidToBlockId, dateHints } = buildTrackerContext(trackerPages, today)
-    expect(markdown).toContain('JULY 2026 TRACKER')
-    expect(cidToBlockId.size).toBe(2)
-    // Only the highlighted-date line yields a hint, and year inference pushes it out.
-    expect(dateHints).toHaveLength(1)
-    expect(dateHints[0].bucket).toBe('later')
-    expect(cidToBlockId.get(dateHints[0].cid)).toBe('p-future')
+    const { candidates, highlightedCids, cidToBlockId } = buildTrackerContext(trackerPages, today)
+
+    const candBlockIds = candidates.map((c) => cidToBlockId.get(c.cid))
+    // Only the well-formed MM/DD line is a candidate; the typo is not.
+    expect(candBlockIds).toEqual(['p-cand'])
+
+    const highlightedBlockIds = [...highlightedCids].map((cid) => cidToBlockId.get(cid)).sort()
+    expect(highlightedBlockIds).toEqual(['p-cand', 'p-typo'])
+    // The plain line is never highlighted.
+    expect(highlightedBlockIds).not.toContain('p-plain')
   })
 
-  it('yields empty hints for an all-undated tracker', () => {
+  it('yields no candidates and no highlighted cids for an all-undated tracker', () => {
     const trackerPages = [
       {
         title: 'Empty',
-        pageId: 'page-1',
         content: {
           type: 'doc',
           content: [
@@ -257,7 +224,211 @@ describe('buildTrackerContext', () => {
         },
       },
     ]
-    const { dateHints } = buildTrackerContext(trackerPages, today)
-    expect(dateHints).toEqual([])
+    const { candidates, highlightedCids } = buildTrackerContext(trackerPages, today)
+    expect(candidates).toEqual([])
+    expect(highlightedCids.size).toBe(0)
+  })
+})
+
+describe('resolveFinalDate', () => {
+  const today = '2026-07-01'
+
+  const bareCandidate: DateCandidate = {
+    cid: 'c1',
+    dateText: '4/15',
+    month: 4,
+    day: 15,
+    deterministicIso: '2026-04-15',
+    needsAiYear: true,
+  }
+
+  it('recombines the AI-resolved year with the deterministic month/day', () => {
+    const date = resolveFinalDate(bareCandidate, '2028-01-01', today)
+    // Only the year (2028) is taken; month/day stay 4/15.
+    expect(date.toISOString().slice(0, 10)).toBe('2028-04-15')
+  })
+
+  it('ignores the AI year when the year is already explicit (needsAiYear false)', () => {
+    const explicit: DateCandidate = { ...bareCandidate, deterministicIso: '2027-04-15', needsAiYear: false }
+    const date = resolveFinalDate(explicit, '2099-01-01', today)
+    expect(date.toISOString().slice(0, 10)).toBe('2027-04-15')
+  })
+
+  it('falls back to the deterministic date when the AI iso_date is invalid', () => {
+    const date = resolveFinalDate(bareCandidate, 'not-a-date', today)
+    expect(date.toISOString().slice(0, 10)).toBe('2026-04-15')
+  })
+
+  it('keeps the current-year default when the AI returns null', () => {
+    const date = resolveFinalDate(bareCandidate, null, today)
+    expect(date.toISOString().slice(0, 10)).toBe('2026-04-15')
+  })
+})
+
+describe('parseDateResolutions', () => {
+  it('parses a fenced JSON object with resolutions and flagged', () => {
+    const raw = [
+      'Here you go:',
+      '```json',
+      '{"resolutions":[{"cid":"c1","iso_date":null,"task":"File form"}],',
+      '"flagged":[{"cid":"c9","iso_date":"2026-03-15","task":"Renew pass"}]}',
+      '```',
+    ].join('\n')
+    const parsed = parseDateResolutions(raw)
+    expect(parsed.format).toBe('resolved')
+    expect(parsed.resolutions.get('c1')).toEqual({ iso_date: null, task: 'File form' })
+    expect(parsed.flagged).toEqual([{ cid: 'c9', iso_date: '2026-03-15', task: 'Renew pass' }])
+  })
+
+  it('ignores entries missing a cid and flagged entries missing an iso_date', () => {
+    const raw = JSON.stringify({
+      resolutions: [{ iso_date: '2027-01-01', task: 'no cid' }, { cid: 'c2', task: 'ok' }],
+      flagged: [{ cid: 'c3', task: 'no date' }],
+    })
+    const parsed = parseDateResolutions(raw)
+    expect(parsed.resolutions.has('c2')).toBe(true)
+    expect(parsed.resolutions.size).toBe(1)
+    expect(parsed.flagged).toEqual([])
+  })
+
+  it('returns empty format on unparseable text', () => {
+    const parsed = parseDateResolutions('total nonsense, no json')
+    expect(parsed.format).toBe('empty')
+    expect(parsed.resolutions.size).toBe(0)
+    expect(parsed.flagged).toEqual([])
+  })
+})
+
+describe('buildDaily — candidates decide the list', () => {
+  const today = '2026-07-01'
+  const cidToBlockId = new Map<string, string>([
+    ['c1', 'block-1'],
+    ['c2', 'block-2'],
+    ['c3', 'block-3'],
+  ])
+  const cidToText = new Map<string, string>([
+    ['c1', 'Pay taxes'],
+    ['c2', 'Book venue'],
+    ['c3', 'Distant thing'],
+  ])
+  const highlightedCids = new Set(['c1', 'c2', 'c3'])
+
+  const candidate = (cid: string, iso: string, needsAiYear = false): DateCandidate => ({
+    cid,
+    dateText: iso.slice(5).replace('-', '/'),
+    month: Number(iso.slice(5, 7)),
+    day: Number(iso.slice(8, 10)),
+    deterministicIso: iso,
+    needsAiYear,
+  })
+
+  it('guarantees an overdue highlighted date lands in ASAP', () => {
+    const candidates = [candidate('c1', '2026-03-15')] // months before today
+    const { asap, fyi } = buildDaily(candidates, emptyResolutions(), cidToBlockId, cidToText, highlightedCids, today)
+    expect(asap).toEqual([{ task: 'Pay taxes', block_ids: ['block-1'], priority: 'high' }])
+    expect(fyi).toEqual([])
+  })
+
+  it('routes a soon (<=2d) date to FYI with medium priority', () => {
+    const candidates = [candidate('c2', '2026-07-02')]
+    const { asap, fyi } = buildDaily(candidates, emptyResolutions(), cidToBlockId, cidToText, highlightedCids, today)
+    expect(asap).toEqual([])
+    expect(fyi).toEqual([{ task: 'Book venue', block_ids: ['block-2'], priority: 'medium' }])
+  })
+
+  it('drops a far-future (later) candidate', () => {
+    const candidates = [candidate('c3', '2026-12-31')]
+    const { asap, fyi } = buildDaily(candidates, emptyResolutions(), cidToBlockId, cidToText, highlightedCids, today)
+    expect(asap).toEqual([])
+    expect(fyi).toEqual([])
+  })
+
+  it('prefers the AI-phrased task but falls back to cidToText', () => {
+    const candidates = [candidate('c1', '2026-07-01')]
+    const parsed: DateResolutions = {
+      resolutions: new Map([['c1', { iso_date: null, task: 'Finance: File taxes' }]]),
+      flagged: [],
+      format: 'resolved',
+    }
+    const { asap } = buildDaily(candidates, parsed, cidToBlockId, cidToText, highlightedCids, today)
+    expect(asap[0].task).toBe('Finance: File taxes')
+
+    const { asap: fallback } = buildDaily(candidates, emptyResolutions(), cidToBlockId, cidToText, highlightedCids, today)
+    expect(fallback[0].task).toBe('Pay taxes')
+  })
+
+  it('applies an AI-resolved year to a needsAiYear candidate before bucketing', () => {
+    // Bare 4/15 defaults to 2026 (overdue), but the AI resolves 2028 → later → dropped.
+    const candidates = [candidate('c1', '2026-04-15', true)]
+    const parsed: DateResolutions = {
+      resolutions: new Map([['c1', { iso_date: '2028-04-15', task: 'Pay taxes' }]]),
+      flagged: [],
+      format: 'resolved',
+    }
+    const { asap, fyi } = buildDaily(candidates, parsed, cidToBlockId, cidToText, highlightedCids, today)
+    expect(asap).toEqual([])
+    expect(fyi).toEqual([])
+  })
+})
+
+describe('buildDaily — flagged extras (additive only)', () => {
+  const today = '2026-07-01'
+  const cidToBlockId = new Map<string, string>([
+    ['c1', 'block-1'],
+    ['c9', 'block-9'],
+  ])
+  const cidToText = new Map<string, string>([
+    ['c1', 'Pay taxes'],
+    ['c9', 'Renew pass'],
+  ])
+  const highlightedCids = new Set(['c1', 'c9'])
+
+  const flaggedParsed = (flagged: DateResolutions['flagged']): DateResolutions => ({
+    resolutions: new Map(),
+    flagged,
+    format: 'resolved',
+  })
+
+  it('adds a highlighted non-candidate overdue flag and reports feedback', () => {
+    const parsed = flaggedParsed([{ cid: 'c9', iso_date: '2026-03-15', task: 'Renew pass' }])
+    const { asap, feedback } = buildDaily([], parsed, cidToBlockId, cidToText, highlightedCids, today)
+    expect(asap).toEqual([{ task: 'Renew pass', block_ids: ['block-9'], priority: 'high' }])
+    expect(feedback).toHaveLength(1)
+    expect(feedback[0]).toContain('Renew pass')
+  })
+
+  it('rejects a flagged cid that is not highlighted', () => {
+    const notHighlighted = new Set(['c1']) // c9 absent
+    const parsed = flaggedParsed([{ cid: 'c9', iso_date: '2026-03-15', task: 'Renew pass' }])
+    const { asap, fyi, feedback } = buildDaily([], parsed, cidToBlockId, cidToText, notHighlighted, today)
+    expect(asap).toEqual([])
+    expect(fyi).toEqual([])
+    expect(feedback).toEqual([])
+  })
+
+  it('never lets a flagged entry override a candidate on the same cid', () => {
+    const candidates: DateCandidate[] = [
+      { cid: 'c1', dateText: '3/15', month: 3, day: 15, deterministicIso: '2026-03-15', needsAiYear: false },
+    ]
+    // Flag tries to move c1 to a far-future date; it must be ignored.
+    const parsed = flaggedParsed([{ cid: 'c1', iso_date: '2030-03-15', task: 'Hijacked' }])
+    const { asap, feedback } = buildDaily(candidates, parsed, cidToBlockId, cidToText, highlightedCids, today)
+    expect(asap).toEqual([{ task: 'Pay taxes', block_ids: ['block-1'], priority: 'high' }])
+    expect(feedback).toEqual([])
+  })
+
+  it('drops a flagged far-future date via bucketForDate', () => {
+    const parsed = flaggedParsed([{ cid: 'c9', iso_date: '2030-01-01', task: 'Renew pass' }])
+    const { asap, fyi, feedback } = buildDaily([], parsed, cidToBlockId, cidToText, highlightedCids, today)
+    expect(asap).toEqual([])
+    expect(fyi).toEqual([])
+    expect(feedback).toEqual([])
+  })
+
+  it('rejects a flagged entry with an invalid iso_date', () => {
+    const parsed = flaggedParsed([{ cid: 'c9', iso_date: '2026-13-40', task: 'Renew pass' }])
+    const { asap, fyi } = buildDaily([], parsed, cidToBlockId, cidToText, highlightedCids, today)
+    expect(asap).toEqual([])
+    expect(fyi).toEqual([])
   })
 })

--- a/supabase/functions/generate-daily/dailyHelpers.ts
+++ b/supabase/functions/generate-daily/dailyHelpers.ts
@@ -5,21 +5,26 @@ export type InlineSegment = {
   highlighted: boolean
 }
 
-// One advisory hint per line that contains a highlighted (due-style) date. The
-// server no longer decides placement from these — the AI does — so a hint is
-// purely informational: "this line has a date; here's how the deterministic
-// pass reads it".
-export type DateHint = {
+// One deterministic candidate per line that carries a highlighted MM/DD token.
+// The deterministic pass is the judge of what makes the list; a candidate holds
+// everything that decision needs. `needsAiYear` is true only when the year came
+// from the current-year default (no slash-year, no written 20xx on the line),
+// so the AI is asked to resolve a plain-language year for just those lines.
+export type DateCandidate = {
   cid: string
   dateText: string
-  parsedIso: string
-  bucket: DueBucket
+  month: number
+  day: number
+  deterministicIso: string
+  needsAiYear: boolean
 }
 
-export type ParsedTaskBuckets = {
-  asap: any[]
-  fyi: any[]
-  format: 'empty' | 'asap_fyi'
+// The AI's strictly-additive enrichment output: per-candidate year resolution +
+// phrasing, and flags for highlighted lines whose date the regex couldn't read.
+export type DateResolutions = {
+  resolutions: Map<string, { iso_date: string | null; task: string }>
+  flagged: Array<{ cid: string; iso_date: string; task: string }>
+  format: 'resolved' | 'empty'
 }
 
 export type MappedTask = {
@@ -32,7 +37,8 @@ export type TrackerContext = {
   markdown: string
   cidToBlockId: Map<string, string>
   cidToText: Map<string, string>
-  dateHints: DateHint[]
+  candidates: DateCandidate[]
+  highlightedCids: Set<string>
 }
 
 const DAY_MS = 24 * 60 * 60 * 1000
@@ -81,7 +87,13 @@ const parseDateToken = (
   return date
 }
 
-type DateToken = { date: Date; raw: string }
+type DateToken = {
+  date: Date
+  raw: string
+  month: number
+  day: number
+  hasSlashYear: boolean
+}
 
 const extractDateTokens = (text: string, defaultYear: number): DateToken[] => {
   const results: DateToken[] = []
@@ -91,11 +103,33 @@ const extractDateTokens = (text: string, defaultYear: number): DateToken[] => {
   let match: RegExpExecArray | null = DATE_TOKEN_REGEX.exec(normalized)
   while (match) {
     const date = parseDateToken(match[1], match[2], match[3], defaultYear)
-    if (date) results.push({ date, raw: match[0] })
+    if (date) {
+      results.push({
+        date,
+        raw: match[0],
+        month: Number(match[1]),
+        day: Number(match[2]),
+        hasSlashYear: Boolean(match[3]),
+      })
+    }
     match = DATE_TOKEN_REGEX.exec(normalized)
   }
 
   return results
+}
+
+// Validate that a value is a real MM/DD calendar date in a 20xx year written as
+// an ISO string. Returns the parsed UTC date and its year, or null. Guards
+// against JS date rollover (e.g. "2027-02-30") by round-tripping the ISO string.
+const VALID_ISO_REGEX = /^(20\d\d)-\d\d-\d\d$/
+
+const parseValidIso = (value: unknown): { date: Date; year: number } | null => {
+  if (typeof value !== 'string') return null
+  const match = value.match(VALID_ISO_REGEX)
+  if (!match) return null
+  const date = toUtcDate(value)
+  if (!date || toIsoDate(date) !== value) return null
+  return { date, year: Number(match[1]) }
 }
 
 const bucketForDate = (dueDate: Date, todayDate: Date): DueBucket => {
@@ -391,18 +425,20 @@ export const serializeTrackerToMarkdown = (content: any, title?: string): Serial
   }
 }
 
-// Build one advisory hint per line that contains a highlighted date. Year
-// inference: when a highlighted date has no slash-year, a written year on the
-// same line (e.g. "(of 2027)") is used as the default; an explicit slash-year
-// always wins.
-export const buildDateHints = (
+// Build one deterministic candidate per line that carries a highlighted MM/DD
+// token. Year ladder: an explicit slash-year wins; else a written 20xx year on
+// the same line (e.g. "(of 2027)") is used; else the current year is the
+// default. `needsAiYear` is set only in that last case — the one time a
+// plain-language year could change the result — so the AI never touches
+// month/day, only the year for those lines.
+export const buildCandidates = (
   cidSegments: Map<string, InlineSegment[]>,
   today: string,
-): DateHint[] => {
+): DateCandidate[] => {
   const todayDate = toUtcDate(today)
   if (!todayDate) return []
 
-  const hints: DateHint[] = []
+  const candidates: DateCandidate[] = []
 
   for (const [cid, segments] of cidSegments) {
     const fullText = segments.map((s) => s.text).join('')
@@ -421,19 +457,75 @@ export const buildDateHints = (
       .slice()
       .sort((a, b) => a.date.getTime() - b.date.getTime())[0]
 
-    hints.push({
+    candidates.push({
       cid,
       dateText: earliest.raw,
-      parsedIso: toIsoDate(earliest.date),
-      bucket: bucketForDate(earliest.date, todayDate),
+      month: earliest.month,
+      day: earliest.day,
+      deterministicIso: toIsoDate(earliest.date),
+      needsAiYear: !earliest.hasSlashYear && !writtenYearMatch,
     })
   }
 
-  return hints
+  return candidates
+}
+
+// The user's convention: a highlight marks a due date. This is the server-side
+// gate for the AI's additive flagging — a flagged line is only accepted if its
+// cid carries a highlight here.
+export const buildHighlightedCids = (
+  cidSegments: Map<string, InlineSegment[]>,
+): Set<string> => {
+  const highlighted = new Set<string>()
+  for (const [cid, segments] of cidSegments) {
+    if (segments.some((segment) => segment.highlighted && segment.text.trim())) {
+      highlighted.add(cid)
+    }
+  }
+  return highlighted
+}
+
+// Step 4 precedence for a candidate's final date:
+//   1. explicit/digit year (needsAiYear false)  → deterministic date wins.
+//   2. plain-language year the AI resolved       → recombine its YEAR ONLY with
+//      the deterministic month/day (re-validated), else fall back.
+//   3. no valid AI year                          → current-year default stands.
+export const resolveFinalDate = (
+  candidate: DateCandidate,
+  aiIso: unknown,
+  today: string,
+): Date => {
+  const deterministic = toUtcDate(candidate.deterministicIso) as Date
+
+  if (!candidate.needsAiYear) return deterministic
+
+  const parsed = parseValidIso(aiIso)
+  if (parsed) {
+    const todayDate = toUtcDate(today)
+    const currentYear = todayDate ? todayDate.getUTCFullYear() : parsed.year
+    const recombined = parseDateToken(
+      String(candidate.month),
+      String(candidate.day),
+      String(parsed.year),
+      currentYear,
+    )
+    if (recombined) return recombined
+  }
+
+  return deterministic
+}
+
+// A flagged line has no deterministic month/day (the regex missed it), so the
+// AI's full ISO date is used — but only if it parses as a real 20xx date.
+export const resolveFlaggedDate = (aiIso: unknown, _today: string): Date | null => {
+  const parsed = parseValidIso(aiIso)
+  return parsed ? parsed.date : null
 }
 
 // Build the full context sent to the model: whole-tracker markdown, the cid ->
-// block/text maps for mapping the response back, and the advisory date hints.
+// block/text maps for mapping the response back, the deterministic date
+// candidates (which decide the list), and the set of highlighted cids (the
+// server-side gate for the AI's additive flagging).
 export const buildTrackerContext = (trackerPages: any[], today: string): TrackerContext => {
   const counter = { value: 1 }
   const cidToBlockId = new Map<string, string>()
@@ -455,107 +547,136 @@ export const buildTrackerContext = (trackerPages: any[], today: string): Tracker
     markdown: sections.join('\n\n'),
     cidToBlockId,
     cidToText,
-    dateHints: buildDateHints(cidSegments, today),
+    candidates: buildCandidates(cidSegments, today),
+    highlightedCids: buildHighlightedCids(cidSegments),
   }
 }
 
-export const parseTaskBuckets = (text: string): ParsedTaskBuckets => {
-  let asap: any[] = []
-  let fyi: any[] = []
-  let format: ParsedTaskBuckets['format'] = 'empty'
+// Tolerantly parse the AI's structured-extraction JSON. The model is asked to
+// return ONLY `{ resolutions: [...], flagged: [...] }`, but may fence or pad it,
+// so we slice to the first top-level `{...}` object. Entries missing a string
+// `cid` are ignored; flagged entries require a string `iso_date`. `format` is
+// 'resolved' whenever the object parsed (even if empty), so the deterministic
+// list stands without a spurious warning.
+export const parseDateResolutions = (text: string): DateResolutions => {
+  const resolutions = new Map<string, { iso_date: string | null; task: string }>()
+  const flagged: Array<{ cid: string; iso_date: string; task: string }> = []
+  let format: DateResolutions['format'] = 'empty'
 
   try {
     const trimmed = String(text || '').trim()
     let parsed: any = null
 
-    if (trimmed.startsWith('{') || trimmed.startsWith('[')) {
+    if (trimmed.startsWith('{')) {
       parsed = JSON.parse(trimmed)
     } else {
       const objStart = trimmed.indexOf('{')
       const objEnd = trimmed.lastIndexOf('}')
-      const arrStart = trimmed.indexOf('[')
-      const arrEnd = trimmed.lastIndexOf(']')
       if (objStart !== -1 && objEnd !== -1 && objEnd > objStart) {
         parsed = JSON.parse(trimmed.slice(objStart, objEnd + 1))
-      } else if (arrStart !== -1 && arrEnd !== -1 && arrEnd > arrStart) {
-        parsed = JSON.parse(trimmed.slice(arrStart, arrEnd + 1))
       }
     }
 
-    if (parsed && typeof parsed === 'object') {
-      if (Array.isArray(parsed.asap)) asap = parsed.asap
-      if (Array.isArray(parsed.fyi)) fyi = parsed.fyi
+    if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+      format = 'resolved'
 
-      if (Array.isArray(parsed.asap) || Array.isArray(parsed.fyi)) {
-        format = 'asap_fyi'
+      if (Array.isArray(parsed.resolutions)) {
+        for (const entry of parsed.resolutions) {
+          if (!entry || typeof entry.cid !== 'string') continue
+          const iso = typeof entry.iso_date === 'string' ? entry.iso_date : null
+          const task = typeof entry.task === 'string' ? entry.task : ''
+          resolutions.set(entry.cid, { iso_date: iso, task })
+        }
+      }
+
+      if (Array.isArray(parsed.flagged)) {
+        for (const entry of parsed.flagged) {
+          if (!entry || typeof entry.cid !== 'string') continue
+          if (typeof entry.iso_date !== 'string') continue
+          const task = typeof entry.task === 'string' ? entry.task : ''
+          flagged.push({ cid: entry.cid, iso_date: entry.iso_date, task })
+        }
       }
     }
   } catch {
-    asap = []
-    fyi = []
+    resolutions.clear()
+    flagged.length = 0
     format = 'empty'
   }
 
-  return { asap, fyi, format }
+  return { resolutions, flagged, format }
 }
 
-const mapBucket = (
-  tasks: any[],
+// Build today's list. The deterministic candidates decide inclusion (the AI can
+// never remove, move, or re-bucket one); the AI only supplies a resolved year
+// and phrasing. Flagged extras are merged strictly additively, each gated by
+// (a) highlighted, (b) not already a candidate, (c) a valid, parseable date.
+// bucketForDate still decides inclusion for flagged items too.
+export const buildDaily = (
+  candidates: DateCandidate[],
+  parsed: DateResolutions,
   cidToBlockId: Map<string, string>,
   cidToText: Map<string, string>,
-): { tasks: MappedTask[]; dropped: number } => {
-  const mapped: MappedTask[] = []
-  let dropped = 0
+  highlightedCids: Set<string>,
+  today: string,
+): { asap: MappedTask[]; fyi: MappedTask[]; feedback: string[] } => {
+  const asap: MappedTask[] = []
+  const fyi: MappedTask[] = []
+  const feedback: string[] = []
 
-  for (const task of tasks || []) {
-    if (!Array.isArray(task?.cids)) continue
+  const todayDate = toUtcDate(today)
+  if (!todayDate) return { asap, fyi, feedback }
 
-    const cids: string[] = []
-    for (const cid of task.cids) {
-      if (cidToBlockId.has(cid)) {
-        if (!cids.includes(cid)) cids.push(cid)
-      } else {
-        dropped += 1
-      }
+  const candidateCids = new Set(candidates.map((candidate) => candidate.cid))
+
+  const place = (bucket: DueBucket, task: string, blockId: string) => {
+    const isAsap = bucket === 'overdue' || bucket === 'today'
+    const entry: MappedTask = {
+      task,
+      block_ids: [blockId],
+      priority: isAsap ? 'high' : 'medium',
     }
-
-    const blockIds = cids
-      .map((cid) => cidToBlockId.get(cid))
-      .filter((id): id is string => Boolean(id))
-    if (!blockIds.length) continue
-
-    const fallbackTaskText = cids
-      .map((cid) => cidToText.get(cid))
-      .filter((value): value is string => Boolean(value))
-      .join(' + ')
-
-    const taskText = String(task?.task || '').trim() || fallbackTaskText
-    if (!taskText) continue
-
-    const priority = ['high', 'medium', 'low'].includes(task?.priority)
-      ? task.priority
-      : 'medium'
-
-    mapped.push({ task: taskText, block_ids: blockIds, priority })
+    if (isAsap) asap.push(entry)
+    else fyi.push(entry)
   }
 
-  return { tasks: mapped, dropped }
-}
+  // Candidates first — authoritative. Order follows tracker order.
+  for (const candidate of candidates) {
+    const blockId = cidToBlockId.get(candidate.cid)
+    if (!blockId) continue
 
-// Honor the AI's ASAP/FYI placement. The AI is the final judge now, so we keep
-// whichever bucket it chose, resolve cids to block ids for cross-off linking,
-// and silently drop cids the AI invented or that don't exist.
-export const mapTasksByBucket = (
-  parsed: ParsedTaskBuckets,
-  cidToBlockId: Map<string, string>,
-  cidToText: Map<string, string>,
-): { asap: MappedTask[]; fyi: MappedTask[]; droppedUnknownCids: number } => {
-  const asapResult = mapBucket(parsed.asap, cidToBlockId, cidToText)
-  const fyiResult = mapBucket(parsed.fyi, cidToBlockId, cidToText)
+    const resolution = parsed.resolutions.get(candidate.cid)
+    const finalDate = resolveFinalDate(candidate, resolution?.iso_date ?? null, today)
+    const bucket = bucketForDate(finalDate, todayDate)
+    if (bucket !== 'overdue' && bucket !== 'today' && bucket !== 'soon') continue
 
-  return {
-    asap: asapResult.tasks,
-    fyi: fyiResult.tasks,
-    droppedUnknownCids: asapResult.dropped + fyiResult.dropped,
+    const task = (resolution?.task?.trim() || cidToText.get(candidate.cid) || '').trim()
+    if (!task) continue
+
+    place(bucket, task, blockId)
   }
+
+  // Flagged extras — additive only. Never override a candidate cid.
+  for (const entry of parsed.flagged) {
+    const { cid } = entry
+    if (!highlightedCids.has(cid)) continue
+    if (candidateCids.has(cid)) continue
+
+    const blockId = cidToBlockId.get(cid)
+    if (!blockId) continue
+
+    const flaggedDate = resolveFlaggedDate(entry.iso_date, today)
+    if (!flaggedDate) continue
+
+    const bucket = bucketForDate(flaggedDate, todayDate)
+    if (bucket !== 'overdue' && bucket !== 'today' && bucket !== 'soon') continue
+
+    const task = (entry.task?.trim() || cidToText.get(cid) || '').trim()
+    if (!task) continue
+
+    place(bucket, task, blockId)
+    feedback.push(`Added from a highlighted date the parser couldn't read: "${task}"`)
+  }
+
+  return { asap, fyi, feedback }
 }

--- a/supabase/functions/generate-daily/index.ts
+++ b/supabase/functions/generate-daily/index.ts
@@ -148,8 +148,9 @@ resolutions — one entry per CANDIDATE cid:
   written digits, or plain language like "two years out" / "next spring"). Otherwise use null.
   Only the YEAR you provide is used; the parser keeps the month/day. Do not guess a year that
   isn't stated — use null.
-- "task": a self-contained one-liner using the section heading and parent/sibling bullets
-  (e.g. "Wedding: Book photographer"). Keep it concise and actionable.
+- "task": phrase it like an entry on a daily agenda — brief and glanceable, with the section
+  carried in so it stands on its own (e.g. "Wedding: Book photographer"). Use the section
+  heading and parent/sibling bullets for that context. Keep it actionable, not a full sentence.
 
 flagged — ONLY highlighted lines that clearly encode a due date the parser missed (e.g. a
 mistyped date like 4//15, 4/l5, 41/5) and are NOT already in CANDIDATES:

--- a/supabase/functions/generate-daily/index.ts
+++ b/supabase/functions/generate-daily/index.ts
@@ -2,9 +2,9 @@ import "jsr:@supabase/functions-js/edge-runtime.d.ts"
 import { createClient } from 'jsr:@supabase/supabase-js@2'
 
 import {
+  buildDaily,
   buildTrackerContext,
-  mapTasksByBucket,
-  parseTaskBuckets,
+  parseDateResolutions,
 } from './dailyHelpers.ts'
 
 const ALLOWED_ORIGIN = Deno.env.get('ALLOWED_ORIGIN') || '*'
@@ -114,7 +114,8 @@ Deno.serve(async (req) => {
       return jsonResponse({ error: `No API key configured for ${provider}` }, 500)
     }
 
-    const { markdown, cidToBlockId, cidToText, dateHints } = buildTrackerContext(trackerPages, today)
+    const { markdown, cidToBlockId, cidToText, candidates, highlightedCids } =
+      buildTrackerContext(trackerPages, today)
 
     // Only bail out when there is genuinely nothing to reason about. Everything
     // else — including "nothing is due" — is the model's call now.
@@ -127,51 +128,40 @@ Deno.serve(async (req) => {
       })
     }
 
-    const systemPrompt = `You are a daily planner assistant. Today is ${today} (${dayOfWeek}).
+    const systemPrompt = `You are a structured-data extractor for a daily planner. Today is ${today} (${dayOfWeek}).
 
-You are given the user's ENTIRE tracker as lightweight markdown. Every line that can be
-linked has a stable anchor like ⟦c12⟧ at the end. Highlighted text is written as [like this];
-the user highlights due dates in the tracker. You also get DATE_HINTS: a deterministic first
-pass over highlighted dates ("cid | raw date | parsed ISO date | bucket"). The hints are
-ADVISORY ONLY — you make the final decision about what belongs on today's list.
+A deterministic parser already decides WHICH items make today's list, from highlighted MM/DD
+dates in the tracker. You do NOT decide what belongs on the list. You have exactly three narrow
+jobs, all strictly additive: (1) resolve a due date's YEAR when it is stated in plain language,
+(2) phrase each candidate as a clean one-liner from its section/parent context, and (3) flag a
+highlighted line that clearly encodes a due date the parser MISSED (e.g. a typo).
 
-Decide which items belong on today's daily list:
-- ASAP: due today, or overdue — a real deadline whose date is already past and isn't done
-  yet. Overdue items are the highest priority; always surface them.
-- FYI: due within about the next 2 days, or a genuine heads-up worth surfacing today.
+You are given the user's ENTIRE tracker as lightweight markdown. Every linkable line ends with a
+stable anchor like ⟦c12⟧. Highlighted text is written as [like this]. You also get CANDIDATES:
+the lines the parser already matched ("cid | raw MM/DD | line text").
 
-Judgment principles (follow these carefully):
-- Catch overdue deadlines. If a DATE_HINT bucket is "overdue" (or a clear deadline's date is
-  before today) and the item isn't crossed off or checked, it is late — put it in ASAP. A
-  past date being old does NOT by itself make it context; only treat a past date as context
-  when the sentence frames it as a log/journal note rather than a deadline.
-- Only include items with a real, explicit due date. Leave undated items off entirely — do
-  NOT add tasks just to fill the list.
-- An EMPTY daily is a valid, good outcome. If nothing is genuinely due, return empty arrays.
-  Never pad the list; a tracker full of undated content must not spill in.
-- Distinguish a DUE date from a date used as CONTEXT. Journal/log-style dates (e.g. a date
-  tagged at the front of an update noting WHEN it was written) are NOT due dates. Judge how
-  the date is framed in the sentence.
-- Respect the intended year. Skip items clearly meant for a future year even if a bare date
-  matches today (e.g. "(of 2028)"). Trust DATE_HINTS' parsed ISO date and bucket: use it
-  both to skip future-year items and to catch overdue ones.
-- Handle plain-language or slightly typo'd dates ("June 2nd", "Jun 2") using judgment, even if
-  they are not highlighted and not in DATE_HINTS.
-- Ignore background, recurring, notes, and status lines.
-- Make each task self-contained using its section/parent context (e.g. "Wedding: Book
-  photographer"). For FYI items, include the due date inline when the source has one, in its
-  original format.
-- Keep task text concise and actionable.
-- Reference lines ONLY by the ⟦cid⟧ anchors that actually appear in the tracker. Never invent
-  anchors. Put the cids (without the ⟦⟧ brackets) in the "cids" array.
+Output ONLY this JSON object, no other text:
+{"resolutions":[{"cid":"c1","iso_date":"2027-04-15"|null,"task":"short one-liner"}],"flagged":[{"cid":"c9","iso_date":"2026-03-15","task":"short one-liner"}]}
 
-Respond with ONLY a JSON object, no other text. Use this exact shape:
-{"asap":[{"task":"short task description","cids":["c1","c2"],"priority":"high"|"medium"|"low"}],"fyi":[{"task":"short task description","cids":["c1"],"priority":"high"|"medium"|"low"}]}
+resolutions — one entry per CANDIDATE cid:
+- "iso_date": set a full ISO date ONLY when the line states the year in some form (slash digits,
+  written digits, or plain language like "two years out" / "next spring"). Otherwise use null.
+  Only the YEAR you provide is used; the parser keeps the month/day. Do not guess a year that
+  isn't stated — use null.
+- "task": a self-contained one-liner using the section heading and parent/sibling bullets
+  (e.g. "Wedding: Book photographer"). Keep it concise and actionable.
 
-If a bucket is empty, return an empty array.`
+flagged — ONLY highlighted lines that clearly encode a due date the parser missed (e.g. a
+mistyped date like 4//15, 4/l5, 41/5) and are NOT already in CANDIDATES:
+- Reference the line by its ⟦cid⟧ anchor (cid without brackets).
+- Give your best-guess "iso_date" (full ISO date) and a "task" one-liner.
+- NEVER flag a non-highlighted line. NEVER duplicate a candidate. If nothing qualifies, return [].
 
-    const hintLines = dateHints.map(
-      (hint) => `${hint.cid} | "${hint.dateText}" | parsed ${hint.parsedIso} | ${hint.bucket}`,
+Respond with ONLY the JSON object.`
+
+    const candidateLines = candidates.map(
+      (candidate) =>
+        `${candidate.cid} | "${candidate.dateText}" | ${cidToText.get(candidate.cid) ?? ''}`,
     )
 
     const userMessage = [
@@ -181,8 +171,8 @@ If a bucket is empty, return an empty array.`
       'TRACKER_MARKDOWN:',
       markdown,
       '',
-      'DATE_HINTS:',
-      hintLines.length ? hintLines.join('\n') : '(none)',
+      'CANDIDATES:',
+      candidateLines.length ? candidateLines.join('\n') : '(none)',
     ].join('\n')
 
     let fetchUrl = providerConfig.url
@@ -201,22 +191,31 @@ If a bucket is empty, return an empty array.`
     }
 
     const rawText = providerConfig.extractResponse(data)
-    const parsed = parseTaskBuckets(rawText)
+    const parsed = parseDateResolutions(rawText)
 
-    // The model is the final judge of placement now. We honor its ASAP/FYI
-    // buckets, resolve cids to block ids for cross-off linking, and silently
-    // drop any cids it invented or that don't exist in the tracker.
-    const routed = mapTasksByBucket(parsed, cidToBlockId, cidToText)
-    const asap = routed.asap
-    const fyi = routed.fyi
+    // The deterministic candidates decide the list; the AI only resolves a
+    // plain-language year, phrases each task, and can additively flag a
+    // highlighted date the parser couldn't read. The list stands even if the AI
+    // call or parse fails.
+    const { asap, fyi, feedback } = buildDaily(
+      candidates,
+      parsed,
+      cidToBlockId,
+      cidToText,
+      highlightedCids,
+      today,
+    )
 
-    // Only warn when the model failed to produce the expected ASAP/FYI shape at
-    // all — that genuinely means results may be incomplete. Dropped/re-routed
-    // cids are handled deterministically and need no user-facing warning.
-    const warning =
-      parsed.format === 'asap_fyi'
-        ? null
-        : 'FYI: AI response did not follow the ASAP/FYI format. Results may be incomplete.'
+    // Surface any additively-flagged items (informational), plus a note when the
+    // AI response wasn't the expected JSON object (so phrasing/year-resolution
+    // may be missing, though the deterministic list is intact).
+    const warningParts: string[] = [...feedback]
+    if (parsed.format !== 'resolved') {
+      warningParts.push(
+        'FYI: AI response did not follow the expected format. Task phrasing may be incomplete.',
+      )
+    }
+    const warning = warningParts.length ? warningParts.join('\n') : null
 
     return jsonResponse({
       asap,


### PR DESCRIPTION
## Summary

The **AI daily** feature turns the tracker into today's ASAP/FYI list. PR #196 made the **AI the final judge** of what makes the list, to fix one bug: a due date whose year is written in prose *outside* the cyan highlight (`4/15 (of 2027)`) parsed as the current year and wrongly landed in ASAP.

That flip over-corrected. The system prompt became a large judgment essay ("an EMPTY daily is valid", "never pad", "journal dates are context"), and the model started treating real, highlighted, past-due dates as "stale context" and **dropping them**. #197 bolted an overdue rule on top but it fought four strong drop-signals. Net: the daily started *missing* date-tagged items — the opposite failure.

Key realization: the original reason for AI judgment was **already fixed deterministically in the same PR**. `buildDateHints` computed a `defaultYear` from a written-year regex scanning the whole line, and a slash-year could override it — so the parser already handled `4/15 (of 2027)` correctly. The only thing it genuinely can't read is a year in **arbitrary plain language** ("two years out", "next spring").

This PR puts the deterministic parser back in charge of *what makes the list* (reliable, never silently drops) and demotes the AI to three narrow, **strictly additive** jobs:
1. resolve a year stated in plain language (year only; month/day stay deterministic and are re-validated on recombination),
2. phrase each task as a clean one-liner from its section/parent context,
3. **flag a highlighted date the regex couldn't parse** (typo) so it isn't silently lost.

Inclusion stays 100% deterministic; the AI can add/annotate but can never remove, move, or re-bucket a deterministic result.

## Changes

**`dailyHelpers.ts`**
- `extractDateTokens` now carries `month`, `day`, `hasSlashYear`.
- `buildDateHints` → **`buildCandidates`** (`DateCandidate[]`) + **`buildHighlightedCids`** (server-side gate for flagging).
- Add **`resolveFinalDate`** (precedence: explicit/digit year > validated AI year recombined with deterministic month/day > current-year default) and **`resolveFlaggedDate`**.
- `parseTaskBuckets` → **`parseDateResolutions`** (tolerant parse of `{ resolutions, flagged }`).
- `mapTasksByBucket` → **`buildDaily`**: candidates authoritative & deterministically bucketed; flagged extras merged additively (highlighted-only, non-candidate, valid date), collected into `feedback`.
- `TrackerContext` now returns `candidates` + `highlightedCids`.

**`index.ts`**
- Shrunk the judgment-essay system prompt to a small structured-extraction spec.
- Sends `CANDIDATES:` instead of `DATE_HINTS:`.
- `warning` summarizes any flagged-and-added items (+ malformed-response note).
- Deterministic list stands even if the AI call/parse fails.

**Contract unchanged** — `{ asap, fyi, rawText, warning }`. Frontend reads only `task.task`, `task.block_ids`, `data.warning`, so **no frontend changes**.

## Test plan
- [x] `npm run test:unit` green (448 passed) — `generate-daily` suite reworked to the new contract (candidates decide the list, AI year override, flagged additive gating, tolerant parse).
- [ ] Deploy: `npx supabase functions deploy generate-daily --project-ref ogzpgnxmcifaqliuxxzu`
- [ ] Manual (in the live app) — regenerate the daily and confirm:
  - a clearly **overdue** highlighted date shows in **ASAP** (the missing-things fix);
  - `4/15 (of 2027)` (digit prose) stays **out**;
  - a plain-language year ("two years out" / "next spring") resolves and buckets correctly;
  - a bare `4/15` with no year behaves as current-year;
  - a **mistyped highlighted date** (e.g. `4/l5`) still surfaces, with a `warning` note flagging it;
  - sub-bullets render as clean one-liners with parent/section context;
  - cross-off links `[1]`/`[2]` still resolve to the right blocks.