### PR TITLE
fix: formatting keyboard shortcuts should match the toolbar buttons

### DIFF
--- a/e2e/formatting-shortcuts.spec.js
+++ b/e2e/formatting-shortcuts.spec.js
@@ -1,0 +1,223 @@
+import { test, expect } from './fixtures'
+import {
+  getSupabase,
+  createNotebook,
+  createSection,
+  createPage,
+  deleteNotebookById,
+  ensureToolbarExpanded,
+  waitForApp,
+} from './test-helpers'
+
+// One paragraph with a word to highlight plus a trailing word that must stay
+// untouched, so we can prove the shortcut grabs the WHOLE word and nothing more.
+const HIGHLIGHT_CONTENT = {
+  type: 'doc',
+  content: [
+    {
+      type: 'paragraph',
+      attrs: { id: 'p-hl' },
+      content: [{ type: 'text', text: 'highlightme extra' }],
+    },
+  ],
+}
+
+// Three separate lines, one per inline mark, so each toggle is independent.
+const LINE_CONTENT = {
+  type: 'doc',
+  content: [
+    { type: 'paragraph', attrs: { id: 'p-bold' }, content: [{ type: 'text', text: 'bold this whole line' }] },
+    { type: 'paragraph', attrs: { id: 'p-italic' }, content: [{ type: 'text', text: 'italic this whole line' }] },
+    { type: 'paragraph', attrs: { id: 'p-underline' }, content: [{ type: 'text', text: 'underline this whole line' }] },
+  ],
+}
+
+// An empty block (arm-only) plus a word to prove arming after formatting a word.
+const ARM_CONTENT = {
+  type: 'doc',
+  content: [
+    { type: 'paragraph', attrs: { id: 'p-arm-empty' } },
+    { type: 'paragraph', attrs: { id: 'p-arm-word' }, content: [{ type: 'text', text: 'wordone' }] },
+  ],
+}
+
+const PARITY_CONTENT = {
+  type: 'doc',
+  content: [
+    {
+      type: 'paragraph',
+      attrs: { id: 'p-parity' },
+      content: [{ type: 'text', text: 'parityword extra' }],
+    },
+  ],
+}
+
+test.describe('Formatting keyboard shortcuts (match toolbar smart behavior)', () => {
+  let notebookId = null
+  let highlightPage = null
+  let linePage = null
+  let armPage = null
+  let parityPage = null
+
+  // Focus the editor, then place a COLLAPSED caret at a precise character offset
+  // inside a paragraph. Focusing first keeps the editor active so the keyboard
+  // shortcut reaches ProseMirror; setting the DOM selection drives the smart
+  // target (word/line) via syncSelectionFromDom, exactly like a real click+caret.
+  const placeCaretInParagraph = async (page, selector, offset) => {
+    const block = page.locator(`#${selector}`)
+    await expect(block).toBeVisible({ timeout: 5000 })
+    const isTouchOnly = await page.evaluate(() => matchMedia('(pointer: coarse)').matches)
+    if (isTouchOnly) {
+      await page.locator('.ProseMirror').evaluate((node) => node.focus({ preventScroll: true }))
+      await block.tap()
+    } else {
+      await block.click()
+    }
+
+    await page.evaluate(
+      ({ sel, off }) => {
+        const paragraph = document.getElementById(sel)
+        if (!paragraph) throw new Error(`Missing paragraph #${sel}`)
+        const walker = document.createTreeWalker(paragraph, NodeFilter.SHOW_TEXT)
+        const textNodes = []
+        while (walker.nextNode()) textNodes.push(walker.currentNode)
+
+        const range = document.createRange()
+        if (textNodes.length === 0) {
+          // Empty block: collapse into the paragraph element itself.
+          range.setStart(paragraph, 0)
+        } else {
+          let remaining = off
+          let target = textNodes[textNodes.length - 1]
+          let targetOffset = target.textContent.length
+          for (const node of textNodes) {
+            if (remaining <= node.textContent.length) {
+              target = node
+              targetOffset = remaining
+              break
+            }
+            remaining -= node.textContent.length
+          }
+          range.setStart(target, targetOffset)
+        }
+        range.collapse(true)
+        const selection = window.getSelection()
+        selection?.removeAllRanges()
+        selection?.addRange(range)
+      },
+      { sel: selector, off: offset },
+    )
+  }
+
+  test.beforeAll(async () => {
+    const { client, userId } = await getSupabase()
+    const nb = await createNotebook(client, userId, `FmtShortcuts Notebook ${Date.now()}`)
+    notebookId = nb.id
+    const sec = await createSection(client, userId, nb.id, 'FmtShortcuts Section')
+    highlightPage = await createPage(client, userId, sec.id, 'Highlight Word', HIGHLIGHT_CONTENT)
+    linePage = await createPage(client, userId, sec.id, 'Line Marks', LINE_CONTENT, 1)
+    armPage = await createPage(client, userId, sec.id, 'Arm Typing', ARM_CONTENT, 2)
+    parityPage = await createPage(client, userId, sec.id, 'Parity', PARITY_CONTENT, 3)
+  })
+
+  test.afterAll(async () => {
+    const { client } = await getSupabase()
+    await deleteNotebookById(client, notebookId)
+  })
+
+  test('highlight shortcut on a word marks the whole word and toggles off', async ({ page }) => {
+    await waitForApp(page, `/#pg=${highlightPage.id}`, { expectedText: 'highlightme extra' })
+    const block = page.locator('#p-hl')
+
+    // Caret inside "highlightme" (offset 3), nothing selected.
+    await placeCaretInParagraph(page, 'p-hl', 3)
+    await page.keyboard.press('Control+Alt+h')
+
+    // Whole word wrapped in <mark>; "extra" untouched. (The exact reported bug.)
+    await expect(async () => {
+      const result = await block.evaluate((el) => ({
+        markText: el.querySelector('mark')?.textContent ?? '',
+        text: el.textContent.trim(),
+      }))
+      expect(result.markText).toBe('highlightme')
+      expect(result.text).toBe('highlightme extra')
+    }).toPass({ timeout: 3000 })
+
+    // Press again -> highlight removed.
+    await placeCaretInParagraph(page, 'p-hl', 3)
+    await page.keyboard.press('Control+Alt+h')
+    await expect(async () => {
+      const hasMark = await block.evaluate((el) => el.querySelector('mark') !== null)
+      expect(hasMark).toBe(false)
+    }).toPass({ timeout: 3000 })
+  })
+
+  test('bold/italic/underline shortcuts format the whole line', async ({ page }) => {
+    await waitForApp(page, `/#pg=${linePage.id}`, { expectedText: 'bold this whole line' })
+
+    const cases = [
+      { selector: 'p-bold', key: 'Control+b', tag: 'strong', text: 'bold this whole line' },
+      { selector: 'p-italic', key: 'Control+i', tag: 'em', text: 'italic this whole line' },
+      { selector: 'p-underline', key: 'Control+u', tag: 'u', text: 'underline this whole line' },
+    ]
+
+    for (const { selector, key, tag, text } of cases) {
+      // Caret mid-line, nothing selected.
+      await placeCaretInParagraph(page, selector, 4)
+      await page.keyboard.press(key)
+
+      await expect(async () => {
+        const marked = await page
+          .locator(`#${selector} ${tag}`)
+          .evaluate((el) => el.textContent)
+          .catch(() => null)
+        expect(marked).toBe(text)
+      }).toPass({ timeout: 3000 })
+    }
+  })
+
+  test('shortcut arms continued typing (empty block and after a word)', async ({ page }) => {
+    await waitForApp(page, `/#pg=${armPage.id}`, { expectedText: 'wordone' })
+
+    // 1) Empty block: nothing to format, so Ctrl+i just arms; typed text is italic.
+    await placeCaretInParagraph(page, 'p-arm-empty', 0)
+    await page.keyboard.press('Control+i')
+    await page.keyboard.type('freshitalic')
+    await expect(async () => {
+      const emText = await page
+        .locator('#p-arm-empty em')
+        .evaluate((el) => el.textContent)
+        .catch(() => null)
+      expect(emText).toContain('freshitalic')
+    }).toPass({ timeout: 3000 })
+
+    // 2) After highlighting a word, typing inside it stays highlighted (armed).
+    await placeCaretInParagraph(page, 'p-arm-word', 3)
+    await page.keyboard.press('Control+Alt+h')
+    await page.keyboard.type('XYZ')
+    await expect(async () => {
+      const markText = await page
+        .locator('#p-arm-word mark')
+        .evaluate((el) => el.textContent)
+        .catch(() => null)
+      expect(markText).toContain('XYZ')
+    }).toPass({ timeout: 3000 })
+  })
+
+  test('shortcut and toolbar button stay in sync (highlight active state)', async ({ page }) => {
+    await waitForApp(page, `/#pg=${parityPage.id}`, { expectedText: 'parityword extra' })
+    await ensureToolbarExpanded(page)
+
+    const highlightBtn = page.getByRole('button', { name: 'Highlight', exact: true })
+
+    // Format the word via the shortcut -> toolbar button reflects active.
+    await placeCaretInParagraph(page, 'p-parity', 3)
+    await page.keyboard.press('Control+Alt+h')
+    await expect(highlightBtn).toHaveClass(/\bactive\b/, { timeout: 3000 })
+
+    // Toggle off via the shortcut -> toolbar button reflects inactive.
+    await placeCaretInParagraph(page, 'p-parity', 3)
+    await page.keyboard.press('Control+Alt+h')
+    await expect(highlightBtn).not.toHaveClass(/\bactive\b/, { timeout: 3000 })
+  })
+})

