### PR TITLE
feat: slanted (italic) text caret on desktop and mobile

### DIFF
--- a/e2e/italic-caret.spec.js
+++ b/e2e/italic-caret.spec.js
@@ -1,0 +1,204 @@
+/**
+ * E2E regression test for the custom slanted (italic) caret.
+ *
+ * No browser slants the native text caret for italic text, so an ItalicCaret
+ * extension draws its own skewed caret element (`.italic-caret`) and hides the
+ * native one — but ONLY while italic is active on a collapsed caret. This test
+ * asserts the behavioral contract:
+ *   1. Caret inside italic text → a `.italic-caret` element is shown, skewed.
+ *   2. Caret in plain text → no custom caret (native caret used).
+ *   3. Arming italic on an empty spot (the original complaint) → caret appears.
+ *   4. A range selection → no stray custom caret.
+ *
+ * Runs on the Desktop Chrome project; the mechanic is desktop+mobile but the
+ * on-screen-keyboard interaction is verified on-device, not in emulation.
+ */
+
+import { test, expect } from './fixtures'
+import {
+  getSupabase,
+  createNotebook,
+  createSection,
+  createPage,
+  deleteNotebookById,
+  waitForApp,
+  ensureToolbarExpanded,
+} from './test-helpers'
+
+const ITALIC_WORD = 'Slanted'
+const PLAIN_WORD = 'Upright'
+
+const buildSeedContent = () => ({
+  type: 'doc',
+  content: [
+    {
+      type: 'paragraph',
+      attrs: { id: 'p-italic-existing' },
+      content: [{ type: 'text', marks: [{ type: 'italic' }], text: `${ITALIC_WORD} italic line` }],
+    },
+    {
+      type: 'paragraph',
+      attrs: { id: 'p-plain-existing' },
+      content: [{ type: 'text', text: `${PLAIN_WORD} plain line` }],
+    },
+    {
+      type: 'paragraph',
+      attrs: { id: 'p-empty-arm' },
+    },
+  ],
+})
+
+let seedIds = {}
+const seedLabel = `ITALIC-CARET-${Date.now()}`
+
+const placeCaretInWord = async (page, word) => {
+  const line = page.locator('.ProseMirror p', { hasText: word }).first()
+  await expect(line).toBeVisible()
+  await line.evaluate((node, word) => {
+    const walker = document.createTreeWalker(node, NodeFilter.SHOW_TEXT)
+    let textNode = walker.nextNode()
+    while (textNode && !(textNode.textContent ?? '').includes(word)) {
+      textNode = walker.nextNode()
+    }
+    if (!textNode) throw new Error(`Could not find text node containing "${word}"`)
+    const idx = (textNode.textContent ?? '').indexOf(word)
+    const caretAt = idx + Math.floor(word.length / 2)
+    const range = document.createRange()
+    range.setStart(textNode, caretAt)
+    range.collapse(true)
+    const selection = window.getSelection()
+    selection?.removeAllRanges()
+    selection?.addRange(range)
+    node.closest('.ProseMirror')?.focus()
+  }, word)
+}
+
+const placeCaretInEmptyParagraph = async (page, paragraphId) => {
+  await page.locator(`#${paragraphId}`).evaluate((paragraph) => {
+    const range = document.createRange()
+    range.selectNodeContents(paragraph)
+    range.collapse(true)
+    const selection = window.getSelection()
+    selection?.removeAllRanges()
+    selection?.addRange(range)
+    paragraph.closest('.ProseMirror')?.focus()
+  })
+}
+
+const selectWord = async (page, word) => {
+  const line = page.locator('.ProseMirror p', { hasText: word }).first()
+  await line.evaluate((node, word) => {
+    const walker = document.createTreeWalker(node, NodeFilter.SHOW_TEXT)
+    let textNode = walker.nextNode()
+    while (textNode && !(textNode.textContent ?? '').includes(word)) {
+      textNode = walker.nextNode()
+    }
+    if (!textNode) throw new Error(`Could not find text node containing "${word}"`)
+    const idx = (textNode.textContent ?? '').indexOf(word)
+    const range = document.createRange()
+    range.setStart(textNode, idx)
+    range.setEnd(textNode, idx + word.length)
+    const selection = window.getSelection()
+    selection?.removeAllRanges()
+    selection?.addRange(range)
+    node.closest('.ProseMirror')?.focus()
+  }, word)
+}
+
+// The custom caret lives on document.body; it is present but display:none when
+// inactive. Report whether it is actually shown, and its computed transform.
+const readCaretState = (page) =>
+  page.evaluate(() => {
+    const el = document.querySelector('.italic-caret')
+    if (!el) return { present: false, shown: false, transform: null }
+    const style = getComputedStyle(el)
+    return {
+      present: true,
+      shown: style.display !== 'none',
+      transform: style.transform,
+    }
+  })
+
+test.beforeAll(async () => {
+  const { client, userId } = await getSupabase()
+  const notebook = await createNotebook(client, userId, `${seedLabel} Notebook`)
+  const section = await createSection(client, userId, notebook.id, `${seedLabel} Section`, 0)
+  const page = await createPage(
+    client, userId, section.id, `${seedLabel} Page`, buildSeedContent(), 0,
+  )
+  seedIds = { notebook, section, page }
+})
+
+test.afterAll(async () => {
+  const { client } = await getSupabase()
+  await deleteNotebookById(client, seedIds.notebook?.id)
+})
+
+const seedHash = () =>
+  `#nb=${seedIds.notebook.id}&sec=${seedIds.section.id}&pg=${seedIds.page.id}`
+
+test('shows a slanted caret in italic text, hides it in plain text @desktop', async ({
+  page,
+  isMobile,
+}) => {
+  test.skip(isMobile, 'Desktop project owns the caret assertion; on-device covers touch/keyboard')
+
+  await waitForApp(page, seedHash(), { expectedText: ITALIC_WORD })
+  await page.waitForSelector('.ProseMirror[contenteditable="true"]', { timeout: 10000 })
+
+  // (1) Caret inside existing italic text → custom caret shown and skewed.
+  await placeCaretInWord(page, ITALIC_WORD)
+  await expect(async () => {
+    const state = await readCaretState(page)
+    expect(state.shown).toBe(true)
+    // A real skewX renders as a non-identity matrix (not 'none', not identity).
+    expect(state.transform).toContain('matrix')
+    expect(state.transform).not.toBe('matrix(1, 0, 0, 1, 0, 0)')
+  }).toPass({ timeout: 5000 })
+
+  // (2) Caret in plain text → custom caret hidden (native caret used).
+  await placeCaretInWord(page, PLAIN_WORD)
+  await expect(async () => {
+    expect((await readCaretState(page)).shown).toBe(false)
+  }).toPass({ timeout: 5000 })
+})
+
+test('arming italic on an empty spot shows the slanted caret immediately @desktop', async ({
+  page,
+  isMobile,
+}) => {
+  test.skip(isMobile, 'Desktop project owns the caret assertion; on-device covers touch/keyboard')
+
+  await waitForApp(page, seedHash(), { expectedText: ITALIC_WORD })
+  await page.waitForSelector('.ProseMirror[contenteditable="true"]', { timeout: 10000 })
+
+  await placeCaretInEmptyParagraph(page, 'p-empty-arm')
+  // Native caret before arming italic — no custom caret yet.
+  await expect(async () => {
+    expect((await readCaretState(page)).shown).toBe(false)
+  }).toPass({ timeout: 5000 })
+
+  await ensureToolbarExpanded(page)
+  await page.getByRole('button', { name: 'Italic', exact: true }).click()
+
+  // The exact original complaint: caret should go slanted with nothing typed.
+  await expect(async () => {
+    const state = await readCaretState(page)
+    expect(state.shown).toBe(true)
+    expect(state.transform).toContain('matrix')
+  }).toPass({ timeout: 5000 })
+})
+
+test('no stray custom caret during a range selection @desktop', async ({ page, isMobile }) => {
+  test.skip(isMobile, 'Desktop project owns the caret assertion; on-device covers touch/keyboard')
+
+  await waitForApp(page, seedHash(), { expectedText: ITALIC_WORD })
+  await page.waitForSelector('.ProseMirror[contenteditable="true"]', { timeout: 10000 })
+
+  // Select a range of italic text — the native selection UI owns this, so the
+  // custom (collapsed-only) caret must not appear.
+  await selectWord(page, ITALIC_WORD)
+  await expect(async () => {
+    expect((await readCaretState(page)).shown).toBe(false)
+  }).toPass({ timeout: 5000 })
+})

