### PR TITLE
[codex] Clean up formatting line toggles

### DIFF
--- a/e2e/issue-68-line-strikethrough-toggle.spec.js
+++ b/e2e/issue-68-line-strikethrough-toggle.spec.js
@@ -64,9 +64,39 @@ const SEED_CONTENT = {
   ],
 }
 
+const BOLDED_CONTENT = {
+  type: 'doc',
+  content: [
+    {
+      type: 'paragraph',
+      attrs: { id: 'p-strike-bolded' },
+      content: [
+        { type: 'text', marks: [{ type: 'bold' }], text: 'Already bolded' },
+        { type: 'text', text: ' mobile line' },
+      ],
+    },
+  ],
+}
+
+const PARTIAL_STRIKE_CONTENT = {
+  type: 'doc',
+  content: [
+    {
+      type: 'paragraph',
+      attrs: { id: 'p-partial-strike' },
+      content: [
+        { type: 'text', marks: [{ type: 'strike' }], text: 'Already struck' },
+        { type: 'text', text: ' plain line' },
+      ],
+    },
+  ],
+}
+
 test.describe('Issue #68 strikethrough toggle on entire line', () => {
   let notebookId = null
   let testPage = null
+  let boldedPage = null
+  let partialStrikePage = null
 
   const getStrikeButton = (page) => page.getByTestId('toolbar-strikethrough')
 
@@ -110,6 +140,15 @@ test.describe('Issue #68 strikethrough toggle on entire line', () => {
     notebookId = nb.id
     const sec = await createSection(client, userId, nb.id, 'Issue68 Section')
     testPage = await createPage(client, userId, sec.id, 'Test Section', SEED_CONTENT)
+    boldedPage = await createPage(client, userId, sec.id, 'Bolded Test Section', BOLDED_CONTENT, 1)
+    partialStrikePage = await createPage(
+      client,
+      userId,
+      sec.id,
+      'Partial Strike Test Section',
+      PARTIAL_STRIKE_CONTENT,
+      2,
+    )
   })
 
   test.afterAll(async () => {
@@ -223,6 +262,78 @@ test.describe('Issue #68 strikethrough toggle on entire line', () => {
         const s = el.querySelector('s')
         return s !== null && s.textContent.trim().length > 0
       })
+      expect(hasStrike).toBe(false)
+    }).toPass({ timeout: 3000 })
+  })
+
+  test('cursor in bolded text: S button strikes whole line and preserves bold', async ({ page }) => {
+    await waitForApp(page, `/#pg=${boldedPage.id}`, { expectedText: 'Already bolded' })
+
+    const block = page.locator('.ProseMirror p', { hasText: 'Already bolded' }).first()
+    await expect(block).toBeVisible({ timeout: 5000 })
+    await placeCaretInBlock(page, block)
+
+    await ensureToolbarExpanded(page)
+    await getStrikeButton(page).click()
+
+    await expect(async () => {
+      const result = await block.evaluate((el) => {
+        const bold = el.querySelector('strong')
+        return {
+          strikeText: Array.from(el.querySelectorAll('s'))
+            .map((node) => node.textContent ?? '')
+            .join(''),
+          boldText: bold?.textContent ?? '',
+          selectionText: window.getSelection()?.toString() ?? '',
+          selectionCollapsed: Boolean(window.getSelection()?.isCollapsed),
+        }
+      })
+
+      expect(result.strikeText).toBe('Already bolded mobile line')
+      expect(result.boldText).toBe('Already bolded')
+      expect(result.selectionCollapsed).toBe(true)
+      expect(result.selectionText).toBe('')
+    }).toPass({ timeout: 3000 })
+
+    await ensureToolbarExpanded(page)
+    await getStrikeButton(page).click()
+
+    await expect(async () => {
+      const result = await block.evaluate((el) => ({
+        hasStrike: el.querySelector('s') !== null,
+        boldText: el.querySelector('strong')?.textContent ?? '',
+      }))
+      expect(result.hasStrike).toBe(false)
+      expect(result.boldText).toBe('Already bolded')
+    }).toPass({ timeout: 3000 })
+  })
+
+  test('cursor in partially struck text: S button expands strike to whole line before toggling off', async ({
+    page,
+  }) => {
+    await waitForApp(page, `/#pg=${partialStrikePage.id}`, { expectedText: 'Already struck' })
+
+    const block = page.locator('.ProseMirror p', { hasText: 'Already struck' }).first()
+    await expect(block).toBeVisible({ timeout: 5000 })
+    await placeCaretInBlock(page, block)
+
+    await ensureToolbarExpanded(page)
+    await getStrikeButton(page).click()
+
+    await expect(async () => {
+      const strikeText = await block.evaluate((el) =>
+        Array.from(el.querySelectorAll('s'))
+          .map((node) => node.textContent ?? '')
+          .join(''),
+      )
+      expect(strikeText).toBe('Already struck plain line')
+    }).toPass({ timeout: 3000 })
+
+    await ensureToolbarExpanded(page)
+    await getStrikeButton(page).click()
+
+    await expect(async () => {
+      const hasStrike = await block.evaluate((el) => el.querySelector('s') !== null)
       expect(hasStrike).toBe(false)
     }).toPass({ timeout: 3000 })
   })

