### PR TITLE
fix: anchor bare tracker dates to the tracker's month

### DIFF
--- a/supabase/functions/generate-daily/dailyHelpers.test.ts
+++ b/supabase/functions/generate-daily/dailyHelpers.test.ts
@@ -6,6 +6,7 @@ import {
   buildTrackerContext,
   parseDateResolutions,
   resolveFinalDate,
+  resolveTrackerAnchor,
   serializeTrackerToMarkdown,
   type DateCandidate,
   type DateResolutions,
@@ -158,6 +159,99 @@ describe('buildCandidates', () => {
     expect(candidate.deterministicIso).toBe('2026-07-01')
     expect(candidate.needsAiYear).toBe(true)
   })
+
+  describe('anchoring bare dates to the tracker month', () => {
+    const augustAnchor = new Date(Date.UTC(2026, 7, 1))
+    const augustToday = '2026-08-08'
+
+    it('rolls a bare date earlier than the anchor month to the next year', () => {
+      const cidSegments = new Map<string, InlineSegment[]>([
+        ['c1', [plain('Hotel cancel deadline '), hl('1/10')]],
+      ])
+      const [candidate] = buildCandidates(cidSegments, augustToday, augustAnchor)
+      expect(candidate.deterministicIso).toBe('2027-01-10')
+      expect(candidate.needsAiYear).toBe(true)
+    })
+
+    it('leaves a bare date inside the anchor month alone (still overdue)', () => {
+      const cidSegments = new Map<string, InlineSegment[]>([
+        ['c1', [plain('Overdue thing '), hl('8/1')]],
+      ])
+      const [candidate] = buildCandidates(cidSegments, augustToday, augustAnchor)
+      expect(candidate.deterministicIso).toBe('2026-08-01')
+    })
+
+    it('never touches an explicit slash-year', () => {
+      const cidSegments = new Map<string, InlineSegment[]>([
+        ['c1', [plain('Due '), hl('4/15/2030')]],
+      ])
+      const [candidate] = buildCandidates(cidSegments, augustToday, augustAnchor)
+      expect(candidate.deterministicIso).toBe('2030-04-15')
+    })
+
+    it('never touches a written year on the line', () => {
+      const cidSegments = new Map<string, InlineSegment[]>([
+        ['c1', [plain('They are due by '), hl('4/15'), plain(' (of 2027)')]],
+      ])
+      const [candidate] = buildCandidates(cidSegments, augustToday, augustAnchor)
+      expect(candidate.deterministicIso).toBe('2027-04-15')
+      expect(candidate.needsAiYear).toBe(false)
+    })
+
+    it('picks the truly earliest token after rolling (12/26 before 1/10)', () => {
+      const cidSegments = new Map<string, InlineSegment[]>([
+        ['c1', [plain('Window '), hl('1/10'), plain(' to '), hl('12/26')]],
+      ])
+      const [candidate] = buildCandidates(cidSegments, augustToday, augustAnchor)
+      expect(candidate.deterministicIso).toBe('2026-12-26')
+      expect(candidate.dateText).toBe('12/26')
+    })
+
+    it('defaults the anchor to the first of today’s month', () => {
+      const cidSegments = new Map<string, InlineSegment[]>([
+        ['c1', [plain('Deadline '), hl('1/10')]],
+      ])
+      const [candidate] = buildCandidates(cidSegments, augustToday)
+      expect(candidate.deterministicIso).toBe('2027-01-10')
+    })
+
+    it('still lets the AI year override a rolled candidate', () => {
+      const cidSegments = new Map<string, InlineSegment[]>([
+        ['c1', [plain('Deadline '), hl('1/10')]],
+      ])
+      const [candidate] = buildCandidates(cidSegments, augustToday, augustAnchor)
+      const date = resolveFinalDate(candidate, '2029-01-10', augustToday)
+      expect(date.toISOString().slice(0, 10)).toBe('2029-01-10')
+    })
+  })
+})
+
+describe('resolveTrackerAnchor', () => {
+  const today = '2026-08-08'
+  const iso = (date: Date) => date.toISOString().slice(0, 10)
+
+  it('reads a full month name and year from the title', () => {
+    expect(iso(resolveTrackerAnchor('August 2026 Tracker', today))).toBe('2026-08-01')
+  })
+
+  it('reads a 3-letter abbreviation', () => {
+    expect(iso(resolveTrackerAnchor('Aug 2026', today))).toBe('2026-08-01')
+  })
+
+  it('reads the month and year in either order', () => {
+    expect(iso(resolveTrackerAnchor('2027 September notes', today))).toBe('2027-09-01')
+  })
+
+  it('falls back to the first of the current month for an unparseable title', () => {
+    expect(iso(resolveTrackerAnchor('Untitled Tracker', today))).toBe('2026-08-01')
+    // A word that merely starts with a month abbreviation is not a month.
+    expect(iso(resolveTrackerAnchor('Marathon Tracker 2026', today))).toBe('2026-08-01')
+  })
+
+  it('falls back for a missing or empty title', () => {
+    expect(iso(resolveTrackerAnchor(undefined, today))).toBe('2026-08-01')
+    expect(iso(resolveTrackerAnchor('', today))).toBe('2026-08-01')
+  })
 })
 
 describe('buildTrackerContext — highlightedCids', () => {
@@ -227,6 +321,37 @@ describe('buildTrackerContext — highlightedCids', () => {
     const { candidates, highlightedCids } = buildTrackerContext(trackerPages, today)
     expect(candidates).toEqual([])
     expect(highlightedCids.size).toBe(0)
+  })
+
+  it('anchors each page to its own month', () => {
+    const datedPage = (title: string, id: string) => ({
+      title,
+      content: {
+        type: 'doc',
+        content: [
+          {
+            type: 'paragraph',
+            attrs: { id },
+            content: [
+              { type: 'text', text: 'Deadline ' },
+              { type: 'text', text: '1/10', marks: [{ type: 'highlight' }] },
+            ],
+          },
+        ],
+      },
+    })
+
+    const { candidates, cidToBlockId } = buildTrackerContext(
+      [datedPage('August 2026 Tracker', 'p-aug'), datedPage('February 2027 Tracker', 'p-feb')],
+      '2026-08-08',
+    )
+
+    const byBlock = new Map(
+      candidates.map((c) => [cidToBlockId.get(c.cid), c.deterministicIso]),
+    )
+    // 1/10 is before August 2026 -> next year; 1/10 is before Feb 2027 -> 2028.
+    expect(byBlock.get('p-aug')).toBe('2027-01-10')
+    expect(byBlock.get('p-feb')).toBe('2028-01-10')
   })
 })
 