--- a/e2e/test-helpers.js
+++ b/e2e/test-helpers.js
@@ -462,6 +462,33 @@ const waitForExpectedEditor = async (
   }
 }
 
+const closeMobileNavigationDrawerIfOpen = async (page) => {
+  const backdrop = page.getByRole('button', { name: 'Close navigation drawer' })
+  if (!(await backdrop.isVisible().catch(() => false))) return
+
+  const box = await backdrop.boundingBox()
+  if (!box) throw new Error('Mobile navigation backdrop has no clickable bounds')
+
+  // The drawer covers most of the backdrop. Tap its exposed right edge rather
+  // than the covered center that locator.click() chooses by default.
+  await backdrop.click({
+    position: {
+      x: Math.max(1, box.width - 2),
+      y: Math.max(1, box.height / 2),
+    },
+  })
+  await expect(backdrop).toBeHidden({ timeout: 5000 })
+}
+
+const waitForExpectedEditorReady = async (page, options) => {
+  await waitForExpectedEditor(page, options)
+  // The fallback navigation path may open the mobile drawer and then discover
+  // that the requested page is already active. In that case no tree-item click
+  // runs to close the drawer, leaving it over the editor and blocking scroll or
+  // toolbar interactions in the test that follows.
+  await closeMobileNavigationDrawerIfOpen(page)
+}
+
 const waitForExpectedNavigationTarget = async (page, treeTitles) => {
   if (!treeTitles) return
 
@@ -522,14 +549,14 @@ export const waitForApp = async (page, hash = '/', { expectedText, waitForEditor
       await waitForExpectedNavigationTarget(page, treeTitles)
       return
     }
-    await waitForExpectedEditor(page, { expectedPageTitle, expectedText, timeout: 5000 })
+    await waitForExpectedEditorReady(page, { expectedPageTitle, expectedText, timeout: 5000 })
   } catch (error) {
     if (!hash || hash === '/') {
       const fallbackHash = await findFallbackPageHash()
       if (!fallbackHash) throw error
       await loadRootWorkspace()
       await navigateViaHashChange(page, fallbackHash)
-      await waitForExpectedEditor(page)
+      await waitForExpectedEditorReady(page)
       return
     }
 
@@ -552,12 +579,12 @@ export const waitForApp = async (page, hash = '/', { expectedText, waitForEditor
       if (treeTitles.pageTitle) {
         await clickTreeItemByTitle(page, '.tree-node-page', treeTitles.pageTitle)
       }
-      await waitForExpectedEditor(page, { expectedPageTitle, expectedText })
+      await waitForExpectedEditorReady(page, { expectedPageTitle, expectedText })
       return
     }
 
     await navigateViaHashChange(page, navigationHash)
-    await waitForExpectedEditor(page, { expectedPageTitle, expectedText })
+    await waitForExpectedEditorReady(page, { expectedPageTitle, expectedText })
   }
 }
 
@@ -580,8 +607,7 @@ export const ensureNavigationVisible = async (page) => {
 export const ensureNavigationHidden = async (page) => {
   const backdrop = page.getByRole('button', { name: 'Close navigation drawer' })
   if (await backdrop.isVisible().catch(() => false)) {
-    await backdrop.evaluate((el) => el.click())
-    await expect(backdrop).toBeHidden({ timeout: 5000 })
+    await closeMobileNavigationDrawerIfOpen(page)
     return
   }
 

--- a/src/extensions/italicCaret.js
+++ b/src/extensions/italicCaret.js
@@ -1,0 +1,139 @@
+import { Extension } from '@tiptap/core'
+import { Plugin, PluginKey } from '@tiptap/pm/state'
+import { shouldShowItalicCaret, caretStyleFromRect } from '../utils/italicCaret'
+
+// No browser slants the native text caret for italic — it is always a vertical
+// bar and no CSS/font property changes that. So when italic is active we hide
+// the native caret (via `.italic-caret-active { caret-color: transparent }`)
+// and draw our own skewed caret element instead. Everywhere else the native
+// caret stays untouched, keeping the risk contained to the italic-only path.
+//
+// The feature runs on desktop AND touch — it is deliberately NOT gated on
+// pointer type (that would disable it on mobile, where it was verified to work).
+
+const ITALIC_CARET_ACTIVE_CLASS = 'italic-caret-active'
+const ITALIC_CARET_CLASS = 'italic-caret'
+
+export const ItalicCaret = Extension.create({
+  name: 'italicCaret',
+
+  addProseMirrorPlugins() {
+    // Captured here (not inside the plugin view) so the view has the Tiptap
+    // editor for `isActive('italic')`/`isFocused` — the DOM cannot answer the
+    // armed-on-empty-spot case (storedMarks italic, but `<p><br></p>`), so
+    // detection must come from editor state.
+    const editor = this.editor
+
+    return [
+      new Plugin({
+        key: new PluginKey('italicCaret'),
+        view: (view) => new ItalicCaretView(view, editor),
+      }),
+    ]
+  },
+})
+
+class ItalicCaretView {
+  constructor(view, editor) {
+    this.view = view
+    this.editor = editor
+    this.active = false
+
+    // The caret is `position: fixed` (viewport coords), so it lives on
+    // document.body rather than inside the editor's scroll container.
+    this.caret = document.createElement('div')
+    this.caret.className = ITALIC_CARET_CLASS
+    this.caret.setAttribute('aria-hidden', 'true')
+    this.caret.style.display = 'none'
+    document.body.appendChild(this.caret)
+
+    // Bound so add/removeEventListener reference the same function.
+    this.handleReposition = () => this.render()
+    this.handleFocus = () => this.render()
+
+    // Recompute after a programmatic focus: `editor.isFocused` can read false
+    // for one tick right after `.focus()`, which a transaction-only update would
+    // miss. The focus event fires once the state settles.
+    editor.on('focus', this.handleFocus)
+    editor.on('blur', this.handleFocus)
+
+    // Capture-phase so it catches BOTH the nested desktop scroller
+    // (section.editor-panel) and the mobile window scroll with one listener.
+    window.addEventListener('scroll', this.handleReposition, true)
+    window.addEventListener('resize', this.handleReposition)
+
+    // Virtual keyboard / mobile URL-bar move the visual viewport without a
+    // document scroll; track those so the fixed caret stays glued to the text.
+    this.visualViewport = window.visualViewport ?? null
+    if (this.visualViewport) {
+      this.visualViewport.addEventListener('resize', this.handleReposition)
+      this.visualViewport.addEventListener('scroll', this.handleReposition)
+    }
+
+    this.render()
+  }
+
+  update() {
+    // Fires on every transaction (selection changes, typing, italic toggle).
+    this.render()
+  }
+
+  render() {
+    const { editor, view } = this
+    if (editor.isDestroyed) return this.hide()
+
+    const state = view.state
+    const show = shouldShowItalicCaret({
+      focused: editor.isFocused,
+      selectionEmpty: state.selection.empty,
+      italicActive: editor.isActive('italic'),
+    })
+
+    if (!show) return this.hide()
+
+    // coordsAtPos returns a solid non-zero rect for every block type incl.
+    // empty paragraph / table cell / heading (collapsed DOM ranges do not).
+    let coords
+    try {
+      coords = view.coordsAtPos(state.selection.from)
+    } catch {
+      return this.hide()
+    }
+
+    const style = caretStyleFromRect(coords)
+    this.caret.style.left = `${style.left}px`
+    this.caret.style.top = `${style.top}px`
+    this.caret.style.height = `${style.height}px`
+    this.caret.style.transform = style.transform
+    this.show()
+  }
+
+  show() {
+    if (!this.active) {
+      this.active = true
+      this.view.dom.classList.add(ITALIC_CARET_ACTIVE_CLASS)
+    }
+    this.caret.style.display = 'block'
+  }
+
+  hide() {
+    if (this.active) {
+      this.active = false
+      this.view.dom.classList.remove(ITALIC_CARET_ACTIVE_CLASS)
+    }
+    this.caret.style.display = 'none'
+  }
+
+  destroy() {
+    this.editor.off('focus', this.handleFocus)
+    this.editor.off('blur', this.handleFocus)
+    window.removeEventListener('scroll', this.handleReposition, true)
+    window.removeEventListener('resize', this.handleReposition)
+    if (this.visualViewport) {
+      this.visualViewport.removeEventListener('resize', this.handleReposition)
+      this.visualViewport.removeEventListener('scroll', this.handleReposition)
+    }
+    this.view.dom.classList.remove(ITALIC_CARET_ACTIVE_CLASS)
+    this.caret.remove()
+  }
+}

--- a/src/hooks/useEditorSetup.js
+++ b/src/hooks/useEditorSetup.js
@@ -24,6 +24,7 @@ import {
   TableHeaderWithBackground,
 } from '../extensions/tableExtensions'
 import { EnsureNodeIds, SecureImage, InternalLink } from '../extensions/editorExtensions'
+import { ItalicCaret } from '../extensions/italicCaret'
 import {
   LinkShortcut,
   ArrowMoveToLineEnd,
@@ -137,6 +138,7 @@ export const useEditorSetup = ({
           placeholder: 'Start writing your tracker...',
         }),
         HighlightPreserve,
+        ItalicCaret,
         // onImageFile only fires inside ProseMirror paste/drop handlers (user
         // events), never during render, so the ref read is safe to defer.
         // eslint-disable-next-line react-hooks/refs

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -3,4 +3,5 @@
 @import './toolbar.css';
 @import './menus-modals.css';
 @import './editor.css';
+@import './italic-caret.css';
 @import './responsive.css';

--- a/src/styles/italic-caret.css
+++ b/src/styles/italic-caret.css
@@ -1,0 +1,37 @@
+/* Custom italic caret (see src/extensions/italicCaret.js).
+   Only engaged while italic is active — normal typing keeps the native caret. */
+
+/* Hide the native (always-vertical) caret only while our slanted one is shown. */
+.ProseMirror.italic-caret-active {
+  caret-color: transparent;
+}
+
+.italic-caret {
+  position: fixed;
+  width: 2px;
+  background: var(--text);
+  /* Pivot the skew about the baseline so it leans like the glyphs above it. */
+  transform-origin: bottom;
+  pointer-events: none;
+  /* Sits above editor content but below toolbar/menus/modals. */
+  z-index: 5;
+  will-change: transform, top, left, height;
+  animation: italic-caret-blink 1.06s steps(1) infinite;
+}
+
+@keyframes italic-caret-blink {
+  0%,
+  50% {
+    opacity: 1;
+  }
+  50.01%,
+  100% {
+    opacity: 0;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .italic-caret {
+    animation: none;
+  }
+}

--- a/src/utils/__tests__/italicCaret.test.js
+++ b/src/utils/__tests__/italicCaret.test.js
@@ -1,0 +1,62 @@
+import { describe, it, expect } from 'vitest'
+import {
+  shouldShowItalicCaret,
+  caretStyleFromRect,
+  ITALIC_CARET_SKEW_DEG,
+} from '../italicCaret'
+
+describe('shouldShowItalicCaret', () => {
+  it('shows the caret when focused, collapsed, and italic is active', () => {
+    expect(
+      shouldShowItalicCaret({ focused: true, selectionEmpty: true, italicActive: true }),
+    ).toBe(true)
+  })
+
+  it('hides the caret when the editor is not focused', () => {
+    expect(
+      shouldShowItalicCaret({ focused: false, selectionEmpty: true, italicActive: true }),
+    ).toBe(false)
+  })
+
+  it('hides the caret when the selection is a range (not collapsed)', () => {
+    expect(
+      shouldShowItalicCaret({ focused: true, selectionEmpty: false, italicActive: true }),
+    ).toBe(false)
+  })
+
+  it('hides the caret when italic is not active', () => {
+    expect(
+      shouldShowItalicCaret({ focused: true, selectionEmpty: true, italicActive: false }),
+    ).toBe(false)
+  })
+
+  it('does not gate on pointer type — extra fields are ignored', () => {
+    expect(
+      shouldShowItalicCaret({
+        focused: true,
+        selectionEmpty: true,
+        italicActive: true,
+        pointerFine: false,
+      }),
+    ).toBe(true)
+  })
+
+  it('coerces missing fields to false rather than throwing', () => {
+    expect(shouldShowItalicCaret({})).toBe(false)
+  })
+})
+
+describe('caretStyleFromRect', () => {
+  it('derives height from the rect and positions from top/left', () => {
+    const style = caretStyleFromRect({ left: 120, top: 200, bottom: 219 })
+    expect(style.left).toBe(120)
+    expect(style.top).toBe(200)
+    expect(style.height).toBe(19)
+  })
+
+  it('applies a negative skewX transform matching the measured italic angle', () => {
+    const style = caretStyleFromRect({ left: 0, top: 0, bottom: 22 })
+    expect(style.transform).toBe(`skewX(-${ITALIC_CARET_SKEW_DEG}deg)`)
+    expect(style.height).toBe(22)
+  })
+})

--- a/src/utils/italicCaret.js
+++ b/src/utils/italicCaret.js
@@ -1,0 +1,44 @@
+// Pure decision + geometry helpers for the custom italic caret. Kept free of
+// ProseMirror/DOM so the plugin glue stays thin and these stay unit-testable.
+
+// Measured slant of Instrument Sans italic (canvas measurement = 13.1deg). The
+// caret leans by the same angle so it reads as part of the italic text.
+export const ITALIC_CARET_SKEW_DEG = 13
+
+/**
+ * Decide whether to draw the custom (slanted) caret in place of the native one.
+ * True only for a focused, collapsed caret sitting in italic-active context.
+ * A range selection (selectionEmpty === false) always yields false so the
+ * native selection UI is never shadowed by a stray caret.
+ *
+ * Note: pointer type is intentionally NOT a gate — the feature runs on desktop
+ * and touch alike (gating on `pointer: fine` would wrongly disable it on
+ * mobile, where the caret was verified to position and slant correctly).
+ *
+ * @param {{ focused: boolean, selectionEmpty: boolean, italicActive: boolean }} params
+ * @returns {boolean}
+ */
+export function shouldShowItalicCaret({ focused, selectionEmpty, italicActive }) {
+  return Boolean(focused) && Boolean(selectionEmpty) && Boolean(italicActive)
+}
+
+/**
+ * Build the inline style values for the caret element from a ProseMirror
+ * `coordsAtPos` rect. `coordsAtPos` returns a solid non-zero rect for every
+ * block type (empty paragraph, table cell, heading, body), unlike collapsed DOM
+ * ranges which report zero height on empty lines.
+ *
+ * Coordinates are viewport-relative, matching `position: fixed`.
+ *
+ * @param {{ left: number, top: number, bottom: number }} rect
+ * @returns {{ left: number, top: number, height: number, transform: string }}
+ */
+export function caretStyleFromRect(rect) {
+  const height = rect.bottom - rect.top
+  return {
+    left: rect.left,
+    top: rect.top,
+    height,
+    transform: `skewX(-${ITALIC_CARET_SKEW_DEG}deg)`,
+  }
+}


### PR DESCRIPTION
## Problem

Reported: *"On desktop when I toggle italics on, the cursor does not go slanted."*

No browser slants the native text caret for italic — it's always a vertical bar, and there's no CSS/font property that changes it (confirmed empirically; `font-synthesis` is irrelevant). Apps that show a slanted caret (Google Docs/Word) don't use `contenteditable` — they draw their own caret. So we do too.

## Approach

A new `ItalicCaret` Tiptap extension draws our own caret element, but **only swaps in the custom caret when italic is active** — everywhere else the native caret is untouched, so the risk is contained to the italic-only path. Works on **desktop and mobile**.

- **Detection uses editor state, not the DOM.** In the armed-on-empty-spot case (toggle italic on an empty paragraph before typing — the exact original complaint), `editor.isActive('italic')` is `true` while the DOM is just `<p><br></p>` with no `<em>`. Shows only when `isFocused && selection.empty && isActive('italic')`.
- **Position from `view.coordsAtPos(selection.from)`** — returns a solid rect for every block type (empty paragraph, table cell, heading, body); collapsed DOM ranges report zero height on empty lines.
- **`position: fixed`** caret on `document.body`, `transform: skewX(-13deg)` (measured Instrument Sans italic angle = 13.1°), `caret-color: transparent` scoped to `.italic-caret-active` to hide the native caret only while ours shows.
- **Recompute triggers:** transaction, editor `focus`/`blur`, capture-phase `window` scroll (covers desktop `.editor-panel` and mobile window scroll), `resize`, and `visualViewport` `resize`/`scroll` (keyboard show/hide). All listeners cleaned up in the plugin view's `destroy()`.
- **Not gated on pointer type** — gating on `pointer: fine` would wrongly disable it on mobile.
- Pure decision/geometry helpers (`shouldShowItalicCaret`, `caretStyleFromRect`) extracted to `src/utils/italicCaret.js` so the ProseMirror-view glue stays thin.

## Changes

- `src/extensions/italicCaret.js` — the extension + plugin view
- `src/utils/italicCaret.js` — pure helpers
- `src/styles/italic-caret.css` — scoped native-caret hiding + skewed blink caret (respects `prefers-reduced-motion`); wired into `index.css`
- `src/hooks/useEditorSetup.js` — registers the extension
- `e2e/test-helpers.js` — `waitForApp` now closes a stray mobile nav drawer left open by the fallback nav path, which otherwise blocks scroll/toolbar interactions in the tests that follow

## Test plan

**Automated**
- Unit (Vitest): truth table for `shouldShowItalicCaret` + geometry for `caretStyleFromRect` — 490/490 pass
- E2E (Playwright, Desktop Chrome): caret shown+skewed in italic text, hidden in plain text, appears when arming italic on an empty spot, absent during range selection

**Manual — desktop live app (all passed)**
- Slant in italic text; native upright in plain text
- Arm italic on an empty spot → slanted immediately (the original complaint)
- Toggle off → native; range selection → no stray caret
- Scroll → caret tracks exactly (−120px = −120px)
- Blur → hides; heading / list item / empty paragraph positioned correctly

**Manual — real Android device, on-screen keyboard (all passed)**
- Caret pixel-aligned on italic text with keyboard open (`delta 0,0`; visual viewport `821→493`, page scrolled to keep the line above the keyboard)
- Combined worst case — keyboard open **+ live finger-scroll** (210px) — caret stayed glued, zero drift
- Verified by injecting the real caret logic into the deployed PWA over an adb-forwarded CDP socket and driving it on-device

## Notes / risks
- Only the italic context swaps the caret, so a bug can at worst affect the caret while italic is active, never normal typing.
- Heading font (Satoshi) may have a slightly different italic angle than the 13° body value; acceptable for v1 (single fixed angle).