### PR TITLE
feat: prompt-based PWA update banner so new deploys reach the user

### DIFF
--- a/src/components/PwaUpdatePrompt.jsx
+++ b/src/components/PwaUpdatePrompt.jsx
@@ -1,0 +1,124 @@
+import { useEffect, useRef, useState } from 'react'
+import { useRegisterSW } from 'virtual:pwa-register/react'
+import { shouldRunResume } from '../utils/resumeThrottle'
+import { shouldCheckForUpdate } from '../utils/pwaUpdate'
+import '../styles/pwa.css'
+
+// Cadence for asking the browser "is there a newer service worker?".
+const UPDATE_CHECK_INTERVAL_MS = 60 * 60 * 1000 // hourly
+// Returning to the foreground fires visibilitychange + online together; collapse
+// that burst into a single check (same throttle useResumeRefresh uses).
+const RESUME_MIN_INTERVAL_MS = 1500
+
+/**
+ * Surfaces a small, non-modal "New version available" banner when a new build
+ * has been precached and is waiting to activate.
+ *
+ * The reload is user-triggered only: it happens exclusively on the Refresh
+ * click, so whatever the user is typing is never touched until they choose to
+ * refresh. Dismissing collapses the banner to a persistent pill rather than
+ * hiding the update — it's always one click away.
+ */
+export default function PwaUpdatePrompt() {
+  // Local "defer for later" state. `needRefresh` stays true; this only controls
+  // whether we show the full banner or the compact pill.
+  const [collapsed, setCollapsed] = useState(false)
+  const lastResumeAtRef = useRef(null)
+
+  const {
+    needRefresh: [needRefresh],
+    updateServiceWorker,
+  } = useRegisterSW({
+    onRegisteredSW(swUrl, r) {
+      if (!r) return
+
+      // Ask the server for the SW script; if it changed, workbox installs the
+      // new SW into the `waiting` state, which flips `needRefresh` -> true.
+      const check = async () => {
+        const guard = {
+          hasRegistration: true,
+          installing: !!r.installing,
+          onLine: !('connection' in navigator) || navigator.onLine,
+        }
+        if (!shouldCheckForUpdate(guard)) return
+        try {
+          const resp = await fetch(swUrl, {
+            cache: 'no-store',
+            headers: { cache: 'no-store', 'cache-control': 'no-cache' },
+          })
+          if (resp?.status === 200) await r.update()
+        } catch {
+          // Network hiccup — the next interval / focus check will retry.
+        }
+      }
+
+      setInterval(check, UPDATE_CHECK_INTERVAL_MS)
+
+      // Also check on refocus / regained network so a tab reopened after days
+      // updates promptly instead of waiting up to an hour.
+      const onResume = () => {
+        const now = Date.now()
+        if (!shouldRunResume(lastResumeAtRef.current, now, RESUME_MIN_INTERVAL_MS)) return
+        lastResumeAtRef.current = now
+        check()
+      }
+      document.addEventListener('visibilitychange', () => {
+        if (document.visibilityState === 'visible') onResume()
+      })
+      window.addEventListener('online', onResume)
+    },
+  })
+
+  // Re-surface a deferred update the next time the tab is refocused: a gentle
+  // reminder, never intrusive mid-edit.
+  useEffect(() => {
+    const handleVisibility = () => {
+      if (document.visibilityState === 'visible' && needRefresh) setCollapsed(false)
+    }
+    document.addEventListener('visibilitychange', handleVisibility)
+    return () => document.removeEventListener('visibilitychange', handleVisibility)
+  }, [needRefresh])
+
+  if (!needRefresh) return null
+
+  const refresh = () => updateServiceWorker(true)
+
+  if (collapsed) {
+    return (
+      <button
+        type="button"
+        className="pwa-update-pill"
+        onClick={refresh}
+        aria-label="Update ready — refresh to load the new version"
+      >
+        Update ready <span aria-hidden="true">⟳</span>
+      </button>
+    )
+  }
+
+  return (
+    <div
+      className="pwa-update-banner"
+      role="status"
+      aria-live="polite"
+      onKeyDown={(e) => {
+        if (e.key === 'Escape') setCollapsed(true)
+      }}
+    >
+      <span className="pwa-update-text">A new version is available.</span>
+      <div className="pwa-update-actions">
+        <button type="button" className="pwa-update-refresh" onClick={refresh}>
+          Refresh
+        </button>
+        <button
+          type="button"
+          className="pwa-update-dismiss"
+          onClick={() => setCollapsed(true)}
+          aria-label="Dismiss for now"
+        >
+          <span aria-hidden="true">×</span>
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -3,11 +3,16 @@ import { createRoot } from 'react-dom/client'
 import './index.css'
 import App from './App.jsx'
 import ErrorBoundary from './components/ErrorBoundary.jsx'
+import PwaUpdatePrompt from './components/PwaUpdatePrompt.jsx'
 
 createRoot(document.getElementById('root')).render(
   <StrictMode>
     <ErrorBoundary>
       <App />
     </ErrorBoundary>
+    {/* Sibling of ErrorBoundary: if a bad deploy crashes App into the
+        fallback, the update banner still shows so the user can Refresh
+        into a fixed build. */}
+    <PwaUpdatePrompt />
   </StrictMode>,
 )

--- a/src/styles/pwa.css
+++ b/src/styles/pwa.css
@@ -1,0 +1,113 @@
+/*
+ * PWA update prompt — a small, non-modal toast in the bottom-right corner.
+ * Warm Industrial / minimal per DESIGN.md: teal accent, stone neutrals, no
+ * decorative noise. Functional elevation only (marks a floating layer).
+ */
+
+.pwa-update-banner,
+.pwa-update-pill {
+  position: fixed;
+  right: var(--space-md);
+  bottom: calc(var(--space-md) + env(safe-area-inset-bottom, 0px));
+  z-index: 80; /* above modals (70) so a bad deploy is always recoverable */
+  font-family: var(--font-body);
+  box-shadow: 0 4px 16px rgba(28, 25, 23, 0.14);
+}
+
+/* Full banner */
+.pwa-update-banner {
+  display: flex;
+  align-items: center;
+  gap: var(--space-md);
+  max-width: min(360px, calc(100vw - 2 * var(--space-md)));
+  padding: var(--space-sm) var(--space-sm) var(--space-sm) var(--space-md);
+  background: var(--surface);
+  border: 1px solid var(--border-strong);
+  border-radius: var(--radius-lg);
+  color: var(--text);
+}
+
+.pwa-update-text {
+  font-size: 0.9375rem;
+  line-height: 1.3;
+}
+
+.pwa-update-actions {
+  display: flex;
+  align-items: center;
+  gap: var(--space-xs);
+  margin-left: auto;
+}
+
+.pwa-update-refresh {
+  padding: var(--space-xs) var(--space-md);
+  background: var(--accent);
+  color: #ffffff;
+  border: none;
+  border-radius: var(--radius-md);
+  font-family: inherit;
+  font-size: 0.875rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background var(--duration-short) var(--ease-out);
+}
+
+.pwa-update-refresh:hover {
+  background: var(--accent-light);
+}
+
+.pwa-update-refresh:active {
+  background: var(--accent-dark);
+}
+
+.pwa-update-dismiss {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  padding: 0;
+  background: transparent;
+  border: none;
+  border-radius: var(--radius-sm);
+  color: var(--text-muted);
+  font-size: 1.25rem;
+  line-height: 1;
+  cursor: pointer;
+  transition:
+    background var(--duration-short) var(--ease-out),
+    color var(--duration-short) var(--ease-out);
+}
+
+.pwa-update-dismiss:hover {
+  background: var(--surface-raised);
+  color: var(--text);
+}
+
+/* Collapsed pill — the deferred "always one click away" reminder */
+.pwa-update-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-xs);
+  padding: var(--space-xs) var(--space-md);
+  background: var(--accent);
+  color: #ffffff;
+  border: none;
+  border-radius: var(--radius-full);
+  font-family: inherit;
+  font-size: 0.8125rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background var(--duration-short) var(--ease-out);
+}
+
+.pwa-update-pill:hover {
+  background: var(--accent-light);
+}
+
+.pwa-update-refresh:focus-visible,
+.pwa-update-dismiss:focus-visible,
+.pwa-update-pill:focus-visible {
+  outline: 2px solid var(--accent-dark);
+  outline-offset: 2px;
+}

