### PR TITLE
fix: spell check scans the whole document (not just the viewport)

### DIFF
--- a/e2e/ai-find.spec.js
+++ b/e2e/ai-find.spec.js
@@ -248,7 +248,7 @@ test.describe('AI Find scroll-into-view', () => {
     }).toPass({ timeout: 5000 })
   })
 
-  test('literal Find Next keeps the current highlight above the mobile toolbar', async ({ page, isMobile }) => {
+  test('literal Find Next keeps the current highlight above the mobile toolbar @mobile', async ({ page, isMobile }) => {
     test.skip(!isMobile, 'Mobile toolbar coverage regression')
 
     await waitForApp(page, `/#pg=${testPage.id}`, { expectedText: 'Delta Airlines top reference' })
@@ -280,7 +280,7 @@ test.describe('AI Find scroll-into-view', () => {
     }).toPass({ timeout: 5000 })
   })
 
-  test('desktop Find Next keeps the current highlight below the sticky toolbar', async ({ page, isMobile }) => {
+  test('desktop Find Next keeps the current highlight below the sticky toolbar @desktop', async ({ page, isMobile }) => {
     test.skip(isMobile, 'Desktop sticky top-toolbar coverage')
 
     await waitForApp(page, `/#pg=${testPage.id}`, { expectedText: 'Delta Airlines top reference' })

--- a/e2e/fixtures.js
+++ b/e2e/fixtures.js
@@ -146,38 +146,45 @@ export const test = base.extend({
     // `provide` is Playwright's fixture callback (passed positionally); it is
     // not React's `use` hook. Naming it `provide` avoids react-hooks/rules-of-hooks
     // false positives, and the named first param avoids no-empty-pattern.
-    async ({ baseURL }, provide, testInfo) => {
-      void baseURL
+    async ({ page }, provide, testInfo) => {
       if (testInfo.project.name === 'setup') {
         await provide()
         return
       }
 
       const snapshot = await readSnapshot()
+      const pendingWrites = new Set()
+      const isSupabaseWrite = (request) =>
+        ['POST', 'PUT', 'PATCH', 'DELETE'].includes(request.method()) &&
+        request.url().includes('/rest/v1/')
+      const trackWrite = (request) => {
+        if (isSupabaseWrite(request)) pendingWrites.add(request)
+      }
+      const finishWrite = (request) => pendingWrites.delete(request)
+
+      page.on('request', trackWrite)
+      page.on('requestfinished', finishWrite)
+      page.on('requestfailed', finishWrite)
       try {
         await provide()
       } finally {
-        // The app's autosave debounce is 2 000 ms.  Wait at least that long
-        // before polling so the debounce has a chance to fire.  Then poll the
-        // DB every 500 ms until two consecutive reads match — meaning any
-        // in-flight save has landed.  Ignore query errors (treat as "changed").
-        await new Promise((r) => setTimeout(r, 2000))
-        const supabase = await getSupabaseClient()
-        const userId = snapshot.userId
-        let prev = null
-        const deadline = Date.now() + 3000
-        while (Date.now() < deadline) {
-          const { data, error } = await supabase
-            .from('pages')
-            .select('id,content,title')
-            .eq('user_id', userId)
-          if (!error) {
-            const snap = JSON.stringify(data ?? [])
-            if (prev !== null && snap === prev) break
-            prev = snap
+        // Editing marks the page as Saving immediately, before the two-second
+        // debounce starts. Wait on that observable state only when it exists;
+        // read-only tests proceed directly to cleanup.
+        const status = page.locator('.status-row')
+        if (await status.count()) {
+          const text = await status.textContent().catch(() => '')
+          if (/Saving|Unsaved \(local\)/.test(text ?? '')) {
+            await expect(status).not.toContainText(/Saving|Unsaved \(local\)/, { timeout: 6000 })
           }
-          await new Promise((r) => setTimeout(r, 500))
         }
+
+        // Also wait for direct create/delete/update requests that do not use
+        // the editor's save status. This normally resolves immediately.
+        await expect.poll(() => pendingWrites.size, { timeout: 5000 }).toBe(0)
+        page.off('request', trackWrite)
+        page.off('requestfinished', finishWrite)
+        page.off('requestfailed', finishWrite)
         await restoreSnapshot(snapshot, getProtectedSeedSnapshot())
       }
     },

--- a/e2e/highlight-toggle-cursor.spec.js
+++ b/e2e/highlight-toggle-cursor.spec.js
@@ -118,7 +118,7 @@ test.afterAll(async () => {
 const seedHash = (pageRow) =>
   `#nb=${seedIds.notebook.id}&sec=${seedIds.section.id}&pg=${pageRow.id}`
 
-test('Highlight on a collapsed caret marks the whole word without disturbing the selection', async ({
+test('Highlight on a collapsed caret marks the whole word without disturbing the selection @desktop', async ({
   page,
   isMobile,
 }) => {
@@ -148,7 +148,7 @@ test('Highlight on a collapsed caret marks the whole word without disturbing the
   }).toPass({ timeout: 5000 })
 })
 
-test('Picking a dropdown color with a collapsed caret highlights the word and keeps it collapsed', async ({
+test('Picking a dropdown color with a collapsed caret highlights the word and keeps it collapsed @desktop', async ({
   page,
   isMobile,
 }) => {

--- a/e2e/issue-115-mobile-keyboard-section-switch.spec.js
+++ b/e2e/issue-115-mobile-keyboard-section-switch.spec.js
@@ -69,7 +69,7 @@ test.afterAll(async () => {
   await deleteNotebookById(client, seedIds.notebook?.id)
 })
 
-test('switching sections in sidebar does NOT focus the editor', async ({ page, isMobile }) => {
+test('switching sections in sidebar does NOT focus the editor @mobile', async ({ page, isMobile }) => {
   test.skip(!isMobile, 'Mobile-only test')
 
   // Navigate to Page A
@@ -97,7 +97,7 @@ test('switching sections in sidebar does NOT focus the editor', async ({ page, i
   expect(interactionState.selectionInEditor).toBe(false)
 })
 
-test('tapping the editor after section switch DOES focus it', async ({ page, isMobile }) => {
+test('tapping the editor after section switch DOES focus it @mobile', async ({ page, isMobile }) => {
   test.skip(!isMobile, 'Mobile-only test')
 
   // Navigate to Page A

--- a/e2e/issue-124-keyboard-toolbar.spec.js
+++ b/e2e/issue-124-keyboard-toolbar.spec.js
@@ -50,7 +50,7 @@ test.afterAll(async () => {
   await deleteNotebookById(client, seedIds.notebook?.id)
 })
 
-test('mobile toolbar is visible and pinned to the bottom of the viewport', async ({ page, isMobile }) => {
+test('mobile toolbar is visible and pinned to the bottom of the viewport @mobile', async ({ page, isMobile }) => {
   test.skip(!isMobile, 'Mobile-only test')
 
   const hash = `#nb=${seedIds.notebook.id}&sec=${seedIds.section.id}&pg=${seedIds.page.id}`
@@ -71,7 +71,7 @@ test('mobile toolbar is visible and pinned to the bottom of the viewport', async
   expect(Math.abs(bottomGap)).toBeLessThanOrEqual(2) // within safe-area / rounding
 })
 
-test('bold button works from the mobile toolbar', async ({ page, isMobile }) => {
+test('bold button works from the mobile toolbar @mobile', async ({ page, isMobile }) => {
   test.skip(!isMobile, 'Mobile-only test')
 
   const hash = `#nb=${seedIds.notebook.id}&sec=${seedIds.section.id}&pg=${seedIds.page.id}`
@@ -91,7 +91,7 @@ test('bold button works from the mobile toolbar', async ({ page, isMobile }) => 
   expect(hasBold).toBe(true)
 })
 
-test('indent and outdent buttons are visible in collapsed mobile toolbar without expanding', async ({ page, isMobile }) => {
+test('indent and outdent buttons are visible in collapsed mobile toolbar without expanding @mobile', async ({ page, isMobile }) => {
   test.skip(!isMobile, 'Mobile-only test')
 
   const hash = `#nb=${seedIds.notebook.id}&sec=${seedIds.section.id}&pg=${seedIds.page.id}`
@@ -105,7 +105,7 @@ test('indent and outdent buttons are visible in collapsed mobile toolbar without
   await expect(outdentBtn).toBeVisible()
 })
 
-test('editor-panel reserves space so content is not hidden behind the toolbar', async ({ page, isMobile }) => {
+test('editor-panel reserves space so content is not hidden behind the toolbar @mobile', async ({ page, isMobile }) => {
   test.skip(!isMobile, 'Mobile-only test')
 
   const hash = `#nb=${seedIds.notebook.id}&sec=${seedIds.section.id}&pg=${seedIds.page.id}`

--- a/e2e/issue-60-mobile-indent-outdent.spec.js
+++ b/e2e/issue-60-mobile-indent-outdent.spec.js
@@ -147,7 +147,7 @@ test.describe('Issue #60 mobile indent/outdent toolbar buttons', () => {
     await deleteNotebookById(client, notebookId)
   })
 
-  test('mobile: indent/outdent buttons appear and work on list items', async ({ page, isMobile }) => {
+  test('mobile: indent/outdent buttons appear and work on list items @mobile', async ({ page, isMobile }) => {
     test.skip(!isMobile, 'Mobile-only toolbar buttons')
 
     await waitForApp(page, `/#pg=${testPage.id}`, { expectedText: 'Send out wedding invites' })
@@ -198,7 +198,7 @@ test.describe('Issue #60 mobile indent/outdent toolbar buttons', () => {
     expect(rowCountAfter).toBe(rowCountBefore)
   })
 
-  test('mobile: indent/outdent on first list item in table does not create rows', async ({ page, isMobile }) => {
+  test('mobile: indent/outdent on first list item in table does not create rows @mobile', async ({ page, isMobile }) => {
     test.skip(!isMobile, 'Mobile-only toolbar buttons')
 
     await waitForApp(page, `/#pg=${testPage.id}`, { expectedText: 'Get DJ scheduled' })
@@ -237,7 +237,7 @@ test.describe('Issue #60 mobile indent/outdent toolbar buttons', () => {
     expect(rowCountAfter).toBe(rowCountBefore)
   })
 
-  test('desktop: indent/outdent buttons are visible', async ({ page, isMobile }) => {
+  test('desktop: indent/outdent buttons are visible @desktop', async ({ page, isMobile }) => {
     test.skip(isMobile, 'Desktop-only check')
 
     await waitForApp(page, `/#pg=${testPage.id}`, { expectedText: 'Wedding Planning' })

--- a/e2e/issue-61-deep-link-focus-recovery.spec.js
+++ b/e2e/issue-61-deep-link-focus-recovery.spec.js
@@ -132,7 +132,7 @@ test.describe('Issue #61 deep-link focus recovery', () => {
     await waitForApp(page, `/#pg=${pageA.id}`, { expectedText: 'Link to' })
   })
 
-  test('desktop: first click-back after highlight clear keeps keyboard scope in editor', async ({ page, isMobile }) => {
+  test('desktop: first click-back after highlight clear keeps keyboard scope in editor @desktop', async ({ page, isMobile }) => {
     test.skip(isMobile, 'Desktop keyboard shortcut regression path')
 
     const { blockId, styleLocator } = await resolveDeepLinkTarget(page)
@@ -160,7 +160,7 @@ test.describe('Issue #61 deep-link focus recovery', () => {
     expect(selectionState.selectedText).not.toContain('Signed in as')
   })
 
-  test('mobile: deep-link landing avoids auto-focus and still supports tap-back editing flow', async ({ page, isMobile }) => {
+  test('mobile: deep-link landing avoids auto-focus and still supports tap-back editing flow @mobile', async ({ page, isMobile }) => {
     test.skip(!isMobile, 'Mobile guard regression path')
 
     const { blockId, styleLocator } = await resolveDeepLinkTarget(page)

--- a/e2e/issue-62-highlight-paste.spec.js
+++ b/e2e/issue-62-highlight-paste.spec.js
@@ -53,7 +53,7 @@ test.describe.fixme('Issue #62 highlight paste regression', () => {
     await deleteNotebookById(client, notebookId)
   })
 
-  test('copy/paste + date edit keeps highlight on date token only', async ({ page, isMobile }) => {
+  test('copy/paste + date edit keeps highlight on date token only @desktop', async ({ page, isMobile }) => {
     test.skip(isMobile, 'Desktop keyboard shortcut flow (Shift+Home, Ctrl+C/V)')
     await waitForApp(page, `/#pg=${testPage.id}`)
     await page.waitForSelector('.ProseMirror[contenteditable="true"]', { timeout: 10000 })

--- a/e2e/issue-71-table-cell-selection-drag.spec.js
+++ b/e2e/issue-71-table-cell-selection-drag.spec.js
@@ -115,7 +115,7 @@ test.describe('Issue #71 cross-cell drag keeps CellSelection', () => {
     await deleteNotebookById(client, notebookId)
   })
 
-  test('drag across two table cells produces CellSelection that persists', async ({ page, isMobile }) => {
+  test('drag across two table cells produces CellSelection that persists @desktop', async ({ page, isMobile }) => {
     test.skip(isMobile, 'Mouse drag CellSelection not supported with touch emulation')
     await waitForApp(page, `/#pg=${testPage.id}`, { expectedText: 'Running' })
 

--- a/e2e/link-paste.spec.js
+++ b/e2e/link-paste.spec.js
@@ -60,7 +60,7 @@ test.describe.fixme('Link paste round-trip (reported regression)', () => {
     await deleteNotebookById(client, notebookId)
   })
 
-  test('copying hyperlinked text and pasting keeps the link', async ({ page, isMobile }) => {
+  test('copying hyperlinked text and pasting keeps the link @desktop', async ({ page, isMobile }) => {
     test.skip(isMobile, 'Desktop keyboard copy/paste flow (Shift+Home, Ctrl+C/V)')
     await waitForApp(page, `/#pg=${testPage.id}`)
     await page.waitForSelector('.ProseMirror[contenteditable="true"]', { timeout: 10000 })

--- a/e2e/mobile-find-close-keyboard.spec.js
+++ b/e2e/mobile-find-close-keyboard.spec.js
@@ -64,7 +64,7 @@ test.afterAll(async () => {
   await deleteNotebookById(client, seedIds.notebook?.id)
 })
 
-test('closing the find bar with the keyboard down does NOT refocus the editor', async ({
+test('closing the find bar with the keyboard down does NOT refocus the editor @mobile', async ({
   page,
   isMobile,
 }) => {

--- a/e2e/mobile-new-page-keyboard.spec.js
+++ b/e2e/mobile-new-page-keyboard.spec.js
@@ -47,7 +47,7 @@ const createNewPage = async (page) => {
   await page.getByRole('button', { name: '+ New page' }).click()
 }
 
-test('creating a new page collapses the drawer and shows a blank page', async ({ page, isMobile }) => {
+test('creating a new page collapses the drawer and shows a blank page @mobile', async ({ page, isMobile }) => {
   test.skip(!isMobile, 'Mobile-only test')
 
   const hash = `#nb=${seedIds.notebook.id}&sec=${seedIds.section.id}`
@@ -64,7 +64,7 @@ test('creating a new page collapses the drawer and shows a blank page', async ({
   await expect(editor).toHaveText('')
 })
 
-test('creating a new page does NOT open the keyboard', async ({ page, isMobile }) => {
+test('creating a new page does NOT open the keyboard @mobile', async ({ page, isMobile }) => {
   test.skip(!isMobile, 'Mobile-only test')
 
   const hash = `#nb=${seedIds.notebook.id}&sec=${seedIds.section.id}`
@@ -80,7 +80,7 @@ test('creating a new page does NOT open the keyboard', async ({ page, isMobile }
   expect(interactionState.selectionInEditor).toBe(false)
 })
 
-test('tapping the editor after creating a new page DOES focus it', async ({ page, isMobile }) => {
+test('tapping the editor after creating a new page DOES focus it @mobile', async ({ page, isMobile }) => {
   test.skip(!isMobile, 'Mobile-only test')
 
   const hash = `#nb=${seedIds.notebook.id}&sec=${seedIds.section.id}`

--- a/e2e/mobile-page-switch-keyboard.spec.js
+++ b/e2e/mobile-page-switch-keyboard.spec.js
@@ -68,7 +68,7 @@ test.afterAll(async () => {
   await deleteNotebookById(client, seedIds.notebook?.id)
 })
 
-test('switching pages in sidebar does NOT focus the editor', async ({ page, isMobile }) => {
+test('switching pages in sidebar does NOT focus the editor @mobile', async ({ page, isMobile }) => {
   test.skip(!isMobile, 'Mobile-only test')
 
   // Navigate to Page A
@@ -95,7 +95,7 @@ test('switching pages in sidebar does NOT focus the editor', async ({ page, isMo
   expect(interactionState.selectionInEditor).toBe(false)
 })
 
-test('tapping the editor after page switch DOES focus it', async ({ page, isMobile }) => {
+test('tapping the editor after page switch DOES focus it @mobile', async ({ page, isMobile }) => {
   test.skip(!isMobile, 'Mobile-only test')
 
   // Navigate to Page A

--- a/e2e/mobile-toolbar-cursor-visibility.spec.js
+++ b/e2e/mobile-toolbar-cursor-visibility.spec.js
@@ -66,7 +66,7 @@ test.afterAll(async () => {
 })
 
 test(
-  'cursor stays visible when toolbar expands on mobile',
+  'cursor stays visible when toolbar expands on mobile @mobile',
   async ({ page, isMobile }) => {
     test.skip(!isMobile, 'Mobile-only test')
 
@@ -126,7 +126,7 @@ test(
 )
 
 test(
-  'toolbar expand does not scroll when cursor is already above the toolbar',
+  'toolbar expand does not scroll when cursor is already above the toolbar @mobile',
   async ({ page, isMobile }) => {
     test.skip(!isMobile, 'Mobile-only test')
 

--- a/e2e/persist-toolbar-colors.spec.js
+++ b/e2e/persist-toolbar-colors.spec.js
@@ -228,7 +228,7 @@ test.afterAll(async () => {
 const seedHash = (pageRow) =>
   `#nb=${seedIds.notebook.id}&sec=${seedIds.section.id}&pg=${pageRow.id}`
 
-test('highlight color picked via caret persists across reload and the main button applies it', async ({
+test('highlight color picked via caret persists across reload and the main button applies it @desktop', async ({
   page,
   isMobile,
 }) => {
@@ -262,7 +262,7 @@ test('highlight color picked via caret persists across reload and the main butto
   }).toPass({ timeout: 5000 })
 })
 
-test('Ctrl+Alt+H applies the persisted highlight color after reload', async ({ page, isMobile }) => {
+test('Ctrl+Alt+H applies the persisted highlight color after reload @desktop', async ({ page, isMobile }) => {
   test.skip(isMobile, 'Desktop keyboard shortcut flow')
 
   await waitForApp(page, seedHash(seedIds.shortcutPage), { expectedText: 'Persisted color test line' })
@@ -285,7 +285,7 @@ test('Ctrl+Alt+H applies the persisted highlight color after reload', async ({ p
   }).toPass({ timeout: 5000 })
 })
 
-test('text color picked via caret persists across reload and the main button applies it', async ({
+test('text color picked via caret persists across reload and the main button applies it @desktop', async ({
   page,
   isMobile,
 }) => {
@@ -317,7 +317,7 @@ test('text color picked via caret persists across reload and the main button app
   }).toPass({ timeout: 5000 })
 })
 
-test('shading color persists across reload and the main button toggles a different cell', async ({
+test('shading color persists across reload and the main button toggles a different cell @desktop', async ({
   page,
   isMobile,
 }) => {
@@ -370,7 +370,7 @@ test('shading color persists across reload and the main button toggles a differe
   )
 })
 
-test('remembered shading color is not clobbered by moving the cursor into a shaded cell', async ({
+test('remembered shading color is not clobbered by moving the cursor into a shaded cell @desktop', async ({
   page,
   isMobile,
 }) => {

--- a/e2e/scroll-cursor-restoration.spec.js
+++ b/e2e/scroll-cursor-restoration.spec.js
@@ -247,7 +247,7 @@ test.describe('scroll + cursor restoration', () => {
     await expect.poll(() => getScroll(page, isMobile), { timeout: 5000 }).toBeLessThan(40)
   })
 
-  test('5. mobile read-mode keeps the keyboard down while restoring', async ({ page, isMobile }) => {
+  test('5. mobile read-mode keeps the keyboard down while restoring @mobile', async ({ page, isMobile }) => {
     test.skip(!isMobile, 'Mobile-only: virtual-keyboard regression guard for #194')
 
     // Seed a scroll offset on the table page via hash nav (no editor focus).

--- a/e2e/spellcheck.spec.js
+++ b/e2e/spellcheck.spec.js
@@ -221,6 +221,27 @@ test('flags a misspelling deep in a tall document without scrolling @desktop', a
   expect(box.y).toBeGreaterThan(viewportHeight)
 })
 
+test('right-click resolves the misspelling under the cursor on a tall page @desktop', async ({
+  page,
+  isMobile,
+}) => {
+  test.skip(isMobile, 'Desktop-only: in-app spell check is gated off on touch devices')
+
+  await waitForApp(page, seedHash(seedIds.tallPage), { expectedText: 'Marathon training' })
+  await page.waitForSelector('.ProseMirror[contenteditable="true"]', { timeout: 10000 })
+
+  const deepError = page.locator('.spellcheck-error', { hasText: DEEP_TYPO })
+  await expect(deepError).toHaveCount(1, { timeout: 15000 })
+
+  // Right-clicking the deep word must open the menu WITH its spelling section.
+  // The menu resolves the word from the clicked element (not coordinate probing),
+  // so it works even though the word is far below the initial viewport.
+  await deepError.click({ button: 'right' })
+  const menu = page.locator('.table-context-menu')
+  await expect(menu).toBeVisible()
+  await expect(menu.getByRole('button', { name: 'Add to dictionary' })).toBeVisible()
+})
+
 test('mobile never underlines and never fetches the dictionary @mobile', async ({ page, isMobile }) => {
   test.skip(!isMobile, 'Mobile-only assertion: feature must stay off on touch devices')
 

--- a/e2e/spellcheck.spec.js
+++ b/e2e/spellcheck.spec.js
@@ -84,7 +84,7 @@ test.afterAll(async () => {
 const seedHash = (pageRow) =>
   `#nb=${seedIds.notebook.id}&sec=${seedIds.section.id}&pg=${pageRow.id}`
 
-test('right-click on a misspelling shows suggestions and corrects the word', async ({
+test('right-click on a misspelling shows suggestions and corrects the word @desktop', async ({
   page,
   isMobile,
 }) => {
@@ -113,7 +113,7 @@ test('right-click on a misspelling shows suggestions and corrects the word', asy
   await expect(page.locator('.spellcheck-error', { hasText: 'teh' })).toHaveCount(0)
 })
 
-test('"Add to dictionary" clears the squiggle and persists across reloads', async ({
+test('"Add to dictionary" clears the squiggle and persists across reloads @desktop', async ({
   page,
   isMobile,
 }) => {
@@ -144,7 +144,7 @@ test('"Add to dictionary" clears the squiggle and persists across reloads', asyn
   await expect(page.locator('.spellcheck-error', { hasText: CUSTOM_WORD })).toHaveCount(0)
 })
 
-test('mobile never underlines and never fetches the dictionary', async ({ page, isMobile }) => {
+test('mobile never underlines and never fetches the dictionary @mobile', async ({ page, isMobile }) => {
   test.skip(!isMobile, 'Mobile-only assertion: feature must stay off on touch devices')
 
   const dictionaryRequests = []

--- a/e2e/spellcheck.spec.js
+++ b/e2e/spellcheck.spec.js
@@ -6,6 +6,9 @@
  *      shows suggestions in the custom menu; clicking one corrects the word.
  *   2. "Add to dictionary" clears the squiggle and persists — after a reload the
  *      custom word is still not flagged.
+ *   3. A misspelling buried deep in a tall (taller-than-viewport) document is
+ *      flagged without scrolling — regression coverage for the full-document
+ *      scan replacing the old, unreliable viewport-only scan.
  *
  * Mobile flow:
  *   The feature is desktop-only. On the Mobile Chrome project nothing is
@@ -25,6 +28,49 @@ import {
 
 // Coined name that will never be in the dictionary — used for the add-to-dictionary flow.
 const CUSTOM_WORD = 'Kacarlsonia'
+
+// Coined word placed deep in the tall page. Distinctive so the locator can find
+// exactly one squiggle; never a real word, so it is always flagged.
+const DEEP_TYPO = 'Zblorptastic'
+
+// A sentence of only common, correctly-spelled English words, so the tall page's
+// filler never produces incidental squiggles that could confuse assertions.
+const FILLER_SENTENCE =
+  'This is a normal line of tracker notes with plenty of everyday words that the checker should not flag as wrong.'
+
+// Build a document far taller than the viewport — like a real month-long tracker —
+// with the sentinel misspelling buried well below the fold. The old viewport-only
+// scan never reached content this deep (and on this app's window-scroll layout
+// collapsed to nothing entirely); the full-document scan flags it immediately.
+const buildTallTrackerContent = () => {
+  const content = [
+    {
+      type: 'paragraph',
+      attrs: { id: 'tall-title' },
+      content: [{ type: 'text', text: 'Marathon training and life admin tracker' }],
+    },
+  ]
+  for (let i = 0; i < 60; i += 1) {
+    content.push({
+      type: 'paragraph',
+      attrs: { id: `tall-fill-${i}` },
+      content: [{ type: 'text', text: `${i + 1}. ${FILLER_SENTENCE}` }],
+    })
+  }
+  content.push({
+    type: 'paragraph',
+    attrs: { id: 'tall-deep-typo' },
+    content: [{ type: 'text', text: `Remember to call the ${DEEP_TYPO} about the thing.` }],
+  })
+  for (let i = 0; i < 5; i += 1) {
+    content.push({
+      type: 'paragraph',
+      attrs: { id: `tall-tail-${i}` },
+      content: [{ type: 'text', text: FILLER_SENTENCE }],
+    })
+  }
+  return { type: 'doc', content }
+}
 
 const buildSuggestContent = () => ({
   type: 'doc',
@@ -71,7 +117,15 @@ test.beforeAll(async () => {
     buildCustomWordContent(),
     1,
   )
-  seedIds = { notebook, section, suggestPage, customPage }
+  const tallPage = await createPage(
+    client,
+    userId,
+    section.id,
+    `${seedLabel} Tall Page`,
+    buildTallTrackerContent(),
+    2,
+  )
+  seedIds = { notebook, section, suggestPage, customPage, tallPage }
 })
 
 test.afterAll(async () => {
@@ -142,6 +196,29 @@ test('"Add to dictionary" clears the squiggle and persists across reloads @deskt
     timeout: 15000,
   }).catch(() => {})
   await expect(page.locator('.spellcheck-error', { hasText: CUSTOM_WORD })).toHaveCount(0)
+})
+
+test('flags a misspelling deep in a tall document without scrolling @desktop', async ({
+  page,
+  isMobile,
+}) => {
+  test.skip(isMobile, 'Desktop-only: in-app spell check is gated off on touch devices')
+
+  await waitForApp(page, seedHash(seedIds.tallPage), { expectedText: 'Marathon training' })
+  await page.waitForSelector('.ProseMirror[contenteditable="true"]', { timeout: 10000 })
+
+  // The sentinel typo sits ~60 paragraphs down, far below the initial viewport.
+  // A viewport-only scan would miss it (this is the regression the full-document
+  // scan fixes); assert it is flagged with no scrolling at all.
+  const deepError = page.locator('.spellcheck-error', { hasText: DEEP_TYPO })
+  await expect(deepError).toHaveCount(1, { timeout: 15000 })
+
+  // Confirm it really was below the fold — proving the whole document was scanned,
+  // not just what happened to be on screen.
+  const box = await deepError.boundingBox()
+  const viewportHeight = page.viewportSize()?.height ?? 0
+  expect(box).not.toBeNull()
+  expect(box.y).toBeGreaterThan(viewportHeight)
 })
 
 test('mobile never underlines and never fetches the dictionary @mobile', async ({ page, isMobile }) => {

--- a/e2e/toolbar-expand-toggle.spec.js
+++ b/e2e/toolbar-expand-toggle.spec.js
@@ -64,7 +64,7 @@ test.afterAll(async () => {
 })
 
 test(
-  'mobile expand toggle flips state on a single tap',
+  'mobile expand toggle flips state on a single tap @mobile',
   async ({ page, isMobile }) => {
     test.skip(!isMobile, 'Mobile-only test')
 
@@ -91,7 +91,7 @@ test(
 )
 
 test(
-  'tapping the expand toggle without prior editor focus does NOT focus the editor',
+  'tapping the expand toggle without prior editor focus does NOT focus the editor @mobile',
   async ({ page, isMobile }) => {
     test.skip(!isMobile, 'Mobile-only test')
 
@@ -127,7 +127,7 @@ test(
 )
 
 test(
-  'tapping a command button preserves editor selection and applies the command',
+  'tapping a command button preserves editor selection and applies the command @mobile',
   async ({ page, isMobile }) => {
     test.skip(!isMobile, 'Mobile-only test')
 

--- a/e2e/underline-toggle-cursor.spec.js
+++ b/e2e/underline-toggle-cursor.spec.js
@@ -382,7 +382,7 @@ test('Ctrl/Cmd+B and Ctrl/Cmd+I format selected existing text', async ({ page, i
   expect(typeof isMobile).toBe('boolean')
 })
 
-test('Picking a text color with a collapsed caret colors the whole line and keeps it collapsed', async ({
+test('Picking a text color with a collapsed caret colors the whole line and keeps it collapsed @desktop', async ({
   page,
   isMobile,
 }) => {

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -23,6 +23,9 @@ export default defineConfig({
     },
     {
       name: 'Desktop Chrome',
+      // Platform-specific tests are tagged in their titles so they can be
+      // filtered before test fixtures and database isolation start.
+      grepInvert: /@mobile/,
       use: {
         ...devices['Desktop Chrome'],
         storageState: 'playwright/.auth/user.json',
@@ -31,6 +34,7 @@ export default defineConfig({
     },
     {
       name: 'Mobile Chrome',
+      grepInvert: /@desktop/,
       use: {
         ...devices['Pixel 7'],
         storageState: 'playwright/.auth/user.json',

--- a/src/components/EditorPanel.jsx
+++ b/src/components/EditorPanel.jsx
@@ -493,11 +493,32 @@ function EditorPanel({
       const blockId = getActiveBlockId()
       // Did the click land on a flagged misspelling? (desktop-only extension —
       // storage helper is absent on touch builds, so this is null there.)
+      //
+      // Resolve the word from the decoration element under the cursor via
+      // posAtDOM. Coordinate probing (posAtCoords) is unreliable on this app's
+      // window-scroll layout — a tall page pushes content past the viewport and
+      // the probe returns degenerate positions — so it's only a fallback for
+      // clicks that didn't land on a squiggle span.
       let misspelling = null
-      const coords = editor.view?.posAtCoords({ left: event.clientX, top: event.clientY })
       const getMisspellingAt = editor.storage?.spellcheck?.getMisspellingAt
-      if (coords?.pos !== undefined && typeof getMisspellingAt === 'function') {
-        misspelling = getMisspellingAt(coords.pos)
+      if (typeof getMisspellingAt === 'function') {
+        const targetEl =
+          event.target?.nodeType === Node.TEXT_NODE ? event.target.parentElement : event.target
+        const errorEl = targetEl?.closest?.('.spellcheck-error')
+        if (errorEl && editor.view) {
+          try {
+            const pos = editor.view.posAtDOM(errorEl.firstChild ?? errorEl, 0)
+            misspelling = getMisspellingAt(pos)
+          } catch {
+            misspelling = null
+          }
+        }
+        if (!misspelling) {
+          const coords = editor.view?.posAtCoords({ left: event.clientX, top: event.clientY })
+          if (coords?.pos !== undefined) {
+            misspelling = getMisspellingAt(coords.pos)
+          }
+        }
       }
       openContextMenu({ x: event.clientX, y: event.clientY, blockId, inTable, misspelling })
     }

--- a/src/extensions/spellcheck.js
+++ b/src/extensions/spellcheck.js
@@ -6,30 +6,8 @@ import { findMisspellings } from '../utils/spellcheckHelpers'
 
 export const spellcheckPluginKey = new PluginKey('spellcheck')
 
-// Re-scan ~400ms after the last edit so typing stays smooth. Scrolling reuses
-// the same debounce so a flick doesn't fire dozens of scans.
+// Re-scan ~400ms after the last edit so typing stays smooth.
 const SCAN_DEBOUNCE_MS = 400
-// Scan a little beyond the visible rect so words just off-screen are already
-// underlined by the time they scroll into view.
-const VIEWPORT_MARGIN_PX = 300
-
-// Resolve the document range currently visible in the editor (plus a margin),
-// so a long document only ever spell-checks the part the user can see.
-const computeVisibleRange = (view) => {
-  const doc = view.state.doc
-  const rect = view.dom.getBoundingClientRect()
-  const viewportBottom = window.innerHeight || document.documentElement.clientHeight || rect.bottom
-  const top = Math.max(rect.top, 0) - VIEWPORT_MARGIN_PX
-  const bottom = Math.min(rect.bottom, viewportBottom) + VIEWPORT_MARGIN_PX
-  // Probe slightly inside the left edge so we land on text, not padding.
-  const x = rect.left + Math.min(20, Math.max(1, rect.width / 2))
-  const start = view.posAtCoords({ left: x, top })
-  const end = view.posAtCoords({ left: x, top: bottom })
-  let from = start ? start.pos : 0
-  let to = end ? end.pos : doc.content.size
-  if (from > to) [from, to] = [to, from]
-  return { from: Math.max(0, from), to: Math.min(doc.content.size, to) }
-}
 
 // Walk the text nodes in `range` and collect a decoration for each misspelling.
 // `cache` memoizes per-word correctness so repeated words (and overlapping scans
@@ -67,31 +45,37 @@ const collectDecorations = (doc, range, checker, ignore, cache) => {
 const decorationSignature = (decorations) =>
   decorations.map((d) => `${d.from}:${d.to}`).join('|')
 
-// Owns the debounced scan loop, the per-word cache, and the scroll listener for
-// one editor view. Created in the plugin's view() lifecycle and torn down with
-// it. Kept out of plugin *state* so scanning (which dispatches its own
-// transaction) never recurses through the state apply path.
+// Owns the debounced scan loop and the per-word cache for one editor view.
+// Created in the plugin's view() lifecycle and torn down with it. Kept out of
+// plugin *state* so scanning (which dispatches its own transaction) never
+// recurses through the state apply path.
 const createScanController = (view, storage) => {
   let timer = null
   let destroyed = false
   let checker = null
   let lastSignature = null
-  let scrollEl = null
 
   const runScan = () => {
     timer = null
     if (destroyed || !checker) return
-    const range = computeVisibleRange(view)
+    // Scan the whole document. Coordinate-based "visible range" probing proved
+    // unreliable in this app: the window (not the editor) is the scroll surface,
+    // so a tall editor extends far past the viewport and posAtCoords returned
+    // degenerate positions, collapsing the range to nothing and leaving real
+    // misspellings unflagged. The per-word cache below keeps a full scan cheap —
+    // repeated words are only checked once, and edits reuse the cache.
+    const doc = view.state.doc
+    const range = { from: 0, to: doc.content.size }
     const decorations = collectDecorations(
-      view.state.doc,
+      doc,
       range,
       checker,
       storage.ignore,
       storage.cache,
     )
     const signature = decorationSignature(decorations)
-    // Skip the dispatch when scrolling reveals nothing new — avoids churning
-    // transactions (and the autosave/selection listeners) for no reason.
+    // Skip the dispatch when nothing changed — avoids churning transactions
+    // (and the autosave/selection listeners) for no reason.
     if (signature === lastSignature) return
     lastSignature = signature
     const decoSet = DecorationSet.create(view.state.doc, decorations)
@@ -106,8 +90,6 @@ const createScanController = (view, storage) => {
     if (immediate) lastSignature = null // force the next scan to dispatch
     timer = setTimeout(runScan, immediate ? 0 : SCAN_DEBOUNCE_MS)
   }
-
-  const onScroll = () => schedule()
 
   const start = () => {
     // Reuse the instance if another view already loaded it; otherwise trigger
@@ -128,14 +110,11 @@ const createScanController = (view, storage) => {
           }
         })
     }
-    scrollEl = view.dom.closest('.editor-panel') || view.dom.parentElement
-    scrollEl?.addEventListener('scroll', onScroll, { passive: true })
   }
 
   const destroy = () => {
     destroyed = true
     if (timer) clearTimeout(timer)
-    scrollEl?.removeEventListener('scroll', onScroll)
   }
 
   return { start, schedule, destroy }

--- a/src/stores/__tests__/editorUIStore.test.js
+++ b/src/stores/__tests__/editorUIStore.test.js
@@ -41,6 +41,33 @@ describe('useEditorUIStore - setToolbarExpanded', () => {
   })
 })
 
+describe('useEditorUIStore - setContextMenu', () => {
+  beforeEach(reset)
+
+  it('accepts a next value object', () => {
+    const next = { open: true, x: 10, y: 20, blockId: 'b1', inTable: false, misspelling: null }
+    useEditorUIStore.getState().setContextMenu(next)
+    expect(useEditorUIStore.getState().contextMenu).toEqual(next)
+  })
+
+  it('accepts a functional updater without storing the function', () => {
+    // Regression: the repositioning effect calls setContextMenu((prev) => ({...prev, x, y})).
+    // If the store stored the function itself, contextMenu.open became undefined and the
+    // menu silently closed the moment it needed repositioning.
+    useEditorUIStore.getState().setContextMenu({
+      open: true, x: 0, y: 0, blockId: 'b1', inTable: false, misspelling: { word: 'teh', from: 1, to: 4 },
+    })
+    useEditorUIStore.getState().setContextMenu((prev) => ({ ...prev, x: 99, y: 42 }))
+
+    const menu = useEditorUIStore.getState().contextMenu
+    expect(typeof menu).toBe('object')
+    expect(menu.open).toBe(true)
+    expect(menu.x).toBe(99)
+    expect(menu.y).toBe(42)
+    expect(menu.misspelling).toEqual({ word: 'teh', from: 1, to: 4 })
+  })
+})
+
 describe('useEditorUIStore - setAiDailyDate', () => {
   beforeEach(reset)
 

--- a/src/stores/editorUIStore.js
+++ b/src/stores/editorUIStore.js
@@ -81,7 +81,12 @@ export const useEditorUIStore = create((set, get) => ({
   contextMenu: { open: false, x: 0, y: 0, blockId: null, inTable: false, misspelling: null },
   submenuOpen: false,
   submenuDirection: 'right',
-  setContextMenu: (m) => set({ contextMenu: m }),
+  // Accepts either a next value or an updater function (prev) => next, matching
+  // React's setState convention. Several callers (closeContextMenu, the
+  // menu-repositioning effect) pass an updater; without this they would store the
+  // function itself as `contextMenu`, silently blanking the menu.
+  setContextMenu: (m) =>
+    set((state) => ({ contextMenu: typeof m === 'function' ? m(state.contextMenu) : m })),
   setSubmenuOpen: (v) => set({ submenuOpen: v }),
   setSubmenuDirection: (d) => set({ submenuDirection: d }),
 


### PR DESCRIPTION
## Summary

Follow-up to #190. In-app spell check was effectively broken on real tracker pages, in three related ways. Two stem from `view.posAtCoords()` being unreliable on this app's window-scroll layout (the window scrolls, not the editor panel, so a tall editor extends far past the viewport and coordinate probes return degenerate positions); the third is a store bug that closed the right-click menu.

All three were confirmed live against the running app.

### 1. Nothing got underlined (scanning)
The extension only scanned the range it computed as "visible" via top/bottom viewport probes. On a tall page those collapsed to `{0, 1}`, so real misspellings were never flagged. Forcing a full-document scan flagged **89 misspellings** instantly.

### 2. Right-click resolved the wrong position (menu lookup)
The right-click handler located the flagged word with `posAtCoords(clickX, clickY)`. Measured against a real tall tracker it resolved only **9 of 88** misspellings. Resolving from the clicked DOM element via `posAtDOM` resolves **88/88**.

### 3. Right-click menu closed itself when it needed repositioning (store)
Even with the correct word, most right-clicks showed nothing. Root cause (found with a stack-trace probe on the store setter): the menu-repositioning effect and `closeContextMenu` call `setContextMenu((prev) => ({ ...prev, x, y }))`, but the store did `set({ contextMenu: m })` unconditionally — storing the **function** as state, so `contextMenu.open` read `undefined` and the menu unmounted the same tick. Only right-clicks that opened without needing repositioning worked ("some work, some don't"). This was a latent bug affecting the Copy-link/Table menu too.

## Changes

- **Commit 1 — `test:`** e2e platform tagging (`@desktop`/`@mobile` + `grepInvert`) and a hardened DB-isolation fixture (save-status + in-flight write tracking instead of a 2s poll). Pre-existing local work, independent of the bug.
- **Commit 2 — `fix:`** full-document spell scan (`src/extensions/spellcheck.js`); per-word cache keeps it cheap; scroll listener removed.
- **Commit 3 — `fix:`** right-click resolves the word from the clicked `.spellcheck-error` element via `posAtDOM` (`src/components/EditorPanel.jsx`); `posAtCoords` kept only as a fallback.
- **Commit 4 — `fix:`** `setContextMenu` in `editorUIStore` now applies functional updaters (matching `setToolbarExpanded`/`setAiDailyDate`) instead of storing the function; adds store unit tests.

E2E: new tall-page (viewport-exceeding) fixture with a misspelling buried deep below the fold, asserting (a) it's flagged without scrolling and (b) a real right-click opens the menu with "Add to dictionary".

## Testing

- `npm run test:unit` → 482 passed (incl. new store regression tests); `npm run build` clean; ESLint clean on touched files
- Full flow verified live on the running app: right-click a misspelling inside a category table now shows suggestions (`ten, eh, meh, tea, tech` for "teh") + Add to dictionary / Ignore, above the existing Copy-link / Table items

🤖 Generated with [Claude Code](https://claude.com/claude-code)
