### PR TITLE
fix: make the PWA update Refresh button actually refresh

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -19,6 +19,7 @@ import { registerDeepLinkSelectionApplier } from './utils/navigationHelpers'
 import { applyDeepLinkSelection } from './utils/deepLinkSelection'
 import { pickPostDeleteTarget } from './utils/navigationHistoryHelpers'
 import { SECTION_PAGE_STATUS, getSectionPageEntry } from './utils/sectionPages'
+import { setBeforeReloadHandler, isIntentionalReload } from './utils/reloadCoordinator'
 import {
   readStoredSidebarCollapsed,
   readStoredSelection,
@@ -558,6 +559,10 @@ function App() {
   useEffect(() => {
     const handleBeforeUnload = (event) => {
       flushAllPendingSaves()
+      // A user-clicked "Refresh" on the PWA update banner is explicit consent
+      // to leave. Prompting there strands them on the old build with a dead
+      // banner; the flush above (plus localStorage drafts) covers the writes.
+      if (isIntentionalReload()) return
       if (!isSaving) return
       event.preventDefault()
       event.returnValue = ''
@@ -575,7 +580,11 @@ function App() {
     window.addEventListener('beforeunload', handleBeforeUnload)
     document.addEventListener('visibilitychange', handleVisibilityChange)
     window.addEventListener('pagehide', handlePageHide)
+    // The update banner lives outside this React tree (main.jsx), so it reaches
+    // the save flush through the coordinator module rather than props.
+    const unsubscribeBeforeReload = setBeforeReloadHandler(flushAllPendingSaves)
     return () => {
+      unsubscribeBeforeReload()
       window.removeEventListener('beforeunload', handleBeforeUnload)
       document.removeEventListener('visibilitychange', handleVisibilityChange)
       window.removeEventListener('pagehide', handlePageHide)

--- a/src/components/PwaUpdatePrompt.jsx
+++ b/src/components/PwaUpdatePrompt.jsx
@@ -1,7 +1,12 @@
 import { useEffect, useRef, useState } from 'react'
 import { useRegisterSW } from 'virtual:pwa-register/react'
 import { shouldRunResume } from '../utils/resumeThrottle'
-import { shouldCheckForUpdate } from '../utils/pwaUpdate'
+import {
+  shouldCheckForUpdate,
+  resolveRefreshAction,
+  isUpdateBannerStale,
+} from '../utils/pwaUpdate'
+import { beginIntentionalReload } from '../utils/reloadCoordinator'
 import '../styles/pwa.css'
 
 // Cadence for asking the browser "is there a newer service worker?".
@@ -9,6 +14,9 @@ const UPDATE_CHECK_INTERVAL_MS = 60 * 60 * 1000 // hourly
 // Returning to the foreground fires visibilitychange + online together; collapse
 // that burst into a single check (same throttle useResumeRefresh uses).
 const RESUME_MIN_INTERVAL_MS = 1500
+// If skipWaiting doesn't produce a reload in this long, reload ourselves. Covers
+// a missed `controlling` event or an activation that raced ahead of the click.
+const RELOAD_FALLBACK_MS = 2000
 
 /**
  * Surfaces a small, non-modal "New version available" banner when a new build
@@ -23,7 +31,14 @@ export default function PwaUpdatePrompt() {
   // Local "defer for later" state. `needRefresh` stays true; this only controls
   // whether we show the full banner or the compact pill.
   const [collapsed, setCollapsed] = useState(false)
+  // A Refresh is in flight — the button reads as busy and can't be double-fired.
+  const [refreshing, setRefreshing] = useState(false)
+  // The banner turned out to be advertising an update that already landed.
+  const [staleDismissed, setStaleDismissed] = useState(false)
   const lastResumeAtRef = useRef(null)
+  // The live registration. `onRegisteredSW`'s `r` is otherwise trapped in that
+  // closure, and refresh() needs to inspect `waiting` to decide what to do.
+  const registrationRef = useRef(null)
 
   const {
     needRefresh: [needRefresh],
@@ -31,6 +46,7 @@ export default function PwaUpdatePrompt() {
   } = useRegisterSW({
     onRegisteredSW(swUrl, r) {
       if (!r) return
+      registrationRef.current = r
 
       // Ask the server for the SW script; if it changed, workbox installs the
       // new SW into the `waiting` state, which flips `needRefresh` -> true.
@@ -69,19 +85,51 @@ export default function PwaUpdatePrompt() {
     },
   })
 
-  // Re-surface a deferred update the next time the tab is refocused: a gentle
-  // reminder, never intrusive mid-edit.
+  // On refocus: re-surface a deferred update (a gentle reminder, never
+  // intrusive mid-edit) and re-validate the banner against reality —
+  // `needRefresh` is never lowered by vite-plugin-pwa once raised, so a worker
+  // that activated on its own would otherwise leave a phantom banner forever.
   useEffect(() => {
     const handleVisibility = () => {
-      if (document.visibilityState === 'visible' && needRefresh) setCollapsed(false)
+      if (document.visibilityState !== 'visible' || !needRefresh) return
+      setCollapsed(false)
+      const r = registrationRef.current
+      // Recomputed (not latched) so a genuinely new update un-dismisses itself.
+      setStaleDismissed(
+        isUpdateBannerStale({
+          hasWaiting: !!r?.waiting,
+          hasInstalling: !!r?.installing,
+          isControlled: !!navigator.serviceWorker?.controller,
+        }),
+      )
     }
     document.addEventListener('visibilitychange', handleVisibility)
     return () => document.removeEventListener('visibilitychange', handleVisibility)
   }, [needRefresh])
 
-  if (!needRefresh) return null
+  if (!needRefresh || staleDismissed) return null
 
-  const refresh = () => updateServiceWorker(true)
+  const refresh = () => {
+    if (refreshing) return
+    setRefreshing(true)
+
+    // Flush pending saves and tell App's beforeunload guard that this unload is
+    // wanted — otherwise it can raise "Leave site?" and cancelling it strands
+    // the page on the old build with a dead banner.
+    beginIntentionalReload()
+
+    const action = resolveRefreshAction({ hasWaiting: !!registrationRef.current?.waiting })
+    if (action === 'reload') {
+      // Nothing waiting: the new build already activated, so just reload into it.
+      window.location.reload()
+      return
+    }
+
+    updateServiceWorker(true)
+    // Belt and braces: the reload above is only a side effect of the
+    // `controlling` event. If that never lands, do it ourselves.
+    setTimeout(() => window.location.reload(), RELOAD_FALLBACK_MS)
+  }
 
   if (collapsed) {
     return (
@@ -89,9 +137,10 @@ export default function PwaUpdatePrompt() {
         type="button"
         className="pwa-update-pill"
         onClick={refresh}
+        disabled={refreshing}
         aria-label="Update ready — refresh to load the new version"
       >
-        Update ready <span aria-hidden="true">⟳</span>
+        {refreshing ? 'Refreshing…' : 'Update ready'} <span aria-hidden="true">⟳</span>
       </button>
     )
   }
@@ -107,8 +156,13 @@ export default function PwaUpdatePrompt() {
     >
       <span className="pwa-update-text">A new version is available.</span>
       <div className="pwa-update-actions">
-        <button type="button" className="pwa-update-refresh" onClick={refresh}>
-          Refresh
+        <button
+          type="button"
+          className="pwa-update-refresh"
+          onClick={refresh}
+          disabled={refreshing}
+        >
+          {refreshing ? 'Refreshing…' : 'Refresh'}
         </button>
         <button
           type="button"

--- a/src/styles/pwa.css
+++ b/src/styles/pwa.css
@@ -60,6 +60,16 @@
   background: var(--accent-dark);
 }
 
+/* Busy state while a refresh is in flight — reads as inert, no hover shift. */
+.pwa-update-refresh:disabled,
+.pwa-update-refresh:disabled:hover,
+.pwa-update-pill:disabled,
+.pwa-update-pill:disabled:hover {
+  background: var(--surface-raised);
+  color: var(--text-muted);
+  cursor: default;
+}
+
 .pwa-update-dismiss {
   display: flex;
   align-items: center;

--- a/src/utils/__tests__/pwaUpdate.test.js
+++ b/src/utils/__tests__/pwaUpdate.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { shouldCheckForUpdate } from '../pwaUpdate'
+import { shouldCheckForUpdate, resolveRefreshAction, isUpdateBannerStale } from '../pwaUpdate'
 
 describe('shouldCheckForUpdate', () => {
   const base = { hasRegistration: true, installing: false, onLine: true }
@@ -18,5 +18,37 @@ describe('shouldCheckForUpdate', () => {
 
   it('skips when the browser is offline', () => {
     expect(shouldCheckForUpdate({ ...base, onLine: false })).toBe(false)
+  })
+})
+
+describe('resolveRefreshAction', () => {
+  it('messages the waiting worker when one is waiting', () => {
+    expect(resolveRefreshAction({ hasWaiting: true })).toBe('skip-waiting')
+  })
+
+  it('falls back to a plain reload when nothing is waiting', () => {
+    // The dead-button case: the worker already activated, so skipWaiting would
+    // be a silent no-op — reloading is what actually lands the new build.
+    expect(resolveRefreshAction({ hasWaiting: false })).toBe('reload')
+  })
+})
+
+describe('isUpdateBannerStale', () => {
+  const base = { hasWaiting: false, hasInstalling: false, isControlled: true }
+
+  it('is stale when nothing is waiting or installing and the page is controlled', () => {
+    expect(isUpdateBannerStale(base)).toBe(true)
+  })
+
+  it('is not stale while a worker is waiting to activate', () => {
+    expect(isUpdateBannerStale({ ...base, hasWaiting: true })).toBe(false)
+  })
+
+  it('is not stale while a new worker is installing', () => {
+    expect(isUpdateBannerStale({ ...base, hasInstalling: true })).toBe(false)
+  })
+
+  it('is not stale when the page has no controlling worker yet', () => {
+    expect(isUpdateBannerStale({ ...base, isControlled: false })).toBe(false)
   })
 })

--- a/src/utils/__tests__/reloadCoordinator.test.js
+++ b/src/utils/__tests__/reloadCoordinator.test.js
@@ -1,0 +1,73 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import {
+  setBeforeReloadHandler,
+  beginIntentionalReload,
+  isIntentionalReload,
+  __resetForTests,
+} from '../reloadCoordinator'
+
+describe('reloadCoordinator', () => {
+  beforeEach(() => {
+    __resetForTests()
+  })
+
+  it('starts with the latch down', () => {
+    expect(isIntentionalReload()).toBe(false)
+  })
+
+  it('invokes the registered handler and latches the flag', () => {
+    const handler = vi.fn()
+    setBeforeReloadHandler(handler)
+
+    beginIntentionalReload()
+
+    expect(handler).toHaveBeenCalledTimes(1)
+    expect(isIntentionalReload()).toBe(true)
+  })
+
+  it('keeps the latch up once raised', () => {
+    beginIntentionalReload()
+    expect(isIntentionalReload()).toBe(true)
+    expect(isIntentionalReload()).toBe(true)
+  })
+
+  it('is a no-op (not a throw) when no handler is registered', () => {
+    expect(() => beginIntentionalReload()).not.toThrow()
+    expect(isIntentionalReload()).toBe(true)
+  })
+
+  it('detaches the handler on unsubscribe', () => {
+    const handler = vi.fn()
+    const unsubscribe = setBeforeReloadHandler(handler)
+
+    unsubscribe()
+    beginIntentionalReload()
+
+    expect(handler).not.toHaveBeenCalled()
+  })
+
+  it('does not let a stale unsubscribe clobber a newer handler', () => {
+    const first = vi.fn()
+    const second = vi.fn()
+    const unsubscribeFirst = setBeforeReloadHandler(first)
+    setBeforeReloadHandler(second)
+
+    unsubscribeFirst()
+    beginIntentionalReload()
+
+    expect(first).not.toHaveBeenCalled()
+    expect(second).toHaveBeenCalledTimes(1)
+  })
+
+  it('__resetForTests clears both the handler and the latch', () => {
+    const handler = vi.fn()
+    setBeforeReloadHandler(handler)
+    beginIntentionalReload()
+
+    __resetForTests()
+
+    expect(isIntentionalReload()).toBe(false)
+    beginIntentionalReload()
+    expect(handler).toHaveBeenCalledTimes(1) // only the pre-reset call
+  })
+})

--- a/src/utils/pwaUpdate.js
+++ b/src/utils/pwaUpdate.js
@@ -19,3 +19,39 @@ export function shouldCheckForUpdate({ hasRegistration, installing, onLine }) {
   if (!onLine) return false
   return true
 }
+
+/**
+ * Decide what a Refresh click should actually do.
+ *
+ * `updateServiceWorker(true)` only messages the *waiting* worker to skip
+ * waiting; the reload is a side effect of the resulting `controlling` event.
+ * If nothing is waiting (the worker already activated on its own, or an
+ * earlier reload was cancelled) that call is a silent no-op and the button
+ * appears dead. In that case the new build is already precached, so a plain
+ * reload is both correct and sufficient.
+ *
+ * @param {{ hasWaiting: boolean }} state
+ * @returns {'skip-waiting' | 'reload'}
+ */
+export function resolveRefreshAction({ hasWaiting }) {
+  return hasWaiting ? 'skip-waiting' : 'reload'
+}
+
+/**
+ * Is the update banner advertising an update that has already landed?
+ *
+ * vite-plugin-pwa never re-validates `needRefresh` against the registration,
+ * so it can stay true forever after the waiting worker activates without us.
+ * That's stale only when there is genuinely nothing left to activate:
+ * nothing waiting, nothing installing, and the page is already controlled by
+ * an active worker.
+ *
+ * @param {{ hasWaiting: boolean, hasInstalling: boolean, isControlled: boolean }} state
+ * @returns {boolean}
+ */
+export function isUpdateBannerStale({ hasWaiting, hasInstalling, isControlled }) {
+  if (hasWaiting) return false
+  if (hasInstalling) return false
+  if (!isControlled) return false
+  return true
+}

--- a/src/utils/reloadCoordinator.js
+++ b/src/utils/reloadCoordinator.js
@@ -1,0 +1,57 @@
+/**
+ * Tiny coordination point between the PWA update banner and the app's
+ * unsaved-work guard.
+ *
+ * PwaUpdatePrompt is rendered as a *sibling* of App (see main.jsx) so it stays
+ * alive even if App crashes into the error boundary. That means there is no
+ * shared React tree to pass a callback through — this module is the seam.
+ *
+ * Two jobs:
+ *   1. App registers a "we're about to reload on purpose" handler (flushing
+ *      pending saves) that the banner can invoke before it reloads.
+ *   2. The latch tells App's `beforeunload` handler that this unload is
+ *      user-intended, so it must not turn it into a native "Leave site?"
+ *      prompt — cancelling that prompt is exactly what leaves the update
+ *      banner permanently dead.
+ *
+ * Framework-free and pure-ish on purpose so it can be unit-tested directly.
+ */
+
+let beforeReloadHandler = null
+let intentional = false
+
+/**
+ * Register the callback to run immediately before an intentional reload.
+ * Only one handler is held at a time (there is only one App).
+ *
+ * @param {() => void} fn
+ * @returns {() => void} unsubscribe — safe to return straight from an effect.
+ */
+export function setBeforeReloadHandler(fn) {
+  beforeReloadHandler = fn
+  return () => {
+    if (beforeReloadHandler === fn) beforeReloadHandler = null
+  }
+}
+
+/**
+ * Flush pending work, then latch "this unload is intentional".
+ *
+ * The latch is deliberately one-way: once the user has asked to reload, any
+ * unload that follows is the one they asked for.
+ */
+export function beginIntentionalReload() {
+  if (beforeReloadHandler) beforeReloadHandler()
+  intentional = true
+}
+
+/** @returns {boolean} whether an intentional reload is in progress. */
+export function isIntentionalReload() {
+  return intentional
+}
+
+/** Test-only: clear module-level state between cases. */
+export function __resetForTests() {
+  beforeReloadHandler = null
+  intentional = false
+}


### PR DESCRIPTION
## Problem

On the deployed app the PWA banner shows "A new version is available." and clicking **Refresh** does nothing. Reproduced live against the Vercel deploy:

- While the banner was up: `registration.waiting === null`, `registration.active.state === 'activated'`, `navigator.serviceWorker.controller` non-null. **Nothing was waiting.**
- Clicking Refresh produced zero effect — no `controllerchange`, no reload, no registration change.
- A manual `location.reload()` made the banner disappear immediately: the app was *already* running the new build. The banner was advertising an update that had already landed.
- On first load of that tab, screenshotting was blocked by an open `beforeunload` dialog — evidence the automatic update reload was attempted and stopped by the app's own save guard.

## Root cause

`refresh()` was just `updateServiceWorker(true)`, which in vite-plugin-pwa's prompt mode reduces to `wb.messageSkipWaiting()`. The reload is only ever a *side effect* of the `controlling` event that the waiting worker fires on activation. Once that worker activates on its own — routine when every client of the old worker goes away, or when the `controlling` reload gets cancelled — `needRefresh` stays `true` with no target left, is never re-validated against the real registration, and the only escape is a manual browser reload.

`App.jsx`'s `handleBeforeUnload` produced exactly that dead state: it called `preventDefault()` while `isSaving`, turning the service worker's automatic reload into a native "Leave site?" prompt. Cancel it and the worker is activated, the reload never happened, and the banner is permanently inert.

## Changes

| File | Change |
|---|---|
| `src/utils/reloadCoordinator.js` | **new** — cross-tree pre-reload handler + intentional-reload latch |
| `src/utils/pwaUpdate.js` | add `resolveRefreshAction`, `isUpdateBannerStale` |
| `src/components/PwaUpdatePrompt.jsx` | registration ref, rewritten `refresh()`, fallback reload, stale self-heal |
| `src/App.jsx` | register pre-reload handler; bail out of the beforeunload guard on intentional reload |
| `src/styles/pwa.css` | `:disabled` busy state for the Refresh button |
| `src/utils/__tests__/pwaUpdate.test.js` | extend |
| `src/utils/__tests__/reloadCoordinator.test.js` | **new** |

Refresh now inspects the real registration: nothing waiting → plain reload; otherwise `skipWaiting` plus a ~2s fallback reload that catches a missed `controlling` event or an activation that raced ahead. A Refresh click flushes pending saves and disarms the beforeunload guard — the banner is a *sibling* of `App` in `main.jsx` (deliberately outside the `ErrorBoundary`), so the signal goes through a small module rather than props or a `window` global. `flushAllPendingSaves` writes localStorage drafts synchronously before dispatching Supabase saves, so draft recovery still covers an interrupted write.

## Test plan

- [x] `npm run test:unit` — 511 passing, including new cases for `resolveRefreshAction`, `isUpdateBannerStale`, and the whole `reloadCoordinator` surface
- [x] `npm run build` — clean, SW regenerated
- [ ] `npm run preview`, make a trivial source change, rebuild, refocus the tab to trigger the check. Banner appears and **Refresh reloads into the new build**
- [ ] **Reproduce the actual bug.** With the banner up: `const r = await navigator.serviceWorker.getRegistration(); r.waiting.postMessage({ type: 'SKIP_WAITING' })`, then cancel/ignore the reload. Verify `r.waiting === null` while the banner still shows — the exact dead state seen in production. Click **Refresh**: it must now reload
- [ ] **Save guard.** Type so a save is in flight ("Saving..."), click Refresh: page reloads with **no** native "Leave site?" dialog, and the typed content survives
- [ ] **Self-heal.** Reach the stale state above, switch tabs and back: the banner removes itself
- [ ] Live re-check on the deployed preview: no phantom banner, `registration.waiting` consistent with what the banner shows

**No E2E spec** — driving a real service-worker update through Playwright needs two distinct builds and control over worker activation timing, which is genuinely flaky. Called out explicitly rather than shipping a spec that would quarantine itself; the decision logic is unit-tested instead.

## Modularization checklist

- **Concern added:** reliable, user-triggered app reload for PWA updates.
- **Extracted:** decision logic into pure functions in `pwaUpdate.js`; cross-component reload coordination into its own `reloadCoordinator.js`. `PwaUpdatePrompt.jsx` stays under 200 lines; `App.jsx` gains a few lines inside an existing effect and takes on no new responsibility.
- **Regression checks:** `npm run test:unit`, `npm run build`, plus the manual save-guard check (the one path where behavior around unsaved data changes).