--- a/supabase/functions/generate-daily/dailyHelpers.ts
+++ b/supabase/functions/generate-daily/dailyHelpers.ts
@@ -52,6 +52,56 @@ const toUtcDate = (value: string) => {
 
 const toIsoDate = (date: Date) => date.toISOString().slice(0, 10)
 
+const firstOfMonth = (date: Date): Date => {
+  const month = String(date.getUTCMonth() + 1).padStart(2, '0')
+  return toUtcDate(`${date.getUTCFullYear()}-${month}-01`) as Date
+}
+
+// Month name (full or 3-letter abbreviation) as a whole word. Longest
+// alternatives first so "september" isn't cut short to "sep". The \b anchors
+// keep "Marathon Tracker" from reading as March.
+const MONTH_NAME_PATTERN =
+  'january|february|march|april|august|september|october|november|december|june|july|jan|feb|mar|apr|may|jun|jul|aug|sept|sep|oct|nov|dec'
+const MONTH_NAME_REGEX = new RegExp(`\\b(${MONTH_NAME_PATTERN})\\b`, 'i')
+const MONTH_NUMBER_BY_PREFIX: Record<string, number> = {
+  jan: 1,
+  feb: 2,
+  mar: 3,
+  apr: 4,
+  may: 5,
+  jun: 6,
+  jul: 7,
+  aug: 8,
+  sep: 9,
+  oct: 10,
+  nov: 11,
+  dec: 12,
+}
+
+// A bare MM/DD in a tracker means the next occurrence relative to the tracker's
+// own month, not relative to today — the user only writes a year out when the
+// date is more than a year away. The anchor is the first of the month named in
+// the page title ("August 2026 Tracker" -> 2026-08-01).
+//
+// NOTE: this makes date resolution title-sensitive. Titles are free-form, so a
+// tracker renamed to something without a month silently falls back to the first
+// of the current month.
+export const resolveTrackerAnchor = (title: unknown, today: string): Date => {
+  const todayDate = toUtcDate(today)
+  const fallback = todayDate ? firstOfMonth(todayDate) : null
+
+  const text = typeof title === 'string' ? title : ''
+  const monthMatch = text.match(MONTH_NAME_REGEX)
+  const yearMatch = text.match(WRITTEN_YEAR_REGEX)
+  if (!monthMatch || !yearMatch) return fallback as Date
+
+  const month = MONTH_NUMBER_BY_PREFIX[monthMatch[1].slice(0, 3).toLowerCase()]
+  if (!month) return fallback as Date
+
+  const anchor = toUtcDate(`${yearMatch[1]}-${String(month).padStart(2, '0')}-01`)
+  return anchor || (fallback as Date)
+}
+
 const normalizeText = (value: string) =>
   String(value || '')
     .replace(/\s+/g, ' ')
@@ -116,6 +166,25 @@ const extractDateTokens = (text: string, defaultYear: number): DateToken[] => {
   }
 
   return results
+}
+
+// Re-anchor a bare MM/DD token: build it in the anchor's year, and if that lands
+// before the anchor, roll it to the next year. Tokens carrying their own
+// slash-year are never touched. If the rolled year isn't a real date (2/29 in a
+// non-leap year), the un-rolled date stands rather than dropping the candidate.
+const rollTokenToAnchor = (token: DateToken, anchor: Date): DateToken => {
+  if (token.hasSlashYear) return token
+
+  const anchorYear = anchor.getUTCFullYear()
+  const month = String(token.month)
+  const day = String(token.day)
+
+  const atAnchorYear = parseDateToken(month, day, String(anchorYear), anchorYear)
+  if (!atAnchorYear) return token
+  if (atAnchorYear.getTime() >= anchor.getTime()) return { ...token, date: atAnchorYear }
+
+  const nextYear = parseDateToken(month, day, String(anchorYear + 1), anchorYear + 1)
+  return { ...token, date: nextYear || atAnchorYear }
 }
 
 // Validate that a value is a real MM/DD calendar date in a 20xx year written as