--- a/e2e/underline-toggle-cursor.spec.js
+++ b/e2e/underline-toggle-cursor.spec.js
@@ -1,18 +1,20 @@
 /**
- * E2E regression test for word-level cursor formatting on Bold, Italic,
- * Underline, and Text color — the same UX as Highlight
- * (see highlight-toggle-cursor.spec.js).
+ * E2E regression test for line-level cursor formatting on Bold, Italic,
+ * Underline, and Text color.
  *
  * With a COLLAPSED caret inside a word (nothing selected), clicking each of
- * these buttons formats the WHOLE word under the caret via a ProseMirror
+ * these buttons formats the WHOLE paragraph/list line via a ProseMirror
  * transaction, never touching the visible selection. So:
- *   1. The whole word gets the mark (e.g. wrapped in <u>/<strong>/<em>, or the
+ *   1. The whole line gets the mark (e.g. wrapped in <u>/<strong>/<em>, or the
  *      <span style="color: …"> for text color).
  *   2. The selection stays collapsed/empty (no leftover native blue overlay).
  *   3. Clicking the same button again removes the mark.
  *
+ * Highlight is the exception and stays word-level; see
+ * highlight-toggle-cursor.spec.js.
+ *
  * The text-color dropdown picker lives in the collapsed "extra" toolbar group on
- * touch devices, so these run desktop-only (matching the highlight spec).
+ * touch devices, so that color picker test runs desktop-only.
  */
 
 import { test, expect } from './fixtures'
@@ -23,6 +25,7 @@ import {
   createPage,
   deleteNotebookById,
   waitForApp,
+  ensureToolbarExpanded,
 } from './test-helpers'
 
 const TEXT_BLUE_RGB = 'rgb(37, 99, 235)' // picked text color (#2563eb)
@@ -40,12 +43,26 @@ const buildSeedContent = (id) => ({
   ],
 })
 
+const buildPartialBoldContent = () => ({
+  type: 'doc',
+  content: [
+    {
+      type: 'paragraph',
+      attrs: { id: 'p-partial-bold-1' },
+      content: [
+        { type: 'text', marks: [{ type: 'bold' }], text: 'Partial' },
+        { type: 'text', text: ' bold line' },
+      ],
+    },
+  ],
+})
+
 let seedIds = {}
 const seedLabel = `MARK-CURSOR-${Date.now()}`
 
 // Place a COLLAPSED caret in the middle of the seed word — no selection.
-const placeCaretInWord = async (page) => {
-  const line = page.locator('.ProseMirror p', { hasText: SEED_WORD }).first()
+const placeCaretInWord = async (page, word = SEED_WORD) => {
+  const line = page.locator('.ProseMirror p', { hasText: word }).first()
   await expect(line).toBeVisible()
   await line.evaluate((node, word) => {
     const walker = document.createTreeWalker(node, NodeFilter.SHOW_TEXT)
@@ -63,25 +80,31 @@ const placeCaretInWord = async (page) => {
     selection?.removeAllRanges()
     selection?.addRange(range)
     node.closest('.ProseMirror')?.focus()
-  }, SEED_WORD)
+  }, word)
 }
 
-// True when the seed word is fully wrapped by an element matching `selector`.
-const wordHasWrapper = (page, selector) =>
+const markedTextForSelector = (page, selector) =>
   page.evaluate(
     ({ word, sel }) => {
       const els = Array.from(document.querySelectorAll(`.ProseMirror ${sel}`))
-      return els.some((el) => (el.textContent ?? '').includes(word))
+      const match = els.find((el) => (el.textContent ?? '').includes(word))
+      return match?.textContent ?? null
     },
     { word: SEED_WORD, sel: selector },
   )
+
+const joinedMarkedTextForSelector = (page, selector) =>
+  page.evaluate((sel) => {
+    const els = Array.from(document.querySelectorAll(`.ProseMirror ${sel}`))
+    return els.map((el) => el.textContent ?? '').join('')
+  }, selector)
 
 // Read the inline text color of the <span> wrapping the seed word, or null.
 const readWordTextColor = (page) =>
   page.evaluate((word) => {
     const spans = Array.from(document.querySelectorAll('.ProseMirror span[style*="color"]'))
     const match = spans.find((s) => (s.textContent ?? '').includes(word))
-    return match ? getComputedStyle(match).color : null
+    return match ? { color: getComputedStyle(match).color, text: match.textContent ?? '' } : null
   }, SEED_WORD)
 
 // True when the native selection is collapsed with no selected text.