--- a/src/utils/__tests__/pwaUpdate.test.js
+++ b/src/utils/__tests__/pwaUpdate.test.js
@@ -1,0 +1,22 @@
+import { describe, it, expect } from 'vitest'
+import { shouldCheckForUpdate } from '../pwaUpdate'
+
+describe('shouldCheckForUpdate', () => {
+  const base = { hasRegistration: true, installing: false, onLine: true }
+
+  it('runs when registered, idle, and online', () => {
+    expect(shouldCheckForUpdate(base)).toBe(true)
+  })
+
+  it('skips when there is no registration yet', () => {
+    expect(shouldCheckForUpdate({ ...base, hasRegistration: false })).toBe(false)
+  })
+
+  it('skips while a new service worker is installing', () => {
+    expect(shouldCheckForUpdate({ ...base, installing: true })).toBe(false)
+  })
+
+  it('skips when the browser is offline', () => {
+    expect(shouldCheckForUpdate({ ...base, onLine: false })).toBe(false)
+  })
+})

--- a/src/utils/pwaUpdate.js
+++ b/src/utils/pwaUpdate.js
@@ -1,0 +1,21 @@
+/**
+ * Decide whether a service-worker update check should run right now.
+ *
+ * Pure on purpose so the guard can be unit-tested without a real
+ * ServiceWorkerRegistration or network — the fetch/`r.update()` wiring lives in
+ * PwaUpdatePrompt.jsx.
+ *
+ * Skips when:
+ *   - there is no registration yet (nothing to update), or
+ *   - a new SW is already installing (a check is effectively in flight), or
+ *   - the browser reports itself offline (the no-store fetch would just fail).
+ *
+ * @param {{ hasRegistration: boolean, installing: boolean, onLine: boolean }} state
+ * @returns {boolean}
+ */
+export function shouldCheckForUpdate({ hasRegistration, installing, onLine }) {
+  if (!hasRegistration) return false
+  if (installing) return false
+  if (!onLine) return false
+  return true
+}