@@ -434,10 +503,12 @@ export const serializeTrackerToMarkdown = (content: any, title?: string): Serial
 export const buildCandidates = (
   cidSegments: Map<string, InlineSegment[]>,
   today: string,
+  anchor?: Date,
 ): DateCandidate[] => {
   const todayDate = toUtcDate(today)
   if (!todayDate) return []
 
+  const anchorDate = anchor || firstOfMonth(todayDate)
   const candidates: DateCandidate[] = []
 
   for (const [cid, segments] of cidSegments) {
@@ -450,6 +521,11 @@ export const buildCandidates = (
     const highlightedTokens = segments
       .filter((segment) => segment.highlighted)
       .flatMap((segment) => extractDateTokens(segment.text, defaultYear))
+      // Roll bare dates to the anchor's year (or the next one) BEFORE picking
+      // the earliest, so the pick reflects the real ordering.
+      .map((token) =>
+        writtenYearMatch ? token : rollTokenToAnchor(token, anchorDate),
+      )
 
     if (!highlightedTokens.length) continue
 
@@ -532,22 +608,31 @@ export const buildTrackerContext = (trackerPages: any[], today: string): Tracker
   const cidToText = new Map<string, string>()
   const cidSegments = new Map<string, InlineSegment[]>()
   const sections: string[] = []
+  const candidates: DateCandidate[] = []
 
   for (const page of trackerPages || []) {
     const ctx = createCtx(counter)
-    // Share the accumulating maps so cids stay globally unique across pages.
+    // Share the accumulating maps so cids stay globally unique across pages,
+    // but keep segments page-local: each page's bare dates are anchored to that
+    // page's own month.
     ctx.cidToBlockId = cidToBlockId
     ctx.cidToText = cidToText
-    ctx.cidSegments = cidSegments
     const markdown = serializeContentWithCtx(page?.content, ctx, page?.title)
     if (markdown) sections.push(markdown)
+
+    const anchor = resolveTrackerAnchor(page?.title, today)
+    candidates.push(...buildCandidates(ctx.cidSegments, today, anchor))
+
+    for (const [cid, segments] of ctx.cidSegments) {
+      cidSegments.set(cid, segments)
+    }
   }
 
   return {
     markdown: sections.join('\n\n'),
     cidToBlockId,
     cidToText,
-    candidates: buildCandidates(cidSegments, today),
+    candidates,
     highlightedCids: buildHighlightedCids(cidSegments),
   }
 }


### PR DESCRIPTION
## Problem

AI Daily on 2026-08-08 put this in **ASAP / high priority**:

> Houston Marathon: Hotel free cancellation deadline — flag for 1/10

The source line, in the **August 2026** tracker:

```
- 7/21 - booked hotel. Can cancel for free until three days before so I'll set that at [1/10]
```

`[1/10]` means **January 10, 2027**. The parser read it as **January 10, 2026** — 210 days overdue — and `overdue` is hardcoded to high-priority ASAP.

The AI is not at fault: it correctly returned `iso_date: null`, since the prompt says not to guess a year that isn't stated, and the year genuinely isn't on that line. The root cause is that bare `MM/DD` dates were anchored to *today*, which drifts forward forever.

## Fix

The convention in these trackers is that a year is only written out when the date is more than a year away — so a bare date is always the *next occurrence relative to the tracker's own month*, not relative to today. Anchor to the first of the month named in the page title and roll forward a year when a bare date lands before that anchor. No magic staleness threshold.

Server-side only, confined to `supabase/functions/generate-daily/dailyHelpers.ts`. No `index.ts` changes, no client changes — `title` was already in the request payload.

- **`resolveTrackerAnchor(title, today)`** — whole-word month name (full or 3-letter abbrev) plus a `20xx` year anywhere in the title, in either order (`"August 2026 Tracker"`, `"Aug 2026"`, `"2026 August"`). Titles are free-form, so no match falls back to the first of the current month.
- **`buildCandidates`** takes an optional `anchor`. Roll-forward applies **only** when the line has no written `20xx` **and** the token has no slash-year — explicit years are never touched. If the +1 rebuild fails validation (`2/29`), the un-rolled date stands rather than dropping the candidate.
- Normalization runs **per token, before** the earliest-token sort. This also fixes a latent ordering bug: a line highlighting both `1/10` and `12/26` used to pick `1/10` as "earliest" when `12/26` of this year actually comes first.
- **`buildTrackerContext`** gives each page a page-local `cidSegments` map so pages anchor independently; the counter and the `cidToBlockId`/`cidToText` maps stay shared so cids remain globally unique. Return shape unchanged.

`resolveFinalDate` and `needsAiYear` semantics are untouched — a plain-language year from the AI ("two years out") still overrides the deterministic date.

## Test plan

- [x] `npm run test:unit` — 524 passed. The 5 pre-existing `buildCandidates` tests pass unchanged under the July-1 default anchor (verified, not assumed).
- [x] 13 new tests: anchor parsing (full name / abbrev / either order / unparseable / missing), roll-forward (`1/10` → 2027-01-10; `8/1` → 2026-08-01, still overdue), explicit-year immunity (slash-year and written-year), default anchor, AI-year override, token ordering, per-page anchors.
- [x] **Replayed the captured production request** through the patched helpers (no AI calls):
  - Anchor: `"August 2026 Tracker"` → `2026-08-01`
  - `c36` → `2027-01-10`, buckets as `later`, **drops out of ASAP (5 → 4)**; the removed entry is exactly the Houston Marathon hotel line
  - The other 4 ASAP entries are byte-identical and in the same order; **all 10 FYI entries byte-identical**
  - `warning` still `null`
  - Explicit-year candidates untouched: `4/15 (of 2027)` → `2027-04-15`, `7/1 (of 2028)` → `2028-07-01`
- [ ] Edge function deployed and one live AI Daily generation run against the August tracker

## Risk

If a bare date earlier than the tracker month ever does appear, it now silently rolls to next year and drops off the list instead of showing as overdue. That's the accepted tradeoff (roll silently, no `warning` text, no UI change); the mitigation is the habit of re-dating items when rolling the tracker forward to a new month.

Title parsing is a new dependency — renaming a tracker to something without a month silently changes its anchor to the current month. Behaviour stays sane, but it's now title-sensitive in a way it wasn't before; noted in a comment at `resolveTrackerAnchor`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)