### PR TITLE
fix: hold restored scroll offset through remount reflow via settle loop

### DIFF
--- a/src/hooks/useScrollRestoration.js
+++ b/src/hooks/useScrollRestoration.js
@@ -12,6 +12,14 @@ const PERSIST_DEBOUNCE_MS = 350
 // after this long and stop waiting.
 const RESTORE_TIMEOUT_MS = 1500
 const TOUCH_RESTORE_TIMEOUT_MS = 3000
+// The restored offset must hold (surface height stable, offset within ~2px) for
+// this long before we declare success. This is what lets us survive the
+// remount reflow: the post-restore clamp shrinks the surface — itself a resize
+// the observer sees — which clears the pending settle so we re-apply and wait
+// again, instead of finishing on the first (transient) success.
+const RESTORE_SETTLE_MS = 250
+// How close the surface offset must be to the saved offset to count as reached.
+const RESTORE_REACHED_TOLERANCE_PX = 2
 
 /**
  * Per-page scroll restoration for the editor surface.
@@ -244,6 +252,7 @@ export function useScrollRestoration({
     let cancelled = false
     let observer = null
     let timer = null
+    let settleTimer = null
     let raf = null
     const restoreTimeoutMs = isTouchOnly ? TOUCH_RESTORE_TIMEOUT_MS : RESTORE_TIMEOUT_MS
 
@@ -256,6 +265,10 @@ export function useScrollRestoration({
       if (timer) {
         clearTimeout(timer)
         timer = null
+      }
+      if (settleTimer) {
+        clearTimeout(settleTimer)
+        settleTimer = null
       }
       if (raf) {
         cancelAnimationFrame(raf)
@@ -280,16 +293,45 @@ export function useScrollRestoration({
       return max >= savedScrollTop || settle
     }
 
+    // "Reached" means the surface is tall enough for the saved offset AND the
+    // offset is actually sitting where we want it (within tolerance). A browser
+    // clamp after a remount reflow fails the height check, so it reads as
+    // not-reached and keeps the settle loop waiting.
+    const isReached = () => {
+      if (mobileOwnsScroll()) return false
+      const surface = getEditorScrollSurface(containerRef.current)
+      const max = getMaxScrollableOffset(surface)
+      if (max < savedScrollTop) return false
+      return Math.abs(surface.get() - savedScrollTop) <= RESTORE_REACHED_TOLERANCE_PX
+    }
+
     if (typeof ResizeObserver !== 'undefined') {
       // Late-loading content (images/tables) can grow the surface tall enough for
       // the saved offset only after the first paint. A ResizeObserver reacts to
       // that growth directly — the principled waiter — and also fires once on
       // observe, so an already-tall page applies immediately. No polling loop is
-      // needed; a single timeout is the only safety net. (The earlier 80ms
+      // needed; a single timeout is the only outer safety net. (The earlier 80ms
       // retry-poll was symptom-chasing for the now-fixed remount crash + surface
       // bugs and has been removed.)
+      //
+      // Rather than finish on the first successful apply, we re-apply and then
+      // require the offset to HOLD for RESTORE_SETTLE_MS. The post-restore
+      // clamp (from the key={sessionKey} editor remount laying out shorter) is a
+      // resize the observer sees: it re-applies the now-clamped value, isReached
+      // fails, we clear the pending settle timer, and we keep waiting until the
+      // surface re-grows and the offset holds. This is the second half of the
+      // fix — restoringRef stays true across the whole window, so the save path
+      // (captureCurrentState) can't persist the transient clamp over the real
+      // offset.
       observer = new ResizeObserver(() => {
-        if (tryApply()) finish()
+        if (cancelled) return
+        tryApply()
+        if (isReached()) {
+          if (!settleTimer) settleTimer = setTimeout(finish, RESTORE_SETTLE_MS)
+        } else if (settleTimer) {
+          clearTimeout(settleTimer)
+          settleTimer = null
+        }
       })
       const observeTarget = containerRef.current?.firstElementChild ?? containerRef.current
       if (observeTarget) observer.observe(observeTarget)
@@ -300,7 +342,7 @@ export function useScrollRestoration({
       if (isTouchOnly && editorDom) observer.observe(editorDom)
       if (typeof document !== 'undefined' && document.body) observer.observe(document.body)
       timer = setTimeout(() => {
-        // Safety net: apply our best effort (clamped) and stop waiting.
+        // Outer safety net: apply our best effort (clamped) and stop waiting.
         if (!cancelled && !mobileOwnsScroll()) {
           tryApply({ settle: true })
         }


### PR DESCRIPTION
## Problem

On the deployed app (desktop Chrome), scrolling a page, switching to another page, and switching back landed you at/near the **top** instead of your saved position — and the real saved offset was **permanently lost**. Did not reproduce on the dev server or a fresh profile, which sent us chasing wrong "fast machine"/"profile" theories.

A read-only stack-trace probe on the live site captured the exact sequence. It is **not** a save bug:

1. Scroll page A to offset `1224` → saved correctly.
2. Switch away and back → saved `1224` read back correctly.
3. `useScrollRestoration` restores it: `tryApply()` sees the (momentarily tall) container, sets `scrollTop = 1224`, and `finish()` **disconnects the ResizeObserver** — restoration considers itself done.
4. One frame later the `key={sessionKey}` editor remount re-lays-out shorter; the browser **clamps** `scrollTop` down to ~137. The observer already finished, so nothing re-applies.
5. That clamp counts as a scroll, so the save path persists `137` over the real `1224`. Position destroyed.

**Why only production:** the app runs in React StrictMode and the deployed bundle is minified — effects run once, on a tighter schedule than dev, so the restore-then-reflow ordering lands in the failure window.

## Fix (one file)

`src/hooks/useScrollRestoration.js` — replace the single-shot "finish on first successful apply" with a **bounded settle loop**:

- Add `RESTORE_SETTLE_MS = 250` — the offset must hold (surface tall enough + within ~2px) this long before declaring success. Existing `RESTORE_TIMEOUT_MS` (1500) / `TOUCH_RESTORE_TIMEOUT_MS` (3000) stay as the outer safety bound.
- **Keep** the ResizeObserver architecture from #195. Change only what happens on a successful apply: the observer callback re-applies via `tryApply()`, then evaluates `isReached()`. When reached, start a settle timer; when a later resize is **not** reached (the reflow/clamp shrinks the surface → observer fires → `tryApply` re-applies the clamped value), clear the pending settle timer and keep waiting. `finish()` runs only after the offset holds with no disruptive resize for 250ms. A browser clamp only happens when `scrollHeight` shrinks — itself a resize the observer sees — so the clamp cannot slip past the gate.
- `restoringRef.current` stays `true` from restore start until `finish()`, blocking `captureCurrentState` from persisting the transient clamp — the second half of the bug.
- All existing guards/branches preserved: `skip`, `savedScrollTop == null` → top, `savedScrollTop <= 0` → caret restore + immediate finish, `mobileOwnsScroll()` deferral, touch-vs-desktop timeout split. No prop/return contract change; `EditorPanel.jsx` call site unchanged.

### Not reverting #195
Checked git + PR #195: its removed 80ms poll **still finished on first successful apply** — it only retried to *reach* success, never verified the offset *held*, so it wouldn't have fixed this. We keep their ResizeObserver and add a **hold/settle** concept the code never had. Different failure mode, additive fix.

## Tests

- `npm run test:unit` — **448/448 green** locally.
- Existing scroll spec `scroll-cursor-restoration` runs as the CI gate (covers long-text, tall-table, image pages on desktop + mobile).
- No new E2E: the timing race is not deterministic in CI, so a new spec would give false confidence. Verification is manual post-deploy.

## Verification (manual, post-deploy)
Deploy to Vercel, scroll a page, switch away and back on everyday Chrome — position should hold. Optional: re-run the `tmp/scroll-debug-console.js` probe and confirm the stored offset is not downgraded after restore.