--- a/src/components/editor/toolbar/tools/textTools.jsx
+++ b/src/components/editor/toolbar/tools/textTools.jsx
@@ -9,8 +9,8 @@ import HighlightPicker from '../HighlightPicker'
 import { useOutsideClick } from '../useOutsideClick'
 import { cmd } from '../toolHelpers'
 import {
-  applyMarkToTarget,
-  applyMarkToBlockTarget,
+  applyMarkSmart,
+  toggleMarkSmart,
   isMarkActiveForBlockToggle,
   isMarkActiveForToggle,
   syncSelectionFromDom,
@@ -21,17 +21,14 @@ import { Btn } from './ToolButton'
 // --- Inline marks ---------------------------------------------------------
 
 // Bold/Italic/Underline use the user's line-level cursor behavior: a collapsed
-// caret formats the current paragraph/list item. Highlight is the exception and
-// remains word-level below. On an empty block, applyMarkToBlockTarget returns
-// false and we fall back to the standard
-// stored-mark command ("format the next typed characters").
-function toggleInlineMark(editor, markName, fallback) {
+// caret formats the current paragraph/list item AND arms continued typing.
+// Highlight is the exception and remains word-level below. On an empty block /
+// whitespace caret, there's nothing to grab, so toggleMarkSmart just arms the
+// next typed characters.
+function toggleInlineMark(editor, markName) {
   const markType = editor?.schema.marks[markName]
   if (!editor || !markType) return
-  syncSelectionFromDom(editor)
-  const remove = isMarkActiveForBlockToggle(editor.state, markType)
-  const acted = applyMarkToBlockTarget(editor, markType, { remove })
-  if (!acted) fallback(cmd(editor)) // empty block: stored-mark fallback
+  toggleMarkSmart(editor, markType, { level: 'block' })
 }
 
 function isInlineMarkActive(editor, markName) {
@@ -43,7 +40,7 @@ export function BoldTool({ editor }) {
   return (
     <Btn
       active={isInlineMarkActive(editor, 'bold')}
-      onActivate={() => toggleInlineMark(editor, 'bold', (c) => c?.toggleBold().run())}
+      onActivate={() => toggleInlineMark(editor, 'bold')}
       title="Bold"
     >
       <BoldIcon />
@@ -55,7 +52,7 @@ export function ItalicTool({ editor }) {
   return (
     <Btn
       active={isInlineMarkActive(editor, 'italic')}
-      onActivate={() => toggleInlineMark(editor, 'italic', (c) => c?.toggleItalic().run())}
+      onActivate={() => toggleInlineMark(editor, 'italic')}
       title="Italic"
     >
       <ItalicIcon />
@@ -67,7 +64,7 @@ export function UnderlineTool({ editor }) {
   return (
     <Btn
       active={isInlineMarkActive(editor, 'underline')}
-      onActivate={() => toggleInlineMark(editor, 'underline', (c) => c?.toggleUnderline().run())}
+      onActivate={() => toggleInlineMark(editor, 'underline')}
       title="Underline"
     >
       <UnderlineIcon />
@@ -117,22 +114,18 @@ export function H2Tool({ editor }) {
 
 // --- Highlight (with picker) ---------------------------------------------
 
-// Apply (color) or remove (color === null) the highlight via the shared word-level
-// core. A collapsed caret in a word marks the WHOLE word without changing the
-// visible selection, so the cursor stays put and no blue overlay hides the color.
-// A whitespace caret falls back to today's stored-mark behavior.
+// Apply (color) or remove (color === null) the highlight via the shared smart-mark
+// core at word level. A collapsed caret in a word marks the WHOLE word (and arms
+// continued typing) without changing the visible selection, so the cursor stays
+// put and no blue overlay hides the color. A whitespace caret just arms.
 function setHighlightSmart(editor, color) {
   if (!editor) return
   const markType = editor.schema.marks.highlight
-  const acted = applyMarkToTarget(editor, markType, {
+  applyMarkSmart(editor, markType, {
+    level: 'word',
     attrs: color ? { color } : null,
     remove: !color,
   })
-  if (acted) return
-
-  // Caret on whitespace: keep today's stored-mark behavior.
-  if (!color) editor.chain().focus().unsetHighlight().run()
-  else editor.chain().focus().setHighlight({ color }).run()
 }
 
 export function HighlightTool({ editor }) {
@@ -212,18 +205,16 @@ export function TextColorTool({ editor }) {
 
   // Text color is the attribute-mark sibling of Highlight: the textStyle mark
   // carries a `color` attr. It follows the regular formatting tools, so a
-  // collapsed caret colors the current paragraph/list item. An empty block
-  // falls back to the standard setColor/unsetColor stored-mark behavior.
+  // collapsed caret colors the current paragraph/list item (and arms continued
+  // typing). An empty block / whitespace caret just arms.
   const setColorSmart = (color) => {
     if (!editor) return
     const markType = editor.schema.marks.textStyle
-    const acted = applyMarkToBlockTarget(editor, markType, {
+    applyMarkSmart(editor, markType, {
+      level: 'block',
       attrs: color ? { color } : null,
       remove: !color,
     })
-    if (acted) return
-    if (!color) cmd(editor)?.unsetColor().run()
-    else cmd(editor)?.setColor(color).run()
   }
 
   const apply = () => setColorSmart(textColor || null)

--- a/src/extensions/keyboard/linkShortcut.js
+++ b/src/extensions/keyboard/linkShortcut.js
@@ -1,17 +1,25 @@
 import { Extension } from '@tiptap/core'
 import { toggleLineStrike } from './toggleLineStrike'
 import { clearLineFormatting } from './clearLineFormatting'
+import { applyMarkSmart, toggleMarkSmart, isMarkActiveForToggle } from '../../utils/smartMark'
 
 export const LinkShortcut = Extension.create({
   name: 'linkShortcut',
   addKeyboardShortcuts() {
     return {
+      // Bold/Italic/Underline mirror the toolbar buttons: a collapsed caret
+      // formats the whole line and arms continued typing. LinkShortcut already
+      // overrides Mod-b/Mod-i; Mod-u overrides the Underline extension default.
       'Mod-b': () => {
-        this.editor.chain().focus().toggleBold().run()
+        toggleMarkSmart(this.editor, this.editor.schema.marks.bold, { level: 'block' })
         return true
       },
       'Mod-i': () => {
-        this.editor.chain().focus().toggleItalic().run()
+        toggleMarkSmart(this.editor, this.editor.schema.marks.italic, { level: 'block' })
+        return true
+      },
+      'Mod-u': () => {
+        toggleMarkSmart(this.editor, this.editor.schema.marks.underline, { level: 'block' })
         return true
       },
       'Mod-k': () => {
@@ -40,19 +48,19 @@ export const LinkShortcut = Extension.create({
         this.editor.chain().focus().toggleBulletList().run()
         return true
       },
+      // Highlight mirrors the toolbar: word-level on a collapsed caret, driven
+      // by the chosen color (editor.storage.highlightColor mirrors the store).
+      // No hard-coded default — matching the toolbar, an unset color removes.
       'Mod-Alt-h': () => {
-        const isHighlighted = this.editor.isActive('highlight')
-        if (isHighlighted) {
-          this.editor.chain().focus().unsetHighlight().run()
-          return true
-        }
-        const storedColor = this.editor.storage?.highlightColor
-        if (storedColor === null) {
-          return true
-        }
-        const currentColor =
-          storedColor || this.editor.getAttributes('highlight')?.color || '#fef08a'
-        this.editor.chain().focus().setHighlight({ color: currentColor }).run()
+        const editor = this.editor
+        const highlightMark = editor.schema.marks.highlight
+        const color = editor.storage?.highlightColor
+        const remove = isMarkActiveForToggle(editor.state, highlightMark) || !color
+        applyMarkSmart(editor, highlightMark, {
+          level: 'word',
+          attrs: remove ? null : { color },
+          remove,
+        })
         return true
       },
     }

--- a/src/utils/__tests__/smartMark.test.js
+++ b/src/utils/__tests__/smartMark.test.js
@@ -1,7 +1,13 @@
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, beforeAll, afterAll } from 'vitest'
 import { Schema } from '@tiptap/pm/model'
 import { EditorState, TextSelection } from '@tiptap/pm/state'
-import { isMarkActiveForBlockToggle, isMarkActiveForToggle, rangeFullyHasMark } from '../smartMark'
+import {
+  applyMarkSmart,
+  isMarkActiveForBlockToggle,
+  isMarkActiveForToggle,
+  rangeFullyHasMark,
+  toggleMarkSmart,
+} from '../smartMark'
 
 // Minimal ProseMirror schema with a plain-text block plus a couple of marks.
 // `underline` stands in for the inclusive Bold/Italic/Underline family; `em`
@@ -145,5 +151,142 @@ describe('rangeFullyHasMark', () => {
   it('returns false when only part of the text range has the mark', () => {
     const state = stateWithMark(d, underline, 1, 6)
     expect(rangeFullyHasMark(state, 1, 12, underline)).toBe(false)
+  })
+})
+
+// --- applyMarkSmart / toggleMarkSmart ------------------------------------
+//
+// These operate on an `editor` (not a raw state), so we build a minimal fake
+// that mimics the Tiptap chain: chain().focus().command(fn).run() runs each
+// command against a single shared transaction and applies it, exactly like the
+// real chain. syncSelectionFromDom bails out immediately because our stubbed
+// window has no selection, so no editor view is needed.
+
+// syncSelectionFromDom reads window.getSelection(); in the node test env there
+// is no window. A stub returning null makes it bail before touching the view.
+beforeAll(() => {
+  globalThis.window = { getSelection: () => null }
+})
+afterAll(() => {
+  delete globalThis.window
+})
+
+const makeEditor = (initialState) => {
+  const editor = {
+    state: initialState,
+    schema: initialState.schema,
+    isDestroyed: false,
+    get view() {
+      return null
+    },
+    chain() {
+      const ops = []
+      const api = {
+        focus() {
+          return api
+        },
+        command(fn) {
+          ops.push(fn)
+          return api
+        },
+        run() {
+          const tr = editor.state.tr
+          for (const fn of ops) {
+            fn({ state: editor.state, tr, dispatch: () => {} })
+          }
+          editor.state = editor.state.apply(tr)
+          return true
+        },
+      }
+      return api
+    },
+  }
+  return editor
+}
+
+// The marks that would apply to the NEXT typed character: explicit stored marks
+// if set, otherwise the marks at the caret. This is what "arm continued typing"
+// really means — when the caret lands inside a freshly-marked word, the marks at
+// the cursor already carry the format, so addStoredMark is a no-op there.
+const armedMarks = (state) => state.storedMarks || state.selection.$from.marks()
+const isArmed = (state, markType) => markType.isInSet(armedMarks(state)) != null
+
+describe('applyMarkSmart', () => {
+  it('word-level: caret inside a word marks the whole word and arms typing', () => {
+    // doc: p("hello world"); caret at pos 3 (inside "hello" = [1, 6]).
+    const editor = makeEditor(withCursor(EditorState.create({ doc: doc.create(null, [p('hello world')]), schema }), 3))
+    applyMarkSmart(editor, underline, { level: 'word' })
+
+    // Whole word "hello" marked, "world" untouched.
+    expect(rangeFullyHasMark(editor.state, 1, 6, underline)).toBe(true)
+    expect(rangeFullyHasMark(editor.state, 7, 12, underline)).toBe(false)
+    // Continued typing armed.
+    expect(isArmed(editor.state, underline)).toBe(true)
+  })
+
+  it('word-level: caret on whitespace leaves the doc unchanged but arms typing', () => {
+    // doc: p("hi  there"); caret at pos 4 sits between the two spaces (no word).
+    const initial = withCursor(EditorState.create({ doc: doc.create(null, [p('hi  there')]), schema }), 4)
+    const editor = makeEditor(initial)
+    applyMarkSmart(editor, underline, { level: 'word' })
+
+    // Nothing to grab: doc text is untouched, no mark applied anywhere.
+    expect(editor.state.doc.eq(initial.doc)).toBe(true)
+    expect(rangeFullyHasMark(editor.state, 1, 10, underline)).toBe(false)
+    // But typing is armed.
+    expect(isArmed(editor.state, underline)).toBe(true)
+  })
+
+  it('block-level: caret inside a line marks the whole block and arms typing', () => {
+    // doc: p("hello world"); caret at pos 9 (inside "world"). Block = [1, 12].
+    const editor = makeEditor(withCursor(EditorState.create({ doc: doc.create(null, [p('hello world')]), schema }), 9))
+    applyMarkSmart(editor, underline, { level: 'block' })
+
+    expect(rangeFullyHasMark(editor.state, 1, 12, underline)).toBe(true)
+    expect(isArmed(editor.state, underline)).toBe(true)
+  })
+
+  it('remove: clears the range mark and disarms the stored mark', () => {
+    // Start with "hello" underlined; caret inside it; remove.
+    const marked = stateWithMark(doc.create(null, [p('hello world')]), underline, 1, 6)
+    const editor = makeEditor(withCursor(marked, 3))
+    applyMarkSmart(editor, underline, { level: 'word', remove: true })
+
+    expect(rangeFullyHasMark(editor.state, 1, 6, underline)).toBe(false)
+    // Stored mark removed (arming off), not carried into the next characters.
+    expect(isArmed(editor.state, underline)).toBe(false)
+  })
+
+  it('formats a non-empty selection without arming', () => {
+    // Select "world" [7, 12]; no collapsed caret, so no stored mark is set.
+    const editor = makeEditor(
+      withSelection(EditorState.create({ doc: doc.create(null, [p('hello world')]), schema }), 7, 12),
+    )
+    applyMarkSmart(editor, underline, { level: 'word' })
+
+    expect(rangeFullyHasMark(editor.state, 7, 12, underline)).toBe(true)
+    expect(isArmed(editor.state, underline)).toBe(false)
+  })
+})
+
+describe('toggleMarkSmart', () => {
+  it('applies the mark when the word target is not yet marked', () => {
+    const editor = makeEditor(withCursor(EditorState.create({ doc: doc.create(null, [p('hello world')]), schema }), 3))
+    toggleMarkSmart(editor, underline, { level: 'word' })
+    expect(rangeFullyHasMark(editor.state, 1, 6, underline)).toBe(true)
+  })
+
+  it('removes the mark when the word target is already fully marked', () => {
+    const marked = stateWithMark(doc.create(null, [p('hello world')]), underline, 1, 6)
+    const editor = makeEditor(withCursor(marked, 3))
+    toggleMarkSmart(editor, underline, { level: 'word' })
+    expect(rangeFullyHasMark(editor.state, 1, 6, underline)).toBe(false)
+  })
+
+  it('block-level: removes when the whole block already carries the mark', () => {
+    const marked = stateWithMark(doc.create(null, [p('hello world')]), underline, 1, 12)
+    const editor = makeEditor(withCursor(marked, 9))
+    toggleMarkSmart(editor, underline, { level: 'block' })
+    expect(rangeFullyHasMark(editor.state, 1, 12, underline)).toBe(false)
   })
 })

--- a/src/utils/smartMark.js
+++ b/src/utils/smartMark.js
@@ -121,82 +121,83 @@ export const isMarkActiveForBlockToggle = (state, markType) => {
   return rangeFullyHasMark(state, selection.from, selection.to, markType)
 }
 
-/**
- * Apply (or remove) a mark on the word under a collapsed caret, or on the
- * current selection. The caret stays collapsed — we never setTextSelection, so
- * no blue overlay flashes over the formatted word.
- *
- * Returns false (without acting) when there is no word/selection target — a
- * caret on whitespace or an empty block — so callers can fall back to the
- * standard stored-mark command ("format the next typed characters").
- *
- * @param {import('@tiptap/core').Editor} editor
- * @param {import('@tiptap/pm/model').MarkType} markType
- * @param {{ attrs?: object | null, remove?: boolean }} [options]
- * @returns {boolean} true when a word/selection target was acted on
- */
-export function applyMarkToTarget(editor, markType, { attrs = null, remove = false } = {}) {
-  if (!editor || !markType) return false
-  syncSelectionFromDom(editor)
-
-  const { selection } = editor.state
-  let range = null
-  if (selection.empty) {
-    range = getWordRangeAt(editor.state)
-    if (!range) return false // whitespace caret: let the caller fall back
-  } else {
-    range = { from: selection.from, to: selection.to }
+// Resolve the target range for a smart mark action. With a non-empty selection
+// we act on the selection. With a collapsed caret we grab the smart target: the
+// word under the cursor (level 'word') or the whole paragraph/list item (level
+// 'block'). Returns null when the caret sits on whitespace / an empty block —
+// there is nothing to grab, so the caller only arms continued typing.
+function resolveSmartRange(state, level) {
+  const { selection } = state
+  if (!selection.empty) {
+    return { from: selection.from, to: selection.to }
   }
-
-  editor
-    .chain()
-    .focus()
-    .command(({ tr, dispatch }) => {
-      if (dispatch) {
-        tr.removeMark(range.from, range.to, markType)
-        if (!remove) tr.addMark(range.from, range.to, markType.create(attrs))
-      }
-      return true
-    })
-    .run()
-
-  return true
+  const range = level === 'word' ? getWordRangeAt(state) : getBlockTextRange(state)
+  if (!range || range.from >= range.to) return null
+  return range
 }
 
 /**
- * Apply (or remove) a mark on the current paragraph/list item when the caret is
- * collapsed, or on the current selection when text is selected. The caret stays
- * collapsed; callers do not need to create a temporary text selection.
+ * Apply (or remove) a mark the way the toolbar buttons do, in one transaction:
+ *
+ *  - Cursor in a word/line (collapsed caret) → format the smart target (word for
+ *    'word', whole block for 'block') AND arm continued typing so newly typed
+ *    text keeps the format.
+ *  - Cursor on whitespace / empty block (nothing to grab) → just arm the next
+ *    typed characters.
+ *  - Text selected → format the selection (no arming).
+ *
+ * The caret stays collapsed — we never setTextSelection, so no native blue
+ * overlay flashes over the formatted text.
  *
  * @param {import('@tiptap/core').Editor} editor
  * @param {import('@tiptap/pm/model').MarkType} markType
- * @param {{ attrs?: object | null, remove?: boolean }} [options]
- * @returns {boolean} true when a block/selection target was acted on
+ * @param {{ attrs?: object | null, level?: 'word' | 'block', remove?: boolean }} [options]
  */
-export function applyMarkToBlockTarget(editor, markType, { attrs = null, remove = false } = {}) {
-  if (!editor || !markType) return false
+export function applyMarkSmart(editor, markType, { attrs = null, level = 'block', remove = false } = {}) {
+  if (!editor || !markType) return
   syncSelectionFromDom(editor)
 
-  const { selection } = editor.state
-  let range = null
-  if (selection.empty) {
-    range = getBlockTextRange(editor.state)
-    if (!range || range.from >= range.to) return false
-  } else {
-    range = { from: selection.from, to: selection.to }
-  }
+  const range = resolveSmartRange(editor.state, level)
 
   editor
     .chain()
     .focus()
-    .command(({ tr, dispatch }) => {
-      if (dispatch) {
+    .command(({ state, tr, dispatch }) => {
+      if (!dispatch) return true
+      const mark = markType.create(attrs)
+
+      if (range) {
         tr.removeMark(range.from, range.to, markType)
-        if (!remove) tr.addMark(range.from, range.to, markType.create(attrs))
+        if (!remove) tr.addMark(range.from, range.to, mark)
       }
+
+      // Collapsed caret: arm continued typing so the next characters match.
+      if (state.selection.empty) {
+        if (remove) tr.removeStoredMark(markType)
+        else tr.addStoredMark(mark)
+      }
+
       return true
     })
     .run()
+}
 
-  return true
+/**
+ * Toggle a mark on the smart target. Reads the current active state via the
+ * matching active-state helper (word- or block-level) so the toggle decision
+ * mirrors the action, then delegates to applyMarkSmart. Shared by the
+ * bold/italic/underline toolbar buttons and their keyboard shortcuts.
+ *
+ * @param {import('@tiptap/core').Editor} editor
+ * @param {import('@tiptap/pm/model').MarkType} markType
+ * @param {{ level?: 'word' | 'block' }} [options]
+ */
+export function toggleMarkSmart(editor, markType, { level = 'block' } = {}) {
+  if (!editor || !markType) return
+  syncSelectionFromDom(editor)
+  const isActive =
+    level === 'word'
+      ? isMarkActiveForToggle(editor.state, markType)
+      : isMarkActiveForBlockToggle(editor.state, markType)
+  applyMarkSmart(editor, markType, { level, remove: isActive })
 }


### PR DESCRIPTION
## Problem

The toolbar formatting buttons were upgraded to smart collapsed-caret behavior: clicking Highlight with the cursor inside a word (no selection) highlights the **whole word**, and clicking Bold/Italic/Underline/Text-color formats the **whole line**. The matching **keyboard shortcuts were never upgraded** — they still called raw Tiptap toggle commands, which on a collapsed caret only "arm" a stored mark instead of acting on the word/line under the cursor.

Symptom: on desktop, cursor placed on a word (nothing selected) + `Ctrl+Alt+H` did nothing visible.

## Approach

Consolidate all collapsed-caret mark logic into `src/utils/smartMark.js` and route **both** the toolbar tools and the keyboard shortcuts through it, so the two can't drift apart again. Also adds a small new behavior applied to both shortcuts and buttons: after formatting the word/line on a collapsed caret, **arm continued typing** so newly typed text keeps the format.

### Unified behavior (no selection)
- **Cursor in a word** → format the smart target (word for highlight; whole line for bold/italic/underline/color) **and** arm continued typing.
- **Cursor in blank space / empty block** → nothing to grab, so just arm the next typed characters.
- **Text selected** → format the selection (unchanged).
- **Press again** → toggles off.

## Changes

- **`src/utils/smartMark.js`** — add `applyMarkSmart` + `toggleMarkSmart`; remove the superseded `applyMarkToTarget` / `applyMarkToBlockTarget`.
- **`src/components/editor/toolbar/tools/textTools.jsx`** — migrate Bold/Italic/Underline/Highlight/Text color to the shared helpers; drop the old stored-mark fallbacks.
- **`src/extensions/keyboard/linkShortcut.js`** — smart `Mod-b`/`Mod-i`/`Mod-Alt-h`, **add `Mod-u`**. Highlight reads the chosen color from `editor.storage.highlightColor` (no hard-coded `#fef08a` default), matching the toolbar.

## Test plan

- [x] Unit (Vitest): extended `smartMark.test.js` for `applyMarkSmart`/`toggleMarkSmart` (word/block/whitespace/remove/selection/toggle). Full suite **472/472** green.
- [x] Lint + production build pass.
- [ ] E2E (Playwright, CI gate): new `e2e/formatting-shortcuts.spec.js` — highlight-on-word (the reported bug) + toggle-off, line-level bold/italic/underline, arming (empty block + after-word), and shortcut↔toolbar parity. Runs on Desktop + Mobile Chrome.
- [ ] Manual smoke: cursor on a word + `Ctrl+Alt+H` highlights the word and toggles off; `Ctrl+B`/`Ctrl+I`/`Ctrl+U` format the line; typing right after keeps the format; toolbar buttons behave identically.

### Hotspot checklist
- **Concern changed:** collapsed-caret formatting for keyboard shortcuts, unified with toolbar tools.
- **Extracted:** shared `applyMarkSmart`/`toggleMarkSmart` in `smartMark.js`; removed two duplicated helpers and the toolbar fallback branches.
- **Regression checks:** `npm run test:unit` (472 pass), eslint, `npm run build`.