### PR TITLE
[codex] Fix deep-link scroll restoration

### DIFF
--- a/e2e/internal-link-navigation.spec.js
+++ b/e2e/internal-link-navigation.spec.js
@@ -13,6 +13,18 @@ import {
 // Block ID that will be used as the deep-link target in Page B
 const TARGET_BLOCK_ID = 'e2e-target-block-nav'
 
+const fillerParagraphs = (prefix, count) =>
+  Array.from({ length: count }, (_, index) => ({
+    type: 'paragraph',
+    attrs: { id: `${prefix}-${index + 1}` },
+    content: [
+      {
+        type: 'text',
+        text: `${prefix} filler paragraph ${index + 1}: enough text to make the target page scroll naturally.`,
+      },
+    ],
+  }))
+
 test.describe('Internal link navigation', () => {
   let notebookId = null
   let pageA = null // "Test Scratchpad" with internal link
@@ -34,21 +46,13 @@ test.describe('Internal link navigation', () => {
           attrs: { level: 2, id: 'h-nav-top' },
           content: [{ type: 'text', text: 'Running Stuff' }],
         },
-        {
-          type: 'paragraph',
-          attrs: { id: 'p-nav-filler' },
-          content: [{ type: 'text', text: 'Some filler content above the target.' }],
-        },
+        ...fillerParagraphs('p-nav-above', 45),
         {
           type: 'paragraph',
           attrs: { id: TARGET_BLOCK_ID },
           content: [{ type: 'text', text: 'This is the deep link target paragraph.' }],
         },
-        {
-          type: 'paragraph',
-          attrs: { id: 'p-nav-below' },
-          content: [{ type: 'text', text: 'Content below the target block.' }],
-        },
+        ...fillerParagraphs('p-nav-below', 45),
       ],
     })
 
@@ -100,14 +104,33 @@ test.describe('Internal link navigation', () => {
     const blockId = new URL('http://x/' + href.replace('#', '?')).searchParams.get('block')
     expect(blockId).toBeTruthy()
 
-    // 2. Navigate to the target page ("Test Section") via sidebar so content is loaded
+    // 2. Navigate to the target page ("Test Section") via sidebar, scroll away
+    // from the anchor, and let that wrong position save. This keeps the test
+    // honest: passing requires deep-link navigation to beat ordinary scroll
+    // restoration for this page.
     await clickNavigationItem(page, page.locator('.tree-node-page', { hasText: 'Test Section' }).first())
     await expect(page.locator('.ProseMirror')).toContainText('This is the deep link target paragraph.', {
       timeout: 10000,
     })
+    const targetBlock = page.locator(`[id="${blockId}"]`)
+    await expect(targetBlock).toHaveCount(1)
+    await page.evaluate(() => {
+      const panel = document.querySelector('.editor-panel')
+      if (panel) panel.scrollTop = panel.scrollHeight
+      window.scrollTo(0, document.body.scrollHeight)
+    })
+    await page.waitForTimeout(700)
+    await expect(async () => {
+      const visible = await isElementStartInEditorSafeView(targetBlock)
+      expect(visible).toBe(false)
+    }).toPass({ timeout: 5000 })
 
-    // 3. Trigger the deep link by setting the hash
-    await page.evaluate((h) => { window.location.hash = h }, href)
+    // 3. Return to the source page and click the internal link so the app
+    // performs the same hash navigation a user triggers.
+    await clickNavigationItem(page, page.locator('.tree-node-page', { hasText: 'Test Scratchpad' }).first())
+    await expect(internalLink).toBeVisible({ timeout: 10000 })
+    await internalLink.click()
+    await expect(page.locator('.title-input')).toHaveValue('Test Section', { timeout: 10000 })
 
     // 4. The app highlights the target block via a <style> tag
     const styleLocator = page.locator('#deep-link-target-style')
@@ -117,18 +140,29 @@ test.describe('Internal link navigation', () => {
     }).toPass({ timeout: 10000 })
 
     // 5. Target block element should be in the viewport (scrolled to)
-    const targetBlock = page.locator(`[id="${blockId}"]`)
     await expect(targetBlock).toBeVisible({ timeout: 5000 })
     await expect(async () => {
       const visible = await isElementStartInEditorSafeView(targetBlock)
       expect(visible).toBe(true)
     }).toPass({ timeout: 5000 })
 
-    // 6. Click a different paragraph in the editor to dismiss the highlight
+    // 6. After the deep-link jump, ordinary page switching should remember the
+    // anchor landing as this page's latest scroll position.
+    await page.waitForTimeout(700)
+    await clickNavigationItem(page, page.locator('.tree-node-page', { hasText: 'Test Scratchpad' }).first())
+    await expect(page.locator('.title-input')).toHaveValue('Test Scratchpad', { timeout: 10000 })
+    await clickNavigationItem(page, page.locator('.tree-node-page', { hasText: 'Test Section' }).first())
+    await expect(page.locator('.title-input')).toHaveValue('Test Section', { timeout: 10000 })
+    await expect(async () => {
+      const visible = await isElementStartInEditorSafeView(targetBlock)
+      expect(visible).toBe(true)
+    }).toPass({ timeout: 5000 })
+
+    // 7. Click a different paragraph in the editor to dismiss the highlight
     const otherParagraph = page.locator(`.ProseMirror p:not([id="${blockId}"])`).first()
     await otherParagraph.click()
 
-    // 7. Highlight style should be cleared
+    // 8. Highlight style should be cleared
     await expect(async () => {
       const content = await styleLocator.textContent()
       expect(content?.trim() || '').toBe('')

--- a/src/hooks/useNavigation.js
+++ b/src/hooks/useNavigation.js
@@ -16,6 +16,13 @@ import {
 } from '../utils/navigationTarget'
 import { SECTION_PAGE_STATUS, getSectionPageEntry } from '../utils/sectionPages'
 
+const sameNavigationTarget = (a, b) =>
+  Boolean(a && b) &&
+  a.notebookId === b.notebookId &&
+  a.sectionId === b.sectionId &&
+  a.pageId === b.pageId &&
+  a.blockId === b.blockId
+
 export const useNavigation = ({
   session,
   notebooks,
@@ -41,12 +48,31 @@ export const useNavigation = ({
   const hashBlockRef = useRef(null)
   const navigateToHashRef = useRef(null)
   const navVersionRef = useRef(0)
+  const clearDeepLinkTargetTimerRef = useRef(null)
   const [initialNavReady, setInitialNavReady] = useState(false)
   const [pendingTarget, setPendingTarget] = useState(null)
 
   const clearPendingTarget = useCallback(() => {
+    if (clearDeepLinkTargetTimerRef.current) {
+      clearTimeout(clearDeepLinkTargetTimerRef.current)
+      clearDeepLinkTargetTimerRef.current = null
+    }
     setPendingTarget(null)
     setPendingNav(null)
+  }, [setPendingNav])
+
+  const clearPendingTargetAfterDeepLinkScroll = useCallback((target) => {
+    if (clearDeepLinkTargetTimerRef.current) {
+      clearTimeout(clearDeepLinkTargetTimerRef.current)
+    }
+    clearDeepLinkTargetTimerRef.current = setTimeout(() => {
+      clearDeepLinkTargetTimerRef.current = null
+      setPendingTarget((current) => {
+        if (!sameNavigationTarget(current, target)) return current
+        setPendingNav(null)
+        return null
+      })
+    }, 500)
   }, [setPendingNav])
 
   const setPendingTargetSafely = useCallback(
@@ -190,6 +216,13 @@ export const useNavigation = ({
     navigateToHashRef.current = navigateToHash
   }, [navigateToHash])
 
+  useEffect(() => () => {
+    if (clearDeepLinkTargetTimerRef.current) {
+      clearTimeout(clearDeepLinkTargetTimerRef.current)
+      clearDeepLinkTargetTimerRef.current = null
+    }
+  }, [])
+
   useEffect(() => {
     if (!session) {
       // eslint-disable-next-line react-hooks/set-state-in-effect -- reset nav state when the session prop transitions to null
@@ -283,7 +316,7 @@ export const useNavigation = ({
 
     requestAnimationFrame(() => {
       const found = scrollToBlock(pendingTarget.blockId)
-      if (found) clearPendingTarget()
+      if (found) clearPendingTargetAfterDeepLinkScroll(pendingTarget)
     })
   }, [
     session,
@@ -301,6 +334,7 @@ export const useNavigation = ({
     setActiveTrackerId,
     flushSaveForTracker,
     clearPendingTarget,
+    clearPendingTargetAfterDeepLinkScroll,
     pickNavFallback,
     queueResolvedTarget,
     setMessage,

--- a/src/hooks/useScrollRestoration.js
+++ b/src/hooks/useScrollRestoration.js
@@ -69,6 +69,7 @@ export function useScrollRestoration({
   const pageIdRef = useRef(pageId)
   const editorRef = useRef(editor)
   const zoomRef = useRef(zoomLevel)
+  const previousSkipRef = useRef(skip)
 
   // Mirror the latest props into refs so the long-lived scroll listener and the
   // restore guards read current values without re-subscribing every change.
@@ -136,7 +137,15 @@ export function useScrollRestoration({
         next.scrollTop = surface.get()
       }
       const selection = readEditorSelection()
-      if (selection) next.selection = selection
+      const isDefaultStartSelection = selection?.from === 1 && selection?.to === 1
+      const previousSelection = previous.selection
+      const hasMeaningfulPreviousSelection =
+        typeof previousSelection?.from === 'number' &&
+        typeof previousSelection?.to === 'number' &&
+        (previousSelection.from !== 1 || previousSelection.to !== 1)
+      if (selection && (!isDefaultStartSelection || !hasMeaningfulPreviousSelection)) {
+        next.selection = selection
+      }
       positionsRef.current.delete(id)
       positionsRef.current.set(id, next)
 
@@ -211,7 +220,9 @@ export function useScrollRestoration({
   // Save cursor/selection changes even when the user has not scrolled.
   useEffect(() => {
     if (!editor || !ready || !pageId || skip) return undefined
-    const recordSelection = () => captureCurrentState({ includeScroll: false })
+    const recordSelection = () => {
+      captureCurrentState({ includeScroll: false, force: true })
+    }
     editor.on('selectionUpdate', recordSelection)
     editor.on('transaction', recordSelection)
     return () => {
@@ -221,9 +232,18 @@ export function useScrollRestoration({
     }
   }, [editor, pageId, ready, skip, captureCurrentState, flushPersist])
 
+  // Once a deep-link jump finishes owning scroll, treat the landed offset as
+  // the page's new remembered position for ordinary later navigation.
+  useEffect(() => {
+    const wasSkipping = previousSkipRef.current
+    previousSkipRef.current = skip
+    if (!wasSkipping || skip || !ready || !pageId) return
+    captureCurrentState({ immediate: true, force: true })
+  }, [skip, ready, pageId, captureCurrentState])
+
   // --- Restore on page change ---------------------------------------------
   useEffect(() => {
-    if (!ready || !pageId) return undefined
+    if (!ready || !pageId || !editor) return undefined
     if (skip) {
       return undefined
     }
@@ -307,6 +327,7 @@ export function useScrollRestoration({
         if (reached) {
           if (reachedSince == null) reachedSince = performance.now()
           if (performance.now() - reachedSince >= RESTORE_SETTLE_MS) {
+            restoreEditorSelection(saved.selection)
             finish()
             return
           }
@@ -330,6 +351,7 @@ export function useScrollRestoration({
         const surface = getEditorScrollSurface(containerRef.current)
         const max = getMaxScrollableOffset(surface)
         surface.set(Math.min(savedScrollTop, max))
+        restoreEditorSelection(saved.selection)
       }
       finish()
     }, restoreTimeoutMs)
@@ -338,5 +360,5 @@ export function useScrollRestoration({
       cancelled = true
       finish()
     }
-  }, [pageId, ready, skip, containerRef, isTouchOnly, mobileOwnsScroll, restoreEditorSelection])
+  }, [pageId, ready, skip, editor, containerRef, isTouchOnly, mobileOwnsScroll, restoreEditorSelection])
 }


### PR DESCRIPTION
## Summary

Fixes deep-link navigation fighting with saved scroll restoration.

- Keeps deep-link navigation active briefly after the block scroll starts so ordinary scroll restoration cannot immediately restore an older saved position over the anchor jump.
- Captures the deep-link landing offset when deep-link mode ends, so later ordinary page navigation returns to that landed position.
- Restores saved ProseMirror selection after scroll restoration settles and waits for the current editor instance before applying selection restore.
- Strengthens internal-link E2E coverage with a tall target page, a previously saved wrong scroll position, an off-screen anchor, and a normal navigate-away/back check.

## Root Cause

Deep-link block scrolling and per-page scroll restoration were both valid behaviors, but the pending deep-link target was cleared too early. That allowed `useScrollRestoration` to reapply a previously saved page offset after the deep-link scroll, leaving the highlighted paragraph out of view. Selection restore also ran before the current remounted editor instance was available in one path.

## Validation

- `npx playwright test e2e/internal-link-navigation.spec.js` - passed
- `npx playwright test e2e/scroll-cursor-restoration.spec.js e2e/internal-link-navigation.spec.js` - 14 passed, 1 skipped
- `npm run test:e2e` - 150 passed, 43 skipped