@@ -107,7 +130,10 @@ test.beforeAll(async () => {
   const colorPage = await createPage(
     client, userId, section.id, `${seedLabel} Color Page`, buildSeedContent('p-color-1'), 3,
   )
-  seedIds = { notebook, section, boldPage, italicPage, underlinePage, colorPage }
+  const partialBoldPage = await createPage(
+    client, userId, section.id, `${seedLabel} Partial Bold Page`, buildPartialBoldContent(), 4,
+  )
+  seedIds = { notebook, section, boldPage, italicPage, underlinePage, colorPage, partialBoldPage }
 })
 
 test.afterAll(async () => {
@@ -119,34 +145,34 @@ const seedHash = (pageRow) =>
   `#nb=${seedIds.notebook.id}&sec=${seedIds.section.id}&pg=${pageRow.id}`
 
 // Shared flow for a simple boolean inline mark (bold/italic/underline): the whole
-// word gets wrapped on click, the selection stays collapsed, and a second click
+// line gets wrapped on click, the selection stays collapsed, and a second click
 // removes the wrapper.
 const runInlineMarkToggle = async ({ page, pageRow, buttonName, wrapperSelector }) => {
   await waitForApp(page, seedHash(pageRow), { expectedText: SEED_WORD })
   await page.waitForSelector('.ProseMirror[contenteditable="true"]', { timeout: 10000 })
 
   await placeCaretInWord(page)
+  await ensureToolbarExpanded(page)
   await page.getByRole('button', { name: buttonName, exact: true }).click()
 
   await expect(async () => {
-    expect(await wordHasWrapper(page, wrapperSelector)).toBe(true)
+    expect(await markedTextForSelector(page, wrapperSelector)).toBe(`${SEED_WORD} notes line`)
   }).toPass({ timeout: 5000 })
 
   expect(await selectionIsCollapsed(page)).toBe(true)
 
   await placeCaretInWord(page)
+  await ensureToolbarExpanded(page)
   await page.getByRole('button', { name: buttonName, exact: true }).click()
 
   await expect(async () => {
-    expect(await wordHasWrapper(page, wrapperSelector)).toBe(false)
+    expect(await markedTextForSelector(page, wrapperSelector)).toBe(null)
   }).toPass({ timeout: 5000 })
 }
 
-test('Underline on a collapsed caret marks the whole word without disturbing the selection', async ({
+test('Underline on a collapsed caret marks the whole line without disturbing the selection', async ({
   page,
-  isMobile,
 }) => {
-  test.skip(isMobile, 'Desktop-only: relies on a collapsed-caret word-format flow')
   await runInlineMarkToggle({
     page,
     pageRow: seedIds.underlinePage,
@@ -155,11 +181,9 @@ test('Underline on a collapsed caret marks the whole word without disturbing the
   })
 })
 
-test('Bold on a collapsed caret marks the whole word and toggles off', async ({
+test('Bold on a collapsed caret marks the whole line and toggles off', async ({
   page,
-  isMobile,
 }) => {
-  test.skip(isMobile, 'Desktop-only: relies on a collapsed-caret word-format flow')
   await runInlineMarkToggle({
     page,
     pageRow: seedIds.boldPage,
@@ -168,11 +192,34 @@ test('Bold on a collapsed caret marks the whole word and toggles off', async ({
   })
 })
 
-test('Italic on a collapsed caret marks the whole word and toggles off', async ({
+test('Bold on a partially bolded line expands bold to the whole line before toggling off', async ({
   page,
-  isMobile,
 }) => {
-  test.skip(isMobile, 'Desktop-only: relies on a collapsed-caret word-format flow')
+  await waitForApp(page, seedHash(seedIds.partialBoldPage), { expectedText: 'Partial bold line' })
+  await page.waitForSelector('.ProseMirror[contenteditable="true"]', { timeout: 10000 })
+
+  await placeCaretInWord(page, 'line')
+  await ensureToolbarExpanded(page)
+  await page.getByRole('button', { name: 'Bold', exact: true }).click()
+
+  await expect(async () => {
+    expect(await joinedMarkedTextForSelector(page, 'strong')).toBe('Partial bold line')
+  }).toPass({ timeout: 5000 })
+
+  expect(await selectionIsCollapsed(page)).toBe(true)
+
+  await placeCaretInWord(page, 'line')
+  await ensureToolbarExpanded(page)
+  await page.getByRole('button', { name: 'Bold', exact: true }).click()
+
+  await expect(async () => {
+    expect(await joinedMarkedTextForSelector(page, 'strong')).toBe('')
+  }).toPass({ timeout: 5000 })
+})
+
+test('Italic on a collapsed caret marks the whole line and toggles off', async ({
+  page,
+}) => {
   await runInlineMarkToggle({
     page,
     pageRow: seedIds.italicPage,
@@ -181,7 +228,7 @@ test('Italic on a collapsed caret marks the whole word and toggles off', async (
   })
 })
 
-test('Picking a text color with a collapsed caret colors the whole word and keeps it collapsed', async ({
+test('Picking a text color with a collapsed caret colors the whole line and keeps it collapsed', async ({
   page,
   isMobile,
 }) => {
@@ -191,11 +238,15 @@ test('Picking a text color with a collapsed caret colors the whole word and keep
   await page.waitForSelector('.ProseMirror[contenteditable="true"]', { timeout: 10000 })
 
   await placeCaretInWord(page)
+  await ensureToolbarExpanded(page)
   await page.getByRole('button', { name: 'Text colors' }).click()
   await page.getByRole('button', { name: 'Blue', exact: true }).click()
 
   await expect(async () => {
-    expect(await readWordTextColor(page)).toBe(TEXT_BLUE_RGB)
+    expect(await readWordTextColor(page)).toEqual({
+      color: TEXT_BLUE_RGB,
+      text: `${SEED_WORD} notes line`,
+    })
   }).toPass({ timeout: 5000 })
 
   expect(await selectionIsCollapsed(page)).toBe(true)

--- a/src/components/editor/toolbar/tools/textTools.jsx
+++ b/src/components/editor/toolbar/tools/textTools.jsx
@@ -10,6 +10,8 @@ import { useOutsideClick } from '../useOutsideClick'
 import { cmd } from '../toolHelpers'
 import {
   applyMarkToTarget,
+  applyMarkToBlockTarget,
+  isMarkActiveForBlockToggle,
   isMarkActiveForToggle,
   syncSelectionFromDom,
 } from '../../../../utils/smartMark'
@@ -18,23 +20,23 @@ import { Btn } from './ToolButton'
 
 // --- Inline marks ---------------------------------------------------------
 
-// Bold/Italic/Underline mirror Highlight: a collapsed caret in a word formats the
-// WHOLE word (via applyMarkToTarget). The button's active state reads the same
-// word/selection target so toggling off works at word edges. On a whitespace
-// caret, applyMarkToTarget returns false and we fall back to the standard
+// Bold/Italic/Underline use the user's line-level cursor behavior: a collapsed
+// caret formats the current paragraph/list item. Highlight is the exception and
+// remains word-level below. On an empty block, applyMarkToBlockTarget returns
+// false and we fall back to the standard
 // stored-mark command ("format the next typed characters").
 function toggleInlineMark(editor, markName, fallback) {
   const markType = editor?.schema.marks[markName]
   if (!editor || !markType) return
   syncSelectionFromDom(editor)
-  const remove = isMarkActiveForToggle(editor.state, markType)
-  const acted = applyMarkToTarget(editor, markType, { remove })
-  if (!acted) fallback(cmd(editor)) // whitespace caret: stored-mark fallback
+  const remove = isMarkActiveForBlockToggle(editor.state, markType)
+  const acted = applyMarkToBlockTarget(editor, markType, { remove })
+  if (!acted) fallback(cmd(editor)) // empty block: stored-mark fallback
 }
 
 function isInlineMarkActive(editor, markName) {
   const markType = editor?.schema.marks[markName]
-  return editor && markType ? isMarkActiveForToggle(editor.state, markType) : false
+  return editor && markType ? isMarkActiveForBlockToggle(editor.state, markType) : false
 }
 
 export function BoldTool({ editor }) {
@@ -209,13 +211,13 @@ export function TextColorTool({ editor }) {
   useOutsideClick({ isOpen: open, onClose: () => setOpen(false), refs })
 
   // Text color is the attribute-mark sibling of Highlight: the textStyle mark
-  // carries a `color` attr. Route through the shared word-level core so a caret
-  // in a word recolors the WHOLE word; a whitespace caret falls back to the
-  // standard setColor/unsetColor stored-mark behavior.
+  // carries a `color` attr. It follows the regular formatting tools, so a
+  // collapsed caret colors the current paragraph/list item. An empty block
+  // falls back to the standard setColor/unsetColor stored-mark behavior.
   const setColorSmart = (color) => {
     if (!editor) return
     const markType = editor.schema.marks.textStyle
-    const acted = applyMarkToTarget(editor, markType, {
+    const acted = applyMarkToBlockTarget(editor, markType, {
       attrs: color ? { color } : null,
       remove: !color,
     })

--- a/src/extensions/keyboard/blockSelectionHelper.js
+++ b/src/extensions/keyboard/blockSelectionHelper.js
@@ -1,14 +1,5 @@
 import { TextSelection } from '@tiptap/pm/state'
-
-const findAncestor = ($from, names) => {
-  for (let depth = $from.depth; depth > 0; depth -= 1) {
-    const node = $from.node(depth)
-    if (names.includes(node.type?.name)) {
-      return { node, pos: $from.before(depth) }
-    }
-  }
-  return null
-}
+import { getBlockTextRange } from '../../utils/blockRange'
 
 const selectionCovers = (selection, from, to) => selection.from <= from && selection.to >= to
 
@@ -17,37 +8,6 @@ const selectRange = (state, view, from, to) => {
   view.dispatch(state.tr.setSelection(nextSelection))
   view.focus()
   return true
-}
-
-// Returns { from, to } for the text range of the current block without mutating selection.
-export const getBlockTextRange = (state) => {
-  const { $from } = state.selection
-
-  const list = findAncestor($from, ['listItem', 'taskItem'])
-  if (list) {
-    let paragraphPos = null
-    let paragraphSize = null
-    list.node.content?.forEach((child, offset) => {
-      if (paragraphPos !== null) return
-      if (child.type?.name === 'paragraph') {
-        paragraphPos = list.pos + 1 + offset
-        paragraphSize = child.nodeSize
-      }
-    })
-
-    const blockFrom = paragraphPos !== null ? paragraphPos + 1 : list.pos + 1
-    const blockTo =
-      paragraphPos !== null && paragraphSize
-        ? paragraphPos + paragraphSize - 1
-        : list.pos + list.node.nodeSize - 1
-
-    return { from: blockFrom, to: blockTo }
-  }
-
-  const textBlock = findAncestor($from, ['paragraph', 'heading'])
-  if (!textBlock) return null
-
-  return { from: textBlock.pos + 1, to: textBlock.pos + textBlock.node.nodeSize - 1 }
 }
 
 export const expandSelectionToBlock = (editor) => {

--- a/src/extensions/keyboard/toggleLineStrike.js
+++ b/src/extensions/keyboard/toggleLineStrike.js
@@ -1,6 +1,6 @@
 import { TextSelection } from '@tiptap/pm/state'
-import { getBlockTextRange } from './blockSelectionHelper'
-import { syncSelectionFromDom } from '../../utils/smartMark'
+import { getBlockTextRange } from '../../utils/blockRange'
+import { rangeFullyHasMark, syncSelectionFromDom } from '../../utils/smartMark'
 import { getMountedEditorView } from '../../utils/editorView'
 
 // Toggles strikethrough on the entire current line/block when the cursor has no
@@ -24,7 +24,9 @@ export const toggleLineStrike = (editor) => {
     return
   }
 
-  // Cursor with no selection — expand to entire block text range
+  // Cursor with no selection: toggle the entire block text range without
+  // creating a visible native selection. This keeps mobile formatting stable
+  // when the line already contains other marks like bold.
   const range = getBlockTextRange(state)
   if (!range || range.from >= range.to) {
     // Empty block or couldn't resolve — fall back to default toggle
@@ -32,17 +34,14 @@ export const toggleLineStrike = (editor) => {
     return
   }
 
-  // Select the full block text, toggle strike, then collapse cursor back
-  const sel = TextSelection.create(state.doc, range.from, range.to)
-  view.dispatch(state.tr.setSelection(sel))
+  const markType = state.schema.marks.strike
+  const remove = rangeFullyHasMark(state, range.from, range.to, markType)
+  const tr = state.tr.removeMark(range.from, range.to, markType)
+  if (!remove) tr.addMark(range.from, range.to, markType.create())
+  view.dispatch(tr)
 
-  editor.chain().toggleStrike().run()
-
-  // Restore cursor to original position
   const next = editor.state
-  const maxPos = next.doc.content.size
-  const cursorPos = Math.min(from, maxPos)
-  const restored = TextSelection.create(next.doc, cursorPos)
-  view.dispatch(next.tr.setSelection(restored))
+  const cursorPos = Math.min(from, next.doc.content.size)
+  view.dispatch(next.tr.setSelection(TextSelection.create(next.doc, cursorPos)))
   view.focus()
 }

--- a/src/utils/__tests__/blockRange.test.js
+++ b/src/utils/__tests__/blockRange.test.js
@@ -1,0 +1,70 @@
+import { describe, it, expect } from 'vitest'
+import { Schema } from '@tiptap/pm/model'
+import { EditorState, TextSelection } from '@tiptap/pm/state'
+import { getBlockTextRange } from '../blockRange'
+
+const schema = new Schema({
+  nodes: {
+    doc: { content: 'block+' },
+    paragraph: { group: 'block', content: 'inline*' },
+    heading: { group: 'block', content: 'inline*', attrs: { level: { default: 1 } } },
+    text: { group: 'inline' },
+    bulletList: { group: 'block', content: 'listItem+' },
+    taskList: { group: 'block', content: 'taskItem+' },
+    listItem: { content: 'block+', defining: true },
+    taskItem: {
+      content: 'block+',
+      defining: true,
+      attrs: { checked: { default: false } },
+    },
+  },
+})
+
+const { doc, paragraph, heading, bulletList, taskList, listItem, taskItem } = schema.nodes
+
+const p = (text) => paragraph.create(null, text ? schema.text(text) : null)
+const h = (text) => heading.create({ level: 2 }, text ? schema.text(text) : null)
+const li = (...blocks) => listItem.create(null, blocks)
+const ti = (...blocks) => taskItem.create(null, blocks)
+const ul = (...items) => bulletList.create(null, items)
+const tl = (...items) => taskList.create(null, items)
+
+const stateWithCursorInText = (docNode, text, offset = 0) => {
+  let textPos = null
+  docNode.descendants((node, pos) => {
+    if (textPos !== null) return false
+    if (node.isText && node.text === text) {
+      textPos = pos
+      return false
+    }
+    return true
+  })
+
+  if (textPos === null) throw new Error(`Could not find text "${text}"`)
+  const state = EditorState.create({ doc: docNode, schema })
+  return state.apply(state.tr.setSelection(TextSelection.create(state.doc, textPos + offset)))
+}
+
+describe('getBlockTextRange', () => {
+  it('returns the current paragraph text range', () => {
+    const state = stateWithCursorInText(doc.create(null, [p('plain line')]), 'plain line', 5)
+    expect(getBlockTextRange(state)).toEqual({ from: 1, to: 11 })
+  })
+
+  it('returns the current heading text range', () => {
+    const state = stateWithCursorInText(doc.create(null, [h('heading line')]), 'heading line', 4)
+    expect(getBlockTextRange(state)).toEqual({ from: 1, to: 13 })
+  })
+
+  it('returns the paragraph range inside a list item', () => {
+    const d = doc.create(null, [ul(li(p('list line')))])
+    const state = stateWithCursorInText(d, 'list line', 4)
+    expect(getBlockTextRange(state)).toEqual({ from: 3, to: 12 })
+  })
+
+  it('returns the paragraph range inside a task item', () => {
+    const d = doc.create(null, [tl(ti(p('task line')))])
+    const state = stateWithCursorInText(d, 'task line', 4)
+    expect(getBlockTextRange(state)).toEqual({ from: 3, to: 12 })
+  })
+})

--- a/src/utils/__tests__/highlightState.test.js
+++ b/src/utils/__tests__/highlightState.test.js
@@ -61,6 +61,11 @@ describe('isHighlightActiveForToggle', () => {
     expect(isHighlightActiveForToggle(state, highlight)).toBe(false)
   })
 
+  it('returns false when the word under the caret is only partially highlighted', () => {
+    const state = withCursor(stateWithHighlight(d, 1, 3), 4)
+    expect(isHighlightActiveForToggle(state, highlight)).toBe(false)
+  })
+
   it('returns true for a non-empty selection over highlighted text', () => {
     const state = withSelection(stateWithHighlight(d, 1, 6), 1, 6)
     expect(isHighlightActiveForToggle(state, highlight)).toBe(true)

--- a/src/utils/__tests__/smartMark.test.js
+++ b/src/utils/__tests__/smartMark.test.js
@@ -1,7 +1,7 @@
 import { describe, it, expect } from 'vitest'
 import { Schema } from '@tiptap/pm/model'
 import { EditorState, TextSelection } from '@tiptap/pm/state'
-import { isMarkActiveForToggle } from '../smartMark'
+import { isMarkActiveForBlockToggle, isMarkActiveForToggle, rangeFullyHasMark } from '../smartMark'
 
 // Minimal ProseMirror schema with a plain-text block plus a couple of marks.
 // `underline` stands in for the inclusive Bold/Italic/Underline family; `em`
@@ -80,6 +80,11 @@ describe('isMarkActiveForToggle', () => {
     expect(isMarkActiveForToggle(state, underline)).toBe(false)
   })
 
+  it('returns false when a selected range is only partially marked', () => {
+    const state = withSelection(stateWithMark(d, underline, 1, 6), 1, 12)
+    expect(isMarkActiveForToggle(state, underline)).toBe(false)
+  })
+
   it('reflects stored marks for a caret on whitespace between words', () => {
     // "hi  there": h=1 i=2 (sp)=3 (sp)=4 t=5 ...; caret at pos 4 sits between
     // two spaces (no word). With no stored mark applied -> false.
@@ -102,5 +107,43 @@ describe('isMarkActiveForToggle', () => {
     expect(isMarkActiveForToggle(null, underline)).toBe(false)
     const state = withCursor(stateWithMark(d, underline, 1, 6), 3)
     expect(isMarkActiveForToggle(state, null)).toBe(false)
+  })
+})
+
+describe('isMarkActiveForBlockToggle', () => {
+  const d = doc.create(null, [p('hello world')])
+
+  it('uses the whole text block for a collapsed caret', () => {
+    const state = withCursor(stateWithMark(d, underline, 1, 12), 9)
+    expect(isMarkActiveForBlockToggle(state, underline)).toBe(true)
+  })
+
+  it('does not report active when another word in the same block has a different mark', () => {
+    const state = withCursor(stateWithMark(d, em, 1, 6), 9)
+    expect(isMarkActiveForBlockToggle(state, underline)).toBe(false)
+  })
+
+  it('does not report active when only part of the block has the target mark', () => {
+    const state = withCursor(stateWithMark(d, underline, 1, 6), 9)
+    expect(isMarkActiveForBlockToggle(state, underline)).toBe(false)
+  })
+
+  it('still uses the selected range when text is selected', () => {
+    const state = withSelection(stateWithMark(d, underline, 1, 6), 7, 12)
+    expect(isMarkActiveForBlockToggle(state, underline)).toBe(false)
+  })
+})
+
+describe('rangeFullyHasMark', () => {
+  const d = doc.create(null, [p('hello world')])
+
+  it('returns true only when all text in the range has the mark', () => {
+    const state = stateWithMark(d, underline, 1, 12)
+    expect(rangeFullyHasMark(state, 1, 12, underline)).toBe(true)
+  })
+
+  it('returns false when only part of the text range has the mark', () => {
+    const state = stateWithMark(d, underline, 1, 6)
+    expect(rangeFullyHasMark(state, 1, 12, underline)).toBe(false)
   })
 })

--- a/src/utils/blockRange.js
+++ b/src/utils/blockRange.js
@@ -1,0 +1,42 @@
+const findAncestor = ($from, names) => {
+  for (let depth = $from.depth; depth > 0; depth -= 1) {
+    const node = $from.node(depth)
+    if (names.includes(node.type?.name)) {
+      return { node, pos: $from.before(depth) }
+    }
+  }
+  return null
+}
+
+// Returns { from, to } for the text range of the current paragraph/heading, or
+// the first paragraph inside the current list/task item, without mutating the
+// editor selection.
+export const getBlockTextRange = (state) => {
+  const { $from } = state.selection
+
+  const list = findAncestor($from, ['listItem', 'taskItem'])
+  if (list) {
+    let paragraphPos = null
+    let paragraphSize = null
+    list.node.content?.forEach((child, offset) => {
+      if (paragraphPos !== null) return
+      if (child.type?.name === 'paragraph') {
+        paragraphPos = list.pos + 1 + offset
+        paragraphSize = child.nodeSize
+      }
+    })
+
+    const blockFrom = paragraphPos !== null ? paragraphPos + 1 : list.pos + 1
+    const blockTo =
+      paragraphPos !== null && paragraphSize
+        ? paragraphPos + paragraphSize - 1
+        : list.pos + list.node.nodeSize - 1
+
+    return { from: blockFrom, to: blockTo }
+  }
+
+  const textBlock = findAncestor($from, ['paragraph', 'heading'])
+  if (!textBlock) return null
+
+  return { from: textBlock.pos + 1, to: textBlock.pos + textBlock.node.nodeSize - 1 }
+}

--- a/src/utils/highlightState.js
+++ b/src/utils/highlightState.js
@@ -1,6 +1,6 @@
-// Thin compatibility re-export. The highlight toggle decision was generalized
-// into the mark-agnostic isMarkActiveForToggle in ./smartMark, so Bold, Italic,
-// Underline, Text color, and Highlight share one implementation. Kept as an
-// alias so existing imports (and highlightState.test.js) keep working.
+// Thin compatibility re-export. Highlight still uses the word-level toggle
+// helper in ./smartMark, while the regular inline toolbar tools use the
+// block-level sibling. Kept as an alias so existing imports and tests keep
+// working.
 
 export { isMarkActiveForToggle as isHighlightActiveForToggle } from './smartMark'

--- a/src/utils/smartMark.js
+++ b/src/utils/smartMark.js
@@ -1,12 +1,10 @@
-// Shared, mark-agnostic helpers for "word-level" cursor formatting. These
-// generalize the highlight behavior so Bold, Italic, Underline, Text color, and
-// Highlight all act on the whole word under a collapsed caret WITHOUT moving the
-// caret or showing a native blue selection overlay.
-//
-// The single code path lives here; the toolbar tools and highlightState re-use
-// it so there is one implementation, not a parallel system per mark.
+// Shared, mark-agnostic helpers for collapsed-caret formatting. Highlight uses
+// the word-level target; the regular inline tools use the block-level target.
+// Both paths avoid moving the visible selection, so no native blue overlay
+// flashes over formatted text.
 
 import { TextSelection } from '@tiptap/pm/state'
+import { getBlockTextRange } from './blockRange'
 import { getWordRangeAt } from './wordRange'
 import { getMountedEditorView } from './editorView'
 
@@ -46,8 +44,34 @@ export function syncSelectionFromDom(editor) {
   }
 }
 
+export const rangeFullyHasMark = (state, from, to, markType) => {
+  if (!state || !markType || from >= to) return false
+
+  let sawText = false
+  let fullyMarked = true
+
+  state.doc.nodesBetween(from, to, (node, pos) => {
+    if (!fullyMarked) return false
+    if (!node.isText) return true
+
+    const textFrom = Math.max(from, pos)
+    const textTo = Math.min(to, pos + node.nodeSize)
+    if (textFrom >= textTo) return false
+
+    sawText = true
+    if (!markType.isInSet(node.marks)) {
+      fullyMarked = false
+      return false
+    }
+
+    return false
+  })
+
+  return sawText && fullyMarked
+}
+
 /**
- * True when the mark is present on the toggle target: the word under a collapsed
+ * True when the mark fully covers the toggle target: the word under a collapsed
  * caret, or the current non-empty selection. Mirrors applyMarkToTarget's
  * targeting so the toggle decision matches the action — instead of relying on
  * caret-adjacency marks (isActive), which inclusive:false marks get wrong at
@@ -63,13 +87,36 @@ export const isMarkActiveForToggle = (state, markType) => {
 
   if (selection.empty) {
     const range = getWordRangeAt(state)
-    if (range) return state.doc.rangeHasMark(range.from, range.to, markType)
+    if (range) return rangeFullyHasMark(state, range.from, range.to, markType)
     // Caret on whitespace / empty block: fall back to stored/adjacent marks.
     const marks = state.storedMarks || selection.$from.marks()
     return marks.some((m) => m.type === markType)
   }
 
-  return state.doc.rangeHasMark(selection.from, selection.to, markType)
+  return rangeFullyHasMark(state, selection.from, selection.to, markType)
+}
+
+/**
+ * True when the mark fully covers the block-level toggle target: the current
+ * paragraph/list item under a collapsed caret, or the current non-empty
+ * selection.
+ *
+ * @param {import('@tiptap/pm/state').EditorState} state
+ * @param {import('@tiptap/pm/model').MarkType} markType
+ * @returns {boolean}
+ */
+export const isMarkActiveForBlockToggle = (state, markType) => {
+  if (!state || !markType) return false
+  const { selection } = state
+
+  if (selection.empty) {
+    const range = getBlockTextRange(state)
+    if (range) return rangeFullyHasMark(state, range.from, range.to, markType)
+    const marks = state.storedMarks || selection.$from.marks()
+    return marks.some((m) => m.type === markType)
+  }
+
+  return rangeFullyHasMark(state, selection.from, selection.to, markType)
 }
 
 /**
@@ -95,6 +142,44 @@ export function applyMarkToTarget(editor, markType, { attrs = null, remove = fal
   if (selection.empty) {
     range = getWordRangeAt(editor.state)
     if (!range) return false // whitespace caret: let the caller fall back
+  } else {
+    range = { from: selection.from, to: selection.to }
+  }
+
+  editor
+    .chain()
+    .focus()
+    .command(({ tr, dispatch }) => {
+      if (dispatch) {
+        tr.removeMark(range.from, range.to, markType)
+        if (!remove) tr.addMark(range.from, range.to, markType.create(attrs))
+      }
+      return true
+    })
+    .run()
+
+  return true
+}
+
+/**
+ * Apply (or remove) a mark on the current paragraph/list item when the caret is
+ * collapsed, or on the current selection when text is selected. The caret stays
+ * collapsed; callers do not need to create a temporary text selection.
+ *
+ * @param {import('@tiptap/core').Editor} editor
+ * @param {import('@tiptap/pm/model').MarkType} markType
+ * @param {{ attrs?: object | null, remove?: boolean }} [options]
+ * @returns {boolean} true when a block/selection target was acted on
+ */
+export function applyMarkToBlockTarget(editor, markType, { attrs = null, remove = false } = {}) {
+  if (!editor || !markType) return false
+  syncSelectionFromDom(editor)
+
+  const { selection } = editor.state
+  let range = null
+  if (selection.empty) {
+    range = getBlockTextRange(editor.state)
+    if (!range || range.from >= range.to) return false
   } else {
     range = { from: selection.from, to: selection.to }
   }

--- a/src/utils/wordRange.js
+++ b/src/utils/wordRange.js
@@ -1,6 +1,5 @@
 // Pure ProseMirror-state helper: find the whitespace-delimited word under a
-// collapsed cursor. Mirrors the pure-state pattern in
-// extensions/keyboard/blockSelectionHelper.js (getBlockTextRange) — read the
+// collapsed cursor. Mirrors the pure-state pattern in blockRange.js: read the
 // resolved position, work in the parent's text content, and map back to
 // document positions via $from.start().
 


### PR DESCRIPTION
## Summary
- make collapsed-caret formatting target the current line for regular inline tools
- keep Highlight word-level
- add full-range mark detection and block range tests
- add desktop/mobile E2E coverage for partial bold and partial strikethrough cases

## Validation
- Full E2E suite: 159 passed, 40 skipped
- Unit formatting/range tests passed
- Build passed
- Changed-file ESLint passed