--- a/vite.config.js
+++ b/vite.config.js
@@ -7,9 +7,11 @@ export default defineConfig({
   plugins: [
     react(),
     VitePWA({
-      // New deploys activate immediately instead of stranding the user on a
-      // stale cached version — the #1 service-worker footgun.
-      registerType: 'autoUpdate',
+      // Prompt lifecycle: a new SW waits until the user clicks "Refresh" in the
+      // in-app banner (see PwaUpdatePrompt.jsx), instead of silently activating.
+      // This avoids reloading mid-edit while still guaranteeing new deploys
+      // reach the user (hourly + on-focus update checks drive the prompt).
+      registerType: 'prompt',
       injectRegister: 'auto',
       includeAssets: ['logo.svg', 'apple-touch-icon.png'],
       manifest: {
@@ -39,9 +41,10 @@ export default defineConfig({
         navigateFallback: '/index.html',
         // Never serve a cached app shell for Supabase API calls.
         navigateFallbackDenylist: [/^\/api/, /supabase/],
-        // New SW takes over open clients immediately (pairs with autoUpdate).
-        skipWaiting: true,
-        clientsClaim: true,
+        // Do NOT set skipWaiting/clientsClaim: in the prompt lifecycle the new
+        // SW must stay `waiting` until the user clicks Refresh, at which point
+        // updateServiceWorker(true) sends SKIP_WAITING and reloads. Self-
+        // activating here would defeat the prompt.
         // No runtimeCaching: we deliberately never cache the Supabase origin
         // (auth/REST/realtime/storage) to avoid stale-data and stale-auth bugs.
       },


### PR DESCRIPTION
## Problem

The app is a PWA whose service worker precaches the built JS/HTML. Twice the user was stranded on a **stale cached bundle** — most recently a bundle Vercel had already deleted (404), served entirely from workbox precache. That old bundle predated the scroll-restoration fix, so scroll silently broke again.

`registerType: 'autoUpdate'` only checks for a new SW on a full document navigation or ~every 24h. This is a **hash-routed SPA** the user keeps open for days and navigates by `#pg=…`, so the check almost never fires. "Empty cache and hard reload" only bypasses the SW for one load — the stale SW takes back over afterward.

## Fix

Add the missing half of the SW lifecycle — **periodic + on-focus update checks** — and switch to the vite-pwa **`prompt`** lifecycle so the new SW *waits* and the user applies it via a small banner at a safe moment (chosen over silent auto-reload to avoid dropping the last ~2s of debounced autosave mid-edit).

### Changes
- **`vite.config.js`** — `registerType: 'autoUpdate'` → `'prompt'`; removed `skipWaiting`/`clientsClaim` so the new SW stays `waiting` until Refresh (verified: `sw.js` only calls `self.skipWaiting()` behind the `SKIP_WAITING` message listener; no inline double-registration).
- **`src/components/PwaUpdatePrompt.jsx`** (new) — `useRegisterSW()` from `virtual:pwa-register/react`. Hourly `setInterval` + `visibilitychange`/`online` checks (burst-collapsed via the existing, unit-tested `shouldRunResume`). Non-modal bottom-corner banner: **Refresh** (user-triggered reload only, `updateServiceWorker(true)`) + **×** that collapses to a persistent "Update ready ⟳" pill (update stays one click away); refocus re-expands it. `role="status"`, `aria-live="polite"`, ESC collapses.
- **`src/styles/pwa.css`** (new) — concern-scoped styles per DESIGN.md (teal accent, minimal).
- **`src/main.jsx`** — mount `<PwaUpdatePrompt />` outside `ErrorBoundary` so a crashed deploy is still recoverable via Refresh.
- **`src/utils/pwaUpdate.js`** (new) — extracted pure `shouldCheckForUpdate` guard + Vitest coverage, mirroring the repo's "pure logic out of hooks" pattern.

## Test plan
- [x] `npm run test:unit` — 452 passed (incl. new `pwaUpdate.test.js`)
- [x] `npm run build` — clean; `sw.js` generated with gated skip-waiting only
- [x] `npx eslint src` — clean
- [ ] **Local prod smoke:** `npm run build && npm run preview`; rebuild after a trivial change → new SW appears **waiting** (not auto-activated) and the banner shows; Refresh activates + reloads to the new hash.
- [ ] **Defer flow:** × collapses to the pill, typing continues, pill click refreshes, refocus re-expands.
- [ ] **Real deploy (acceptance):** with the app open on the old version, push a second Vercel deploy → banner appears within the hour or on refocus; Refresh loads the new bundle with no manual cache clearing.
- E2E: no spec depends on `autoUpdate`/SW semantics (grep-verified); suite unaffected.

## Out of scope
Scroll-restoration fix (already shipped); precache config (`globPatterns`, Supabase denylist) left as-is.