### PR TITLE
feat: timed reminders from highlighted dates

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -153,6 +153,12 @@ Playwright E2E tests live in `e2e/`. Two viewport projects run automatically:
 
 Functions inside React hooks that use ProseMirror `EditorState` should be extracted into standalone util files (e.g., `src/utils/listHelpers.js`) and unit-tested with real ProseMirror state objects constructed via `@tiptap/pm/model` + `@tiptap/pm/state`. No jsdom needed — ProseMirror's state layer is pure JS.
 
+### Edge function shared code (`supabase/functions/_shared/`)
+
+Logic used by more than one edge function lives in `supabase/functions/_shared/`. The leading underscore is the Supabase CLI convention for non-deployed shared code — the CLI bundles it into every importing function. Prefer this over a peer-function reach-in (`../generate-daily/foo.ts`).
+
+**House rule for every module in `_shared/`:** zero `jsr:` / `npm:` / `https://` imports and zero top-level `Deno.*`. That is what lets Vitest import them directly. Anything needing an env var takes it as a parameter (see `deepLink.ts`, which takes `appUrl`). Their `*.test.ts` files sit alongside them and are picked up by `vitest.config.js`'s glob.
+
 ## Commands
 
 - `npm run dev` - Start dev server (binds to 0.0.0.0 — accessible from phone on same network)

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -20,6 +20,13 @@ enabled = true
 verify_jwt = false
 entrypoint = "./functions/check-scores/index.ts"
 
+[functions.send-reminders]
+enabled = true
+# verify_jwt = false is deliberate: pg_cron can't send a Supabase JWT.
+# Auth is the x-cron-secret header, same as check-scores.
+verify_jwt = false
+entrypoint = "./functions/send-reminders/index.ts"
+
 [functions.telegram-bot]
 enabled = true
 # verify_jwt = false is deliberate: Telegram can't send a Supabase JWT.

--- a/supabase/functions/_shared/dailyHelpers.test.ts
+++ b/supabase/functions/_shared/dailyHelpers.test.ts
@@ -4,8 +4,10 @@ import {
   buildCandidates,
   buildDaily,
   buildTrackerContext,
+  extractDateTokens,
   parseDateResolutions,
   resolveFinalDate,
+  resolveTokenDate,
   resolveTrackerAnchor,
   serializeTrackerToMarkdown,
   type DateCandidate,
@@ -555,5 +557,156 @@ describe('buildDaily — flagged extras (additive only)', () => {
     const { asap, fyi } = buildDaily([], parsed, cidToBlockId, cidToText, highlightedCids, today)
     expect(asap).toEqual([])
     expect(fyi).toEqual([])
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Multi-column tables. Every highlighted date must be reachable: these rows used
+// to be anchor-suppressed entirely, so 24 real dates in the user's tracker were
+// invisible to the daily list. The row — not the cell — is the addressable unit.
+// ---------------------------------------------------------------------------
+describe('serializeTrackerToMarkdown — multi-column tables', () => {
+  const cell = (id: string, text: string, highlighted = false) => ({
+    type: 'tableCell',
+    content: [
+      {
+        type: 'paragraph',
+        attrs: { id },
+        content: [{ type: 'text', text, ...(highlighted ? { marks: [{ type: 'highlight' }] } : {}) }],
+      },
+    ],
+  })
+
+  const rewardsTable = {
+    type: 'doc',
+    content: [
+      {
+        type: 'table',
+        content: [
+          {
+            type: 'tableRow',
+            content: [
+              { type: 'tableHeader', content: [{ type: 'paragraph', attrs: { id: 'h-a' }, content: [{ type: 'text', text: 'Reward' }] }] },
+              { type: 'tableHeader', content: [{ type: 'paragraph', attrs: { id: 'h-b' }, content: [{ type: 'text', text: 'Use-By Date' }] }] },
+              { type: 'tableHeader', content: [{ type: 'paragraph', attrs: { id: 'h-c' }, content: [{ type: 'text', text: 'Notes' }] }] },
+            ],
+          },
+          {
+            type: 'tableRow',
+            content: [cell('r1-a', 'Chase Ultimate Rewards'), cell('r1-b', '3/2/27', true), cell('r1-c', 'book flights')],
+          },
+          {
+            type: 'tableRow',
+            content: [cell('r2-a', 'Airline credit'), cell('r2-b', '4/5', true), cell('r2-c', '')],
+          },
+        ],
+      },
+    ],
+  }
+
+  it('anchors each body row once, to the first block id in the row', () => {
+    const { markdown, cidToBlockId } = serializeTrackerToMarkdown(rewardsTable)
+    const lines = markdown.split('\n')
+
+    const headerLine = lines.find((l) => l.includes('Reward')) || ''
+    const row1 = lines.find((l) => l.includes('Chase')) || ''
+    const row2 = lines.find((l) => l.includes('Airline')) || ''
+
+    // Header row is column labels, never an item.
+    expect(headerLine).not.toMatch(/⟦c\d+⟧/)
+    // One anchor per body row, appended after the closing pipe.
+    expect(row1).toMatch(/\|\s⟦c1⟧$/)
+    expect(row2).toMatch(/\|\s⟦c2⟧$/)
+    expect(cidToBlockId.get('c1')).toBe('r1-a')
+    expect(cidToBlockId.get('c2')).toBe('r2-a')
+  })
+
+  it('keeps cell interiors free of anchors', () => {
+    const { markdown } = serializeTrackerToMarkdown(rewardsTable)
+    const row1 = markdown.split('\n').find((l) => l.includes('Chase')) || ''
+    expect([...row1.matchAll(/⟦c\d+⟧/g)]).toHaveLength(1)
+  })
+
+  it("reads the row's cells as one line of text, joined by ·", () => {
+    const { cidToText } = serializeTrackerToMarkdown(rewardsTable)
+    expect(cidToText.get('c1')).toBe('Chase Ultimate Rewards · 3/2/27 · book flights')
+  })
+
+  it('makes a highlighted date in a table row a real daily-list candidate', () => {
+    const { candidates, cidToBlockId } = buildTrackerContext(
+      [{ id: 'page-1', title: 'August 2026 Tracker', content: rewardsTable }],
+      '2026-08-09',
+    )
+    const airline = candidates.find((c) => c.deterministicIso.endsWith('-04-05'))
+    expect(airline).toBeDefined()
+    expect(cidToBlockId.get(airline!.cid)).toBe('r2-a')
+    // Bare 4/5 on an August 2026 page rolls forward to the next April.
+    expect(airline!.deterministicIso).toBe('2027-04-05')
+  })
+})
+
+describe('single-column tables are unchanged', () => {
+  it('still preserves inner structure and its own anchors', () => {
+    const content = {
+      type: 'doc',
+      content: [
+        {
+          type: 'table',
+          content: [
+            {
+              type: 'tableRow',
+              content: [
+                {
+                  type: 'tableCell',
+                  content: [
+                    { type: 'paragraph', attrs: { id: 'c-p1' }, content: [{ type: 'text', text: 'RUNNING' }] },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    }
+    const { markdown, cidToBlockId } = serializeTrackerToMarkdown(content)
+    expect(markdown).toContain('RUNNING ⟦c1⟧')
+    expect(markdown).not.toContain('|')
+    expect(cidToBlockId.get('c1')).toBe('c-p1')
+  })
+})
+
+describe('resolveTokenDate', () => {
+  const anchor = new Date(Date.UTC(2026, 7, 1)) // August 2026 tracker
+  const tokenFor = (text: string) => extractDateTokens(text, 2026)[0]
+
+  it('lets an explicit slash-year win outright', () => {
+    const result = resolveTokenDate(tokenFor('3/2/27'), '3/2/27', anchor)
+    expect(result.date.toISOString().slice(0, 10)).toBe('2027-03-02')
+    expect(result.needsAiYear).toBe(false)
+  })
+
+  it('uses a written 20xx year found elsewhere on the line', () => {
+    const line = 'Renew 1/5 (of 2028)'
+    const result = resolveTokenDate(tokenFor(line), line, anchor)
+    expect(result.date.toISOString().slice(0, 10)).toBe('2028-01-05')
+    expect(result.needsAiYear).toBe(false)
+  })
+
+  it('rolls a bare date forward past the tracker anchor', () => {
+    const result = resolveTokenDate(tokenFor('1/5'), '1/5', anchor)
+    expect(result.date.toISOString().slice(0, 10)).toBe('2027-01-05')
+    expect(result.needsAiYear).toBe(true)
+  })
+
+  it('keeps a bare date in the anchor year when it is not yet past', () => {
+    const result = resolveTokenDate(tokenFor('9/26'), '9/26', anchor)
+    expect(result.date.toISOString().slice(0, 10)).toBe('2026-09-26')
+  })
+
+  it('resolves each token on a two-date line independently', () => {
+    const line = '8/17 and 1/5'
+    const [first, second] = extractDateTokens(line, 2026)
+    expect(resolveTokenDate(first, line, anchor).date.toISOString().slice(0, 10)).toBe('2026-08-17')
+    expect(resolveTokenDate(second, line, anchor).date.toISOString().slice(0, 10)).toBe('2027-01-05')
   })
 })

--- a/supabase/functions/_shared/dailyHelpers.ts
+++ b/supabase/functions/_shared/dailyHelpers.ts
@@ -37,6 +37,11 @@ export type TrackerContext = {
   markdown: string
   cidToBlockId: Map<string, string>
   cidToText: Map<string, string>
+  // Per-cid highlighted/plain runs. buildCandidates collapses these away, but the
+  // reminder deriver needs them intact (a line can carry two timed dates).
+  cidSegments: Map<string, InlineSegment[]>
+  // Which page each cid came from — the deep link needs a pageId.
+  cidToPageId: Map<string, string>
   candidates: DateCandidate[]
   highlightedCids: Set<string>
 }
@@ -137,15 +142,18 @@ const parseDateToken = (
   return date
 }
 
-type DateToken = {
+export type DateToken = {
   date: Date
   raw: string
   month: number
   day: number
   hasSlashYear: boolean
+  // Offset of the match within the text it was extracted from — the reminder
+  // deriver needs it to read the clock time that follows the date.
+  index: number
 }
 
-const extractDateTokens = (text: string, defaultYear: number): DateToken[] => {
+export const extractDateTokens = (text: string, defaultYear: number): DateToken[] => {
   const results: DateToken[] = []
   const normalized = String(text || '')
 
@@ -160,6 +168,7 @@ const extractDateTokens = (text: string, defaultYear: number): DateToken[] => {
         month: Number(match[1]),
         day: Number(match[2]),
         hasSlashYear: Boolean(match[3]),
+        index: match.index,
       })
     }
     match = DATE_TOKEN_REGEX.exec(normalized)
@@ -221,7 +230,7 @@ const appendSegment = (segments: InlineSegment[], segment: InlineSegment) => {
 
 // Collect visible inline text as highlighted/plain runs. Struck-through
 // (completed) text is dropped so finished items don't resurface as due dates.
-const collectInlineSegments = (nodes: any[]): InlineSegment[] => {
+export const collectInlineSegments = (nodes: any[]): InlineSegment[] => {
   const segments: InlineSegment[] = []
 
   const walk = (node: any) => {
@@ -304,6 +313,55 @@ function registerAnchor(
   ctx.counter.value += 1
   ctx.cidToBlockId.set(cid, id)
   const segments = collectInlineSegments(inlineContent || [])
+  ctx.cidSegments.set(cid, segments)
+  ctx.cidToText.set(cid, normalizeText(segments.map((s) => s.text).join('')))
+  return ` ⟦${cid}⟧`
+}
+
+// First `attrs.id` found walking the row depth-first. Every cell's first
+// paragraph carries one, so a row effectively always resolves to a block id.
+function firstBlockIdInRow(row: any): string | null {
+  let found: string | null = null
+  const walk = (node: any) => {
+    if (found || !node || typeof node !== 'object') return
+    const id = node.attrs?.id
+    if (typeof id === 'string' && id) {
+      found = id
+      return
+    }
+    if (Array.isArray(node.content)) node.content.forEach(walk)
+  }
+  ;(row?.content || []).forEach(walk)
+  return found
+}
+
+// A row's inline runs: each cell mapped through collectInlineSegments (which
+// already recurses nested lists and drops struck-through text), joined with a
+// plain " · " so cidToText reads sensibly.
+function collectRowSegments(row: any): InlineSegment[] {
+  const segments: InlineSegment[] = []
+  const cells = row?.content || []
+  cells.forEach((cell: any, idx: number) => {
+    if (idx > 0) appendSegment(segments, { text: ' · ', highlighted: false })
+    collectInlineSegments(cell?.content || []).forEach((segment) =>
+      appendSegment(segments, segment),
+    )
+  })
+  return segments
+}
+
+// Row-level sibling of registerAnchor: takes already-collected segments (the row
+// spans several cells) and ignores ctx.suppressAnchors, which is set for the
+// cells' benefit, not the row's.
+function registerRowAnchor(
+  ctx: SerializeCtx,
+  id: string | null,
+  segments: InlineSegment[],
+): string {
+  if (!id) return ''
+  const cid = `c${ctx.counter.value}`
+  ctx.counter.value += 1
+  ctx.cidToBlockId.set(cid, id)
   ctx.cidSegments.set(cid, segments)
   ctx.cidToText.set(cid, normalizeText(segments.map((s) => s.text).join('')))
   return ` ⟦${cid}⟧`
@@ -399,8 +457,14 @@ function serializeNode(
           }
         })
       } else {
-        // Multi-column table: flatten to pipe rows. Anchoring individual cells
-        // inside a joined row would be noise, so suppress anchors here.
+        // Multi-column table: flatten to pipe rows. A ⟦c42⟧ mid-pipe-row would be
+        // noise, so anchors stay suppressed INSIDE the cells — but the row itself
+        // gets one anchor appended to the line. The pipe row is the logical item
+        // (one reward, one expiration), so it's the right addressable unit, and
+        // it's what makes highlighted dates inside these tables reachable at all.
+        //
+        // Nesting rule: the OUTERMOST multi-column row is the anchoring unit. A
+        // nested table inside a cell folds into its parent row's text.
         const previousSuppress = ctx.suppressAnchors
         ctx.suppressAnchors = true
         rows.forEach((row: any, rowIdx: number) => {
@@ -409,7 +473,12 @@ function serializeNode(
             cell.content?.forEach((child: any) => serializeNode(child, cellLines, ctx, 0))
             return cellLines.join(' ').trim()
           })
-          lines.push(prefix + '| ' + cells.join(' | ') + ' |')
+          // Skip the header row — it's column labels, never an item.
+          const anchor =
+            rowIdx === 0
+              ? ''
+              : registerRowAnchor(ctx, firstBlockIdInRow(row), collectRowSegments(row))
+          lines.push(prefix + '| ' + cells.join(' | ') + ' |' + anchor)
           if (rowIdx === 0) {
             const separator = cells.map((c: string) => '-'.repeat(Math.max(c.length, 3))).join(' | ')
             lines.push(prefix + '| ' + separator + ' |')
@@ -500,6 +569,30 @@ export const serializeTrackerToMarkdown = (content: any, title?: string): Serial
 // default. `needsAiYear` is set only in that last case — the one time a
 // plain-language year could change the result — so the AI never touches
 // month/day, only the year for those lines.
+// The year ladder for ONE date token, applied per token rather than per line so
+// a line carrying two dates resolves each independently:
+//   1. an explicit slash-year wins;
+//   2. else a written 20xx year anywhere on the same line (e.g. "(of 2027)");
+//   3. else roll the bare MM/DD to the tracker's anchor month (or the next year).
+// `needsAiYear` is true only in case 3 — the one time a plain-language year on
+// the line could change the answer, so the AI is asked about just those.
+export const resolveTokenDate = (
+  token: DateToken,
+  lineText: string,
+  anchor: Date,
+): { date: Date; needsAiYear: boolean } => {
+  if (token.hasSlashYear) return { date: token.date, needsAiYear: false }
+
+  const writtenYear = String(lineText || '').match(WRITTEN_YEAR_REGEX)
+  if (writtenYear) {
+    const year = Number(writtenYear[1])
+    const rebuilt = parseDateToken(String(token.month), String(token.day), String(year), year)
+    return { date: rebuilt || token.date, needsAiYear: false }
+  }
+
+  return { date: rollTokenToAnchor(token, anchor).date, needsAiYear: true }
+}
+
 export const buildCandidates = (
   cidSegments: Map<string, InlineSegment[]>,
   today: string,
@@ -513,33 +606,28 @@ export const buildCandidates = (
 
   for (const [cid, segments] of cidSegments) {
     const fullText = segments.map((s) => s.text).join('')
-    const writtenYearMatch = fullText.match(WRITTEN_YEAR_REGEX)
-    const defaultYear = writtenYearMatch
-      ? Number(writtenYearMatch[1])
-      : todayDate.getUTCFullYear()
+    const defaultYear = todayDate.getUTCFullYear()
 
-    const highlightedTokens = segments
+    const resolved = segments
       .filter((segment) => segment.highlighted)
       .flatMap((segment) => extractDateTokens(segment.text, defaultYear))
-      // Roll bare dates to the anchor's year (or the next one) BEFORE picking
-      // the earliest, so the pick reflects the real ordering.
-      .map((token) =>
-        writtenYearMatch ? token : rollTokenToAnchor(token, anchorDate),
-      )
+      // Resolve the year BEFORE picking the earliest, so the pick reflects the
+      // real ordering.
+      .map((token) => ({ token, ...resolveTokenDate(token, fullText, anchorDate) }))
 
-    if (!highlightedTokens.length) continue
+    if (!resolved.length) continue
 
-    const earliest = highlightedTokens
+    const earliest = resolved
       .slice()
       .sort((a, b) => a.date.getTime() - b.date.getTime())[0]
 
     candidates.push({
       cid,
-      dateText: earliest.raw,
-      month: earliest.month,
-      day: earliest.day,
+      dateText: earliest.token.raw,
+      month: earliest.token.month,
+      day: earliest.token.day,
       deterministicIso: toIsoDate(earliest.date),
-      needsAiYear: !earliest.hasSlashYear && !writtenYearMatch,
+      needsAiYear: earliest.needsAiYear,
     })
   }
 
@@ -607,6 +695,7 @@ export const buildTrackerContext = (trackerPages: any[], today: string): Tracker
   const cidToBlockId = new Map<string, string>()
   const cidToText = new Map<string, string>()
   const cidSegments = new Map<string, InlineSegment[]>()
+  const cidToPageId = new Map<string, string>()
   const sections: string[] = []
   const candidates: DateCandidate[] = []
 
@@ -623,8 +712,10 @@ export const buildTrackerContext = (trackerPages: any[], today: string): Tracker
     const anchor = resolveTrackerAnchor(page?.title, today)
     candidates.push(...buildCandidates(ctx.cidSegments, today, anchor))
 
+    const pageId = page?.pageId ?? page?.id
     for (const [cid, segments] of ctx.cidSegments) {
       cidSegments.set(cid, segments)
+      if (typeof pageId === 'string' && pageId) cidToPageId.set(cid, pageId)
     }
   }
 
@@ -632,6 +723,8 @@ export const buildTrackerContext = (trackerPages: any[], today: string): Tracker
     markdown: sections.join('\n\n'),
     cidToBlockId,
     cidToText,
+    cidSegments,
+    cidToPageId,
     candidates,
     highlightedCids: buildHighlightedCids(cidSegments),
   }

--- a/supabase/functions/_shared/dateToken.ts
+++ b/supabase/functions/_shared/dateToken.ts
@@ -1,0 +1,37 @@
+// The {{date:…}} sentinel the model wraps a key date phrase in, and the one
+// splitter that reads it. Shared so the preview, the stored doc, and the bot's
+// "I'll text you…" confirmation agree by construction.
+//
+// HOUSE RULE: zero jsr:/npm:/https:// imports, zero top-level `Deno.*`.
+
+/** The user highlights key dates in this cyan; the app treats it as a due date. */
+export const DATE_HIGHLIGHT_COLOR = '#67e8f9'
+
+const DATE_TOKEN_RE = /\{\{date:([^}]*)\}\}/g
+
+export type DateTokenRun = { text: string; isDate: boolean }
+
+/**
+ * Split an item string into runs, marking each {{date:…}} token's inner phrase.
+ * Empty runs are dropped — ProseMirror rejects a text node with text:''.
+ */
+export function splitDateTokens(text: string): DateTokenRun[] {
+  const runs: DateTokenRun[] = []
+  const source = String(text ?? '')
+  let lastIndex = 0
+
+  const pushPlain = (segment: string) => {
+    if (segment) runs.push({ text: segment, isDate: false })
+  }
+
+  for (const match of source.matchAll(DATE_TOKEN_RE)) {
+    const start = match.index ?? 0
+    pushPlain(source.slice(lastIndex, start))
+    const phrase = (match[1] ?? '').trim()
+    if (phrase) runs.push({ text: phrase, isDate: true })
+    lastIndex = start + match[0].length
+  }
+  pushPlain(source.slice(lastIndex))
+
+  return runs
+}

--- a/supabase/functions/_shared/deepLink.test.ts
+++ b/supabase/functions/_shared/deepLink.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest'
+
+import { buildDeepLink } from './deepLink.ts'
+// The front-end parser this must satisfy. If these two ever disagree, links
+// navigate nowhere with no error anywhere — hence the direct round-trip test.
+import { parseDeepLink } from '../../../src/utils/navigationHelpers.js'
+
+const APP = 'https://life-tracker-mu-sandy.vercel.app'
+
+const hashOf = (url: string) => url.slice(url.indexOf('#'))
+
+describe('buildDeepLink', () => {
+  it('puts nb first so parseDeepLink accepts the hash', () => {
+    const url = buildDeepLink(
+      { notebookId: 'nb1', sectionId: 'sec1', pageId: 'pg1', blockId: 'blk1' },
+      APP,
+    )
+    expect(url.startsWith(`${APP}/#nb=`)).toBe(true)
+  })
+
+  it('falls back to #sec= then #pg= as parts drop out', () => {
+    expect(hashOf(buildDeepLink({ sectionId: 's', pageId: 'p' }, APP)).startsWith('#sec=')).toBe(true)
+    expect(hashOf(buildDeepLink({ pageId: 'p', blockId: 'b' }, APP)).startsWith('#pg=')).toBe(true)
+  })
+
+  it('returns empty when nothing is resolvable', () => {
+    expect(buildDeepLink({}, APP)).toBe('')
+    expect(buildDeepLink({ notebookId: null, pageId: null }, APP)).toBe('')
+  })
+
+  it('tolerates a trailing slash on APP_URL', () => {
+    expect(buildDeepLink({ pageId: 'p' }, `${APP}/`)).toBe(`${APP}/#pg=p`)
+  })
+
+  it('returns a bare hash when no app URL is configured', () => {
+    expect(buildDeepLink({ pageId: 'p' }, '')).toBe('#pg=p')
+  })
+
+  it('round-trips through the front-end parser', () => {
+    const parts = { notebookId: 'nb1', sectionId: 'sec1', pageId: 'pg1', blockId: 'blk1' }
+    expect(parseDeepLink(hashOf(buildDeepLink(parts, APP)))).toEqual(parts)
+  })
+
+  it('round-trips a block-only-under-page link', () => {
+    const url = buildDeepLink({ pageId: 'pg1', blockId: 'blk1' }, APP)
+    expect(parseDeepLink(hashOf(url))).toEqual({
+      notebookId: null,
+      sectionId: null,
+      pageId: 'pg1',
+      blockId: 'blk1',
+    })
+  })
+})

--- a/supabase/functions/_shared/deepLink.ts
+++ b/supabase/functions/_shared/deepLink.ts
@@ -1,0 +1,34 @@
+// The one implementation of an app deep link. Lifted out of telegram-bot/
+// capture.ts so the bot and the reminder sweep can't drift apart.
+//
+// HOUSE RULE: zero jsr:/npm:/https:// imports, zero top-level `Deno.*` — `appUrl`
+// is a parameter, not a module-scope env read.
+
+export type DeepLinkParts = {
+  notebookId?: string | null
+  sectionId?: string | null
+  pageId?: string | null
+  blockId?: string | null
+}
+
+/**
+ * Build an app URL whose hash the front end can route on.
+ *
+ * ⚠️ KEY ORDER IS LOAD-BEARING. src/utils/navigationHelpers.js `parseDeepLink`
+ * rejects any hash that doesn't START with `#pg=`, `#sec=`, or `#nb=`. Keep the
+ * nb -> sec -> pg -> block order below: reordering silently produces links that
+ * navigate nowhere, with no error anywhere.
+ */
+export function buildDeepLink(parts: DeepLinkParts, appUrl?: string | null): string {
+  const params = new URLSearchParams()
+  if (parts.notebookId) params.set('nb', parts.notebookId)
+  if (parts.sectionId) params.set('sec', parts.sectionId)
+  if (parts.pageId) params.set('pg', parts.pageId)
+  if (parts.blockId) params.set('block', parts.blockId)
+
+  const hash = params.size ? `#${params.toString()}` : ''
+  if (!hash) return ''
+
+  const base = String(appUrl ?? '').replace(/\/$/, '')
+  return base ? `${base}/${hash}` : hash
+}

--- a/supabase/functions/_shared/deriveReminders.test.ts
+++ b/supabase/functions/_shared/deriveReminders.test.ts
@@ -1,0 +1,314 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  countOrphanedTimedHighlights,
+  deferPastQuietHours,
+  deriveReminders,
+  mergeAdjacentHighlights,
+  type DeriveOptions,
+} from './deriveReminders.ts'
+
+const NY = 'America/New_York'
+const CYAN = '#67e8f9'
+
+const OPTS: DeriveOptions = {
+  todayLocal: '2026-08-09',
+  timeZone: NY,
+  defaultLeadMinutes: 90,
+  quiet: { startHour: 22, endHour: 7 },
+}
+
+let idCounter = 0
+const nextId = () => `block-${++idCounter}`
+
+/** A paragraph whose content is [plain, highlighted, plain, …] by alternation. */
+const para = (runs: Array<[string, boolean]>, id = nextId()) => ({
+  type: 'paragraph',
+  attrs: { id },
+  content: runs.map(([text, highlighted]) => ({
+    type: 'text',
+    text,
+    ...(highlighted ? { marks: [{ type: 'highlight', attrs: { color: CYAN } }] } : {}),
+  })),
+})
+
+const doc = (...blocks: unknown[]) => ({ type: 'doc', content: blocks })
+
+const page = (...blocks: unknown[]) => ({
+  id: 'page-1',
+  title: 'August 2026 Tracker',
+  content: doc(...blocks),
+})
+
+const derive = (content: unknown, opts: Partial<DeriveOptions> = {}) =>
+  deriveReminders([{ id: 'page-1', title: 'August 2026 Tracker', content }], { ...OPTS, ...opts })
+
+const iso = (ts: number) => new Date(ts).toISOString()
+
+// ---------------------------------------------------------------------------
+// ⭐ The #1 regression to guard: the user's 573 existing date-only highlights.
+// ---------------------------------------------------------------------------
+describe('date-only highlights never arm a reminder', () => {
+  const dateOnly = [
+    '8/17',
+    'EOD 4/5',
+    'by EOD 2/15',
+    '2/22 weekend',
+    '12/28/30',
+    '3/2/27',
+    '10/25/27',
+    '8/17 2026',
+    '8/17 5-10 miles',
+  ]
+
+  it.each(dateOnly)('%j -> zero reminders', (text) => {
+    expect(derive(doc(para([['Some task ', false], [text, true]])))).toEqual([])
+  })
+})
+
+describe('a clock time inside the highlight arms a reminder', () => {
+  it('uses the 90-minute default lead', () => {
+    const [reminder, ...rest] = derive(
+      doc(para([['Dietician appointment  ', false], ['8/17 8:20am', true]])),
+    )
+    expect(rest).toEqual([])
+    expect(iso(reminder.dueAt)).toBe('2026-08-17T12:20:00.000Z') // 8:20 AM EDT
+    expect(reminder.leadMinutes).toBe(90)
+    // Raw fire time is 6:50 AM, which sits inside the 22:00-07:00 quiet window,
+    // so it defers to the 7:00 boundary — still an hour and change before the
+    // appointment. The quiet rule wins over the raw lead arithmetic.
+    expect(reminder.quietDeferred).toBe(true)
+    expect(iso(reminder.fireAt)).toBe('2026-08-17T11:00:00.000Z') // 7:00 AM EDT
+    expect(reminder.blockId).toBeTruthy()
+    expect(reminder.pageId).toBe('page-1')
+  })
+
+  it('honours a lead-time phrase in the plain text', () => {
+    const [reminder] = derive(
+      doc(para([['Call venue ', false], ['8/21 2pm', true], [' (remind 3 hours before)', false]])),
+    )
+    expect(reminder.leadMinutes).toBe(180)
+    expect(iso(reminder.fireAt)).toBe('2026-08-21T15:00:00.000Z') // 11:00 AM EDT
+  })
+
+  it('stays silent when the line says not to remind', () => {
+    expect(
+      derive(doc(para([['Standup ', false], ['8/13 9am', true], [' — no reminder', false]]))),
+    ).toEqual([])
+  })
+
+  it('ignores struck-through lines', () => {
+    const struck = {
+      type: 'paragraph',
+      attrs: { id: nextId() },
+      content: [
+        {
+          type: 'text',
+          text: '8/17 8:20am',
+          marks: [{ type: 'highlight', attrs: { color: CYAN } }, { type: 'strike' }],
+        },
+      ],
+    }
+    expect(derive(doc(struck))).toEqual([])
+  })
+
+  it('ignores a time that sits OUTSIDE the highlight', () => {
+    expect(derive(doc(para([['8/17', true], [' 8:20am', false]])))).toEqual([])
+  })
+
+  it('emits one reminder per timed date on a line', () => {
+    const reminders = derive(
+      doc(para([['Dinner ', false], ['8/17 7pm', true], [', brunch ', false], ['8/18 10am', true]])),
+    )
+    expect(reminders).toHaveLength(2)
+    expect(new Set(reminders.map((r) => r.dedupKey)).size).toBe(2)
+  })
+
+  it('emits one reminder per lead when several are requested', () => {
+    const reminders = derive(
+      doc(para([['Flight ', false], ['9/26 6:15am', true], [' — remind 1 day and 2h before', false]])),
+    )
+    expect(reminders.map((r) => r.leadMinutes)).toEqual([1440, 120])
+  })
+})
+
+describe('highlight pairing', () => {
+  it('pairs across an unhighlighted space', () => {
+    expect(derive(doc(para([['8/17', true], [' ', false], ['8:20am', true]])))).toHaveLength(1)
+  })
+
+  it('does NOT pair across a hard break', () => {
+    const block = {
+      type: 'paragraph',
+      attrs: { id: nextId() },
+      content: [
+        { type: 'text', text: '8/17', marks: [{ type: 'highlight', attrs: { color: CYAN } }] },
+        { type: 'hardBreak' },
+        { type: 'text', text: '8:20am', marks: [{ type: 'highlight', attrs: { color: CYAN } }] },
+      ],
+    }
+    expect(derive(doc(block))).toEqual([])
+  })
+
+  it('scopes the lead phrase to its own visual line', () => {
+    // The "remind 1 day before" sits on line 2; the date is on line 1.
+    const block = {
+      type: 'paragraph',
+      attrs: { id: nextId() },
+      content: [
+        { type: 'text', text: '8/17 8:20am', marks: [{ type: 'highlight', attrs: { color: CYAN } }] },
+        { type: 'hardBreak' },
+        { type: 'text', text: 'other thing — remind 1 day before' },
+      ],
+    }
+    expect(derive(doc(block))[0].leadMinutes).toBe(90) // the default, not 1440
+  })
+
+  it('mergeAdjacentHighlights folds a chain but respects newlines', () => {
+    expect(
+      mergeAdjacentHighlights([
+        { text: 'a', highlighted: true },
+        { text: ' ', highlighted: false },
+        { text: 'b', highlighted: true },
+      ]),
+    ).toEqual([{ text: 'a b', highlighted: true }])
+
+    expect(
+      mergeAdjacentHighlights([
+        { text: 'a', highlighted: true },
+        { text: '\n', highlighted: false },
+        { text: 'b', highlighted: true },
+      ]),
+    ).toHaveLength(3)
+  })
+})
+
+describe('the year ladder', () => {
+  it('rolls a bare date past the tracker month into the next year', () => {
+    // "January 2027 Tracker" doesn't exist yet; on the August 2026 page a bare
+    // 1/5 means the NEXT January.
+    const [reminder] = derive(doc(para([['Renew ', false], ['1/5 9am', true]])))
+    expect(iso(reminder.dueAt).slice(0, 10)).toBe('2027-01-05')
+  })
+
+  it('respects an explicit slash-year', () => {
+    const [reminder] = derive(doc(para([['Expires ', false], ['3/2/27 9am', true]])))
+    expect(iso(reminder.dueAt).slice(0, 10)).toBe('2027-03-02')
+  })
+})
+
+describe('quiet hours defer rather than drop', () => {
+  it('pushes an 03:00 fire time to 07:00 local', () => {
+    // Event at 9am, 6h lead -> 3am. Deferred to 7am, still before the event.
+    const [reminder] = derive(
+      doc(para([['Thing ', false], ['8/17 9:00am', true], [' — remind 6 hours before', false]])),
+    )
+    expect(reminder.quietDeferred).toBe(true)
+    expect(iso(reminder.fireAt)).toBe('2026-08-17T11:00:00.000Z') // 7:00 AM EDT
+  })
+
+  it('does NOT defer past the event itself', () => {
+    // 6am flight, 90-min lead -> 4:30am. Deferring to 7am would be after takeoff.
+    const [reminder] = derive(doc(para([['Flight ', false], ['9/26 6:15am', true]])))
+    expect(reminder.quietDeferred).toBe(false)
+    expect(iso(reminder.fireAt)).toBe('2026-09-26T08:45:00.000Z') // 4:45 AM EDT
+  })
+
+  it('leaves a daytime fire time alone', () => {
+    const dueAt = Date.parse('2026-08-17T20:00:00Z')
+    const fireAt = Date.parse('2026-08-17T18:00:00Z') // 2pm EDT
+    expect(deferPastQuietHours(fireAt, dueAt, NY, { startHour: 22, endHour: 7 })).toEqual({
+      fireAt,
+      deferred: false,
+    })
+  })
+})
+
+// ---------------------------------------------------------------------------
+// ⭐ Part 1's payoff: dates inside multi-column tables used to be unreachable.
+// ---------------------------------------------------------------------------
+describe('multi-column table rows', () => {
+  const cell = (runs: Array<[string, boolean]>) => ({
+    type: 'tableCell',
+    content: [para(runs)],
+  })
+
+  const rewardsTable = {
+    type: 'table',
+    content: [
+      {
+        type: 'tableRow',
+        content: [
+          { type: 'tableHeader', content: [para([['Reward', false]])] },
+          { type: 'tableHeader', content: [para([['Use-By Date', false]])] },
+          { type: 'tableHeader', content: [para([['Notes', false]])] },
+        ],
+      },
+      {
+        type: 'tableRow',
+        content: [
+          cell([['Chase points', false]]),
+          cell([['8/17 8:20am', true]]),
+          cell([['book the flight', false]]),
+        ],
+      },
+    ],
+  }
+
+  it('derives a reminder from a timed date in a table cell', () => {
+    const reminders = derive(doc(rewardsTable))
+    expect(reminders).toHaveLength(1)
+    expect(reminders[0].blockId).toBeTruthy()
+    // The whole row is the addressable unit, so the Notes cell is in the text.
+    expect(reminders[0].lineText).toContain('Chase points')
+    expect(reminders[0].lineText).toContain('book the flight')
+  })
+
+  it('does not derive anything from the header row', () => {
+    const headerOnly = {
+      type: 'table',
+      content: [
+        {
+          type: 'tableRow',
+          content: [
+            { type: 'tableHeader', content: [para([['8/17 8:20am', true]])] },
+            { type: 'tableHeader', content: [para([['x', false]])] },
+          ],
+        },
+      ],
+    }
+    expect(derive(doc(headerOnly))).toEqual([])
+  })
+})
+
+describe('countOrphanedTimedHighlights', () => {
+  it('is zero when every timed highlight was reachable', () => {
+    const content = doc(para([['Appt ', false], ['8/17 8:20am', true]]))
+    const reminders = derive(content)
+    expect(countOrphanedTimedHighlights([page(...(content.content as never[]))], reminders.length)).toBe(0)
+  })
+
+  it('reports a timed highlight that produced no reminder', () => {
+    const content = doc(para([['Appt ', false], ['8/17 8:20am', true]]))
+    expect(countOrphanedTimedHighlights([{ id: 'p', title: 'August 2026 Tracker', content }], 0)).toBe(1)
+  })
+})
+
+describe('dedup keys', () => {
+  it('changes when the time changes but not when the wording does', () => {
+    const first = derive(doc(para([['Appt ', false], ['8/17 8:20am', true]], 'fixed-id')))
+    const reworded = derive(doc(para([['Doctor appt ', false], ['8/17 8:20am', true]], 'fixed-id')))
+    const retimed = derive(doc(para([['Appt ', false], ['8/17 9:20am', true]], 'fixed-id')))
+
+    expect(reworded[0].dedupKey).toBe(first[0].dedupKey)
+    expect(retimed[0].dedupKey).not.toBe(first[0].dedupKey)
+  })
+
+  it('changes when the lead changes', () => {
+    const base = derive(doc(para([['Appt ', false], ['8/17 8:20am', true]], 'fixed-id')))
+    const led = derive(
+      doc(para([['Appt ', false], ['8/17 8:20am', true], [' (remind 30 min before)', false]], 'fixed-id')),
+    )
+    expect(led[0].dedupKey).not.toBe(base[0].dedupKey)
+  })
+})

--- a/supabase/functions/_shared/deriveReminders.ts
+++ b/supabase/functions/_shared/deriveReminders.ts
@@ -1,0 +1,307 @@
+// Turn tracker documents into the complete set of reminders that SHOULD exist
+// right now — deterministically, with zero AI tokens.
+//
+// HOUSE RULE: zero jsr:/npm:/https:// imports, zero top-level `Deno.*`.
+//
+// The contract that protects the user's 573 existing date-only highlights: a
+// highlighted date arms a push ONLY if a clock time sits inside the same
+// highlight. A bare date is, and stays, daily-list-only.
+
+import {
+  collectInlineSegments,
+  extractDateTokens,
+  resolveTokenDate,
+  resolveTrackerAnchor,
+  serializeTrackerToMarkdown,
+  type InlineSegment,
+} from './dailyHelpers.ts'
+import { parseTimeAfterDate } from './timeParse.ts'
+import { DEFAULT_LEAD_MINUTES, parseLeadTimes } from './leadTime.ts'
+import { localWallClock, wallClockToUtc } from './wallClock.ts'
+
+export type QuietHours = { startHour: number; endHour: number }
+
+export type DeriveOptions = {
+  /** Today's date in the USER's zone, YYYY-MM-DD. See the `today` trap below. */
+  todayLocal: string
+  timeZone: string
+  defaultLeadMinutes?: number
+  quiet?: QuietHours | null
+}
+
+export type TimedDate = {
+  /** UTC ms of the event itself. */
+  dueAt: number
+  leadMinutes: number
+  /** UTC ms the text should go out — lead applied, quiet hours resolved. */
+  fireAt: number
+  /** The raw date token, e.g. "8/17". */
+  dateText: string
+  /** The visual line the token sits on (hard breaks split a block into lines). */
+  lineText: string
+  /** Character range of the lead clause within lineText, if one was found. */
+  leadMatch: { start: number; end: number } | null
+  quietDeferred: boolean
+  dstShifted: boolean
+}
+
+export type DerivedReminder = TimedDate & {
+  dedupKey: string
+  blockId: string
+  pageId: string | null
+  cid: string
+}
+
+const MS_PER_MINUTE = 60_000
+
+/**
+ * The user sometimes leaves the space BETWEEN a date and its time unhighlighted,
+ * which would silently break pairing. Merge `highlighted, blank-plain,
+ * highlighted` triples back into one run.
+ *
+ * Excludes `\n` deliberately: collectInlineSegments emits a newline segment for a
+ * hardBreak, and a line break must break the pairing.
+ */
+export function mergeAdjacentHighlights(segments: InlineSegment[]): InlineSegment[] {
+  const out: InlineSegment[] = []
+  let i = 0
+  while (i < segments.length) {
+    const a = segments[i]
+    const b = segments[i + 1]
+    const c = segments[i + 2]
+    if (a?.highlighted && c?.highlighted && b && !b.highlighted && /^[ \t]*$/.test(b.text)) {
+      // Fold the triple, then keep folding onto it (a b c b c … chain).
+      let text = a.text + b.text + c.text
+      i += 3
+      while (
+        segments[i] &&
+        !segments[i].highlighted &&
+        /^[ \t]*$/.test(segments[i].text) &&
+        segments[i + 1]?.highlighted
+      ) {
+        text += segments[i].text + segments[i + 1].text
+        i += 2
+      }
+      out.push({ text, highlighted: true })
+      continue
+    }
+    out.push(a)
+    i += 1
+  }
+  return out
+}
+
+const inQuietWindow = (hour: number, quiet: QuietHours): boolean => {
+  const { startHour, endHour } = quiet
+  if (startHour === endHour) return false
+  if (startHour < endHour) return hour >= startHour && hour < endHour
+  return hour >= startHour || hour < endHour // window wraps midnight
+}
+
+/**
+ * Quiet hours DEFER, they don't drop.
+ *
+ * The escape hatch matters: a 6am flight with a 90-minute lead fires at 4:30am
+ * rather than being pushed to 7am, which would be after takeoff.
+ */
+export function deferPastQuietHours(
+  fireAt: number,
+  dueAt: number,
+  timeZone: string,
+  quiet: QuietHours | null | undefined,
+): { fireAt: number; deferred: boolean } {
+  if (!quiet) return { fireAt, deferred: false }
+
+  const local = localWallClock(fireAt, timeZone)
+  if (!inQuietWindow(local.hour, quiet)) return { fireAt, deferred: false }
+
+  // Next endHour:00 local at or after fireAt.
+  let target = { ...local, hour: quiet.endHour, minute: 0 }
+  let solved = wallClockToUtc(target, timeZone).ts
+  if (solved <= fireAt) {
+    const next = new Date(Date.UTC(local.year, local.month - 1, local.day + 1))
+    target = {
+      year: next.getUTCFullYear(),
+      month: next.getUTCMonth() + 1,
+      day: next.getUTCDate(),
+      hour: quiet.endHour,
+      minute: 0,
+    }
+    solved = wallClockToUtc(target, timeZone).ts
+  }
+
+  if (solved > dueAt) return { fireAt, deferred: false }
+  return { fireAt: solved, deferred: true }
+}
+
+/** The \n-delimited run of `text` containing `offset` — a hard break ends a line. */
+const lineRunAt = (text: string, offset: number): { text: string; start: number } => {
+  const start = text.lastIndexOf('\n', Math.max(0, offset - 1)) + 1
+  const endIdx = text.indexOf('\n', offset)
+  const end = endIdx === -1 ? text.length : endIdx
+  return { text: text.slice(start, end), start }
+}
+
+/**
+ * Every timed date on one block's inline runs. Shared by the cron sweep and the
+ * bot's confirmation message, so the bot can never promise a reminder the sweep
+ * won't send.
+ */
+export function deriveFromSegments(
+  segments: InlineSegment[],
+  anchor: Date,
+  opts: DeriveOptions,
+): TimedDate[] {
+  const merged = mergeAdjacentHighlights(segments ?? [])
+  const fullText = merged.map((s) => s.text).join('')
+  const defaultLead = opts.defaultLeadMinutes ?? DEFAULT_LEAD_MINUTES
+  const results: TimedDate[] = []
+
+  let offset = 0
+  for (const segment of merged) {
+    if (!segment.highlighted) {
+      offset += segment.text.length
+      continue
+    }
+
+    // The date's year still follows the daily list's ladder over the whole block,
+    // so a "(of 2027)" note anywhere on the line keeps working.
+    for (const token of extractDateTokens(segment.text, 1970)) {
+      const tail = segment.text.slice(token.index + token.raw.length)
+      const time = parseTimeAfterDate(tail)
+      if (!time) continue // date with no time inside the highlight -> never a push
+
+      const { date } = resolveTokenDate(token, fullText, anchor)
+      const due = wallClockToUtc(
+        {
+          year: date.getUTCFullYear(),
+          month: date.getUTCMonth() + 1,
+          day: date.getUTCDate(),
+          hour: time.hour,
+          minute: time.minute,
+        },
+        opts.timeZone,
+      )
+
+      // Lead phrases are scoped to the visual line: a phrase after a hard break
+      // must not apply to a date before it.
+      const run = lineRunAt(fullText, offset + token.index)
+      const lead = parseLeadTimes(run.text)
+      if (lead.suppressed) continue
+
+      const leads = lead.minutes.length ? lead.minutes : [defaultLead]
+      for (const leadMinutes of leads) {
+        const raw = due.ts - leadMinutes * MS_PER_MINUTE
+        const quiet = deferPastQuietHours(raw, due.ts, opts.timeZone, opts.quiet)
+        results.push({
+          dueAt: due.ts,
+          leadMinutes,
+          fireAt: quiet.fireAt,
+          dateText: token.raw,
+          lineText: run.text,
+          leadMatch: lead.match,
+          quietDeferred: quiet.deferred,
+          dstShifted: due.shifted,
+        })
+      }
+    }
+
+    offset += segment.text.length
+  }
+
+  return results
+}
+
+/**
+ * Identity of a derived reminder.
+ *
+ * Deliberately EXCLUDES the line text — fixing a typo must not re-fire.
+ * Deliberately INCLUDES due_at and lead — editing either yields a new key, so the
+ * corrected reminder fires and the stale one simply is never derived again.
+ */
+export const derivedDedupKey = (blockId: string, dueAt: number, leadMinutes: number): string =>
+  `d:${blockId}:${new Date(dueAt).toISOString()}:${leadMinutes}`
+
+export const snoozeDedupKey = (blockId: string, fireAt: number): string =>
+  `s:${blockId}:${new Date(fireAt).toISOString()}`
+
+export type ReminderPage = {
+  id?: string
+  pageId?: string
+  title?: string
+  content?: unknown
+}
+
+/**
+ * Derive the complete reminder set from tracker pages.
+ *
+ * ⚠️ THE `today` TRAP: `opts.todayLocal` must be computed with
+ * localIsoDate(now, tz) — NOT `toISOString().slice(0,10)`, which already says
+ * "tomorrow" at 8pm Eastern and would shift the whole year ladder by a day for
+ * five hours every night.
+ */
+export function deriveReminders(
+  pages: ReminderPage[],
+  opts: DeriveOptions,
+): DerivedReminder[] {
+  const out: DerivedReminder[] = []
+
+  ;(pages ?? []).forEach((page, pageIdx) => {
+    // Per page, so each page's bare dates anchor to that page's own month and the
+    // pageId is known without a second lookup.
+    const { cidToBlockId, cidSegments } = serializeTrackerToMarkdown(page?.content, page?.title)
+    const anchor = resolveTrackerAnchor(page?.title, opts.todayLocal)
+    const pageId = page?.pageId ?? page?.id ?? null
+
+    for (const [cid, segments] of cidSegments) {
+      const blockId = cidToBlockId.get(cid)
+      if (!blockId) continue
+
+      for (const timed of deriveFromSegments(segments, anchor, opts)) {
+        out.push({
+          ...timed,
+          dedupKey: derivedDedupKey(blockId, timed.dueAt, timed.leadMinutes),
+          blockId,
+          pageId,
+          cid: `p${pageIdx}-${cid}`,
+        })
+      }
+    }
+  })
+
+  return out
+}
+
+/**
+ * Diagnostic: highlighted runs that DO carry a clock time but never got an anchor,
+ * and so can never become a reminder. Should be 0. Anything else is a new class of
+ * unreachable date and deserves a loud warning rather than a silent no-op.
+ */
+export function countOrphanedTimedHighlights(
+  pages: ReminderPage[],
+  reachable: number,
+): number {
+  let total = 0
+
+  const countBlock = (nodes: unknown[]) => {
+    const merged = mergeAdjacentHighlights(collectInlineSegments(nodes as any[]))
+    for (const segment of merged) {
+      if (!segment.highlighted) continue
+      for (const token of extractDateTokens(segment.text, 1970)) {
+        if (parseTimeAfterDate(segment.text.slice(token.index + token.raw.length))) total += 1
+      }
+    }
+  }
+
+  const walk = (node: any) => {
+    if (!node || typeof node !== 'object' || !Array.isArray(node.content)) return
+    if (node.content.some((child: any) => child?.type === 'text')) {
+      countBlock(node.content)
+      return
+    }
+    node.content.forEach(walk)
+  }
+
+  ;(pages ?? []).forEach((page) => walk(page?.content))
+  return Math.max(0, total - reachable)
+}

--- a/supabase/functions/_shared/leadTime.test.ts
+++ b/supabase/functions/_shared/leadTime.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from 'vitest'
+
+import { DEFAULT_LEAD_MINUTES, parseLeadTimes } from './leadTime.ts'
+
+const leads = (text: string) => parseLeadTimes(text).minutes
+
+describe('parseLeadTimes — accepted clauses', () => {
+  const cases: Array<[string, number[]]> = [
+    ['Flight to Denver 9/26 6:15am — text me 1 day before', [1440]],
+    ['Call venue 8/21 2pm (remind 3 hours before)', [180]],
+    ['ping me 30 min before', [30]],
+    ['alert 45 minutes before', [45]],
+    ['nudge me 2h before', [120]],
+    ['warn me 1 week before', [10080]],
+    ['an hour before', [60]], // terminal clause, no trigger needed
+    ['half an hour before', [30]],
+    ['1 day before', [1440]],
+    ['remind 1 hour 30 min before', [90]], // adjacent quantities sum
+    ['remind 1 day and 2h before', [1440, 120]], // a connector splits them
+    ['text me 15 minutes before.', [15]],
+    ['notify me two days before', [2880]],
+  ]
+
+  it.each(cases)('%j -> %j', (text, expected) => {
+    expect(leads(text)).toEqual(expected)
+  })
+})
+
+describe('parseLeadTimes — suppression wins over everything', () => {
+  const suppressing = [
+    'Standup 8/13 9am — no reminder',
+    'no reminders',
+    'no alerts please',
+    "don't remind me",
+    'do not text me',
+    // Even alongside a perfectly good lead clause.
+    'remind 2 hours before — actually no reminder',
+  ]
+
+  it.each(suppressing)('%j', (text) => {
+    const result = parseLeadTimes(text)
+    expect(result.suppressed).toBe(true)
+    expect(result.minutes).toEqual([])
+  })
+})
+
+// The real false-positive class. Ordinary prose must never silently rewrite its
+// own lead time — these fall through to the caller's default.
+describe('parseLeadTimes — prose is not an instruction', () => {
+  const noClause = [
+    'finish 3 days before the wedding 8/17 7pm',
+    '20 mi before work',
+    'run 5 miles before breakfast',
+    'Dietician appointment 8/17 8:20am',
+    '',
+  ]
+
+  it.each(noClause)('%j -> no clause', (text) => {
+    const result = parseLeadTimes(text)
+    expect(result.suppressed).toBe(false)
+    expect(result.minutes).toEqual([])
+    expect(result.match).toBeNull()
+  })
+})
+
+it('caps runaway clauses at three leads', () => {
+  expect(leads('remind 1 day and 2 hours and 30 min and 10 min before').length).toBeLessThanOrEqual(3)
+})
+
+it('reports the clause range so the display text can strip it', () => {
+  const text = 'Call venue (remind 3 hours before)'
+  const result = parseLeadTimes(text)
+  expect(text.slice(result.match!.start, result.match!.end)).toBe('remind 3 hours before')
+})
+
+it('exposes the agreed 90-minute default', () => {
+  expect(DEFAULT_LEAD_MINUTES).toBe(90)
+})

--- a/supabase/functions/_shared/leadTime.ts
+++ b/supabase/functions/_shared/leadTime.ts
@@ -1,0 +1,171 @@
+// "How early should I be told?" — parsed from the PLAIN text on the same line as
+// a highlighted date. Highlight = when; line text = how early.
+//
+// HOUSE RULE: zero jsr:/npm:/https:// imports, zero top-level `Deno.*`.
+
+export const DEFAULT_LEAD_MINUTES = 90
+
+/** At most this many reminders from one line, however many clauses it carries. */
+const MAX_LEADS = 3
+
+const NUMWORD: Record<string, number> = {
+  a: 1,
+  an: 1,
+  one: 1,
+  two: 2,
+  three: 3,
+  four: 4,
+  five: 5,
+  six: 6,
+  seven: 7,
+  eight: 8,
+  nine: 9,
+  ten: 10,
+  eleven: 11,
+  twelve: 12,
+  fifteen: 15,
+  twenty: 20,
+  thirty: 30,
+  forty: 40,
+  fortyfive: 45,
+  sixty: 60,
+  ninety: 90,
+}
+
+const UNIT_MIN: Record<string, number> = {
+  m: 1,
+  min: 1,
+  mins: 1,
+  minute: 1,
+  minutes: 1,
+  h: 60,
+  hr: 60,
+  hrs: 60,
+  hour: 60,
+  hours: 60,
+  d: 1440,
+  day: 1440,
+  days: 1440,
+  w: 10080,
+  week: 10080,
+  weeks: 10080,
+}
+
+// Longest-first so "minutes" is never cut short to "min".
+const byLengthDesc = (keys: string[]) => keys.slice().sort((a, b) => b.length - a.length)
+const UNITS_SRC = byLengthDesc(Object.keys(UNIT_MIN)).join('|')
+const NUMWORDS_SRC = byLengthDesc(Object.keys(NUMWORD)).join('|')
+
+// One quantity: "30 min", "an hour", "half an hour", "2h".
+// The trailing \b is what stops "20 mi before work" from reading as a quantity.
+const QTY_SRC = `(?:\\d+|half\\s+an?|${NUMWORDS_SRC})\\s*(?:${UNITS_SRC})\\b`
+const QTY_G = new RegExp(`(\\d+|half\\s+an?|${NUMWORDS_SRC})\\s*(${UNITS_SRC})\\b`, 'gi')
+
+// One or more quantities, then "before".
+const LEAD_G = new RegExp(`(?:${QTY_SRC}[\\s,]*(?:and\\s+)?)+\\s*before\\b`, 'gi')
+
+// A LEAD run only counts as an instruction if it's asked for. Either a trigger
+// verb sits just before it, or the clause terminates the sentence/parenthetical.
+const TRIGGER_RE = /\b(remind|text|ping|alert|notify|nudge|buzz|warn)\w*\b/i
+const TRIGGER_WINDOW = 24
+const TERMINAL_RE = /^\s*([)\].,;]|$)/
+
+const SUPPRESS_RES = [
+  /\bno\s+(reminder|alert|ping)s?\b/i,
+  /\b(don'?t|do not)\s+(remind|text|ping|notify)\b/i,
+]
+
+/**
+ * A standalone duration phrase ("30m", "2 hours", "an hour", "1 day") in minutes,
+ * or null if the whole string isn't one. Used by the snooze parser, which needs
+ * the quantity grammar without the "before" clause around it.
+ */
+export function parseDurationPhrase(text: string): number | null {
+  const trimmed = String(text ?? '').trim()
+  if (!trimmed) return null
+  const exact = new RegExp(`^(\\d+|half\\s+an?|${NUMWORDS_SRC})\\s*(${UNITS_SRC})$`, 'i')
+  const match = trimmed.match(exact)
+  if (!match) return null
+  const minutes = quantityMinutes(match[1], match[2])
+  return minutes > 0 ? Math.round(minutes) : null
+}
+
+export type LeadResult = {
+  /** The user explicitly asked for silence on this line. */
+  suppressed: boolean
+  /** Lead times in minutes. Empty means "no clause found — use the default". */
+  minutes: number[]
+  /** Character range of the matched clause, so callers can strip it from display text. */
+  match: { start: number; end: number } | null
+}
+
+const quantityMinutes = (numRaw: string, unitRaw: string): number => {
+  const unit = UNIT_MIN[unitRaw.toLowerCase()] ?? 0
+  const token = numRaw.trim().toLowerCase()
+  if (/^\d+$/.test(token)) return Number(token) * unit
+  if (token.startsWith('half')) return unit / 2
+  return (NUMWORD[token] ?? 0) * unit
+}
+
+/**
+ * Read a lead-time instruction out of a line.
+ *
+ * Acceptance, in priority order:
+ *   1. Suppression wins outright.
+ *   2. A quantity clause with a trigger verb within ~24 chars before it.
+ *   3. A quantity clause that terminates the sentence or parenthetical.
+ *   4. Otherwise no clause — the caller uses its default.
+ *
+ * Rules 2-3 exist to stop ordinary prose from silently rewriting its own lead
+ * time: "finish 3 days before the wedding" is a description, not an instruction.
+ */
+export function parseLeadTimes(text: string): LeadResult {
+  const line = String(text ?? '')
+  if (SUPPRESS_RES.some((re) => re.test(line))) {
+    return { suppressed: true, minutes: [], match: null }
+  }
+
+  LEAD_G.lastIndex = 0
+  let match: RegExpExecArray | null = LEAD_G.exec(line)
+  while (match) {
+    const start = match.index
+    const end = start + match[0].length
+    const windowStart = Math.max(0, start - TRIGGER_WINDOW)
+    const before = line.slice(windowStart, start)
+    const trigger = before.match(TRIGGER_RE)
+    const accepted = Boolean(trigger) || TERMINAL_RE.test(line.slice(end))
+
+    if (accepted) {
+      const minutes = splitLeadParts(match[0])
+      if (minutes.length) {
+        // Report the clause INCLUDING its trigger verb, so stripping it for
+        // display leaves "Call venue ()" rather than "Call venue (remind )".
+        const clauseStart = trigger ? windowStart + (trigger.index ?? 0) : start
+        return { suppressed: false, minutes, match: { start: clauseStart, end } }
+      }
+    }
+    match = LEAD_G.exec(line)
+  }
+
+  return { suppressed: false, minutes: [], match: null }
+}
+
+// "1 hour 30 min before" is ONE lead of 90 minutes (adjacent quantities sum);
+// "1 day and 2h before" is TWO leads (an explicit connector splits them).
+function splitLeadParts(run: string): number[] {
+  const parts = run.split(/\s*(?:,|\band\b)\s*/i)
+  const leads: number[] = []
+
+  for (const part of parts) {
+    QTY_G.lastIndex = 0
+    let total = 0
+    let qty: RegExpExecArray | null = QTY_G.exec(part)
+    while (qty) {
+      total += quantityMinutes(qty[1], qty[2])
+      qty = QTY_G.exec(part)
+    }
+    if (total > 0) leads.push(Math.round(total))
+  }
+
+  return leads.slice(0, MAX_LEADS)
+}

--- a/supabase/functions/_shared/reminderMessage.test.ts
+++ b/supabase/functions/_shared/reminderMessage.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  buildReminderText,
+  cleanLineText,
+  describeArmedReminders,
+  describeLead,
+} from './reminderMessage.ts'
+import type { DeriveOptions } from './deriveReminders.ts'
+
+const NY = 'America/New_York'
+const OPTS: DeriveOptions = {
+  todayLocal: '2026-08-09',
+  timeZone: NY,
+  defaultLeadMinutes: 90,
+  quiet: { startHour: 22, endHour: 7 },
+}
+const ANCHOR = new Date(Date.UTC(2026, 7, 1)) // "August 2026 Tracker"
+
+describe('describeLead', () => {
+  it.each([
+    [0, 'now'],
+    [30, '30 minutes'],
+    [1, '1 minute'],
+    [90, '90 minutes'],
+    [120, '2 hours'],
+    [180, '3 hours'],
+    [1440, '1 day'],
+    [2880, '2 days'],
+  ])('%i -> %s', (minutes, expected) => {
+    expect(describeLead(minutes)).toBe(expected)
+  })
+})
+
+describe('cleanLineText', () => {
+  it('strips the lead clause and collapses whitespace', () => {
+    const line = 'Call venue   8/21 2pm (remind 3 hours before)'
+    expect(cleanLineText(line, { start: line.indexOf('remind'), end: line.length - 1 })).toBe(
+      'Call venue 8/21 2pm',
+    )
+  })
+
+  it('leaves the line alone when there is no clause', () => {
+    expect(cleanLineText('  Dietician appointment  8/17 8:20am ', null)).toBe(
+      'Dietician appointment 8/17 8:20am',
+    )
+  })
+
+  it('truncates a very long line', () => {
+    const cleaned = cleanLineText('x'.repeat(400), null)
+    expect(cleaned.length).toBeLessThanOrEqual(200)
+    expect(cleaned.endsWith('…')).toBe(true)
+  })
+})
+
+describe('buildReminderText', () => {
+  it('renders header, local time, and the link', () => {
+    const text = buildReminderText(
+      {
+        dueAt: Date.parse('2026-08-17T12:20:00Z'),
+        leadMinutes: 90,
+        lineText: 'Dietician appointment  8/17 8:20am',
+        leadMatch: null,
+      },
+      NY,
+      'https://example.test/#nb=1&block=2',
+    )
+    expect(text).toBe(
+      '⏰ In 90 minutes — Dietician appointment 8/17 8:20am\n\n' +
+        'Mon Aug 17 · 8:20 AM\n\n' +
+        'https://example.test/#nb=1&block=2',
+    )
+  })
+
+  it('omits the link line when there is nothing to link to', () => {
+    const text = buildReminderText(
+      { dueAt: Date.parse('2026-08-17T12:20:00Z'), leadMinutes: 30, lineText: 'Thing', leadMatch: null },
+      NY,
+      '',
+    )
+    expect(text.split('\n')).toHaveLength(3)
+  })
+})
+
+// The bot's confirmation runs the SAME deriver the cron does, so it can never
+// promise a reminder the sweep won't send.
+describe('describeArmedReminders', () => {
+  it('states the armed time and lead for a timed date', () => {
+    const line = describeArmedReminders(
+      ['call the venue {{date:8/21 2:00 PM}} (remind 3 hours before)'],
+      ANCHOR,
+      OPTS,
+    )
+    expect(line).toContain('3 hours before')
+    expect(line).toContain('11:00 AM')
+    expect(line).toContain('Fri Aug 21')
+  })
+
+  it('stays silent for a date with no time', () => {
+    expect(describeArmedReminders(['renew pass {{date:6/15}}'], ANCHOR, OPTS)).toBe('')
+  })
+
+  it('stays silent when the user asked for no reminder', () => {
+    expect(
+      describeArmedReminders(['standup {{date:8/13 9:00 AM}} (no reminder)'], ANCHOR, OPTS),
+    ).toBe('')
+  })
+
+  it('reports one line per armed reminder', () => {
+    const text = describeArmedReminders(
+      ['dinner {{date:8/17 7:00 PM}}', 'brunch {{date:8/18 10:00 AM}}'],
+      ANCHOR,
+      OPTS,
+    )
+    expect(text.split('\n')).toHaveLength(2)
+  })
+})

--- a/supabase/functions/_shared/reminderMessage.ts
+++ b/supabase/functions/_shared/reminderMessage.ts
@@ -1,0 +1,100 @@
+// Wording for the outbound reminder text and for the bot's post-confirmation
+// "here's what I'll do" line.
+//
+// HOUSE RULE: zero jsr:/npm:/https:// imports, zero top-level `Deno.*`.
+
+import { deriveFromSegments, type DeriveOptions, type TimedDate } from './deriveReminders.ts'
+import { splitDateTokens } from './dateToken.ts'
+import { formatInZone } from './wallClock.ts'
+import type { InlineSegment } from './dailyHelpers.ts'
+
+const MAX_BODY_CHARS = 200
+
+/** "90 minutes" / "2 hours" / "1 day". */
+export function describeLead(minutes: number): string {
+  if (minutes <= 0) return 'now'
+  if (minutes < 120) return `${minutes} minute${minutes === 1 ? '' : 's'}`
+  if (minutes % 1440 === 0) {
+    const days = minutes / 1440
+    return `${days} day${days === 1 ? '' : 's'}`
+  }
+  if (minutes % 60 === 0) {
+    const hours = minutes / 60
+    return `${hours} hour${hours === 1 ? '' : 's'}`
+  }
+  return `${minutes} minutes`
+}
+
+/**
+ * The line's text as a person should read it: the lead-time instruction removed
+ * (it's machine-facing, and it's already restated in the header), whitespace
+ * collapsed, and trimmed to a sane length for a push notification.
+ */
+export function cleanLineText(
+  lineText: string,
+  leadMatch: { start: number; end: number } | null,
+): string {
+  const source = String(lineText ?? '')
+  const stripped = leadMatch
+    ? source.slice(0, leadMatch.start) + source.slice(leadMatch.end)
+    : source
+
+  const collapsed = stripped
+    .replace(/\(\s*\)/g, '') // an emptied parenthetical
+    .replace(/\s+/g, ' ')
+    .trim()
+
+  if (collapsed.length <= MAX_BODY_CHARS) return collapsed
+  return collapsed.slice(0, MAX_BODY_CHARS - 1).trimEnd() + '…'
+}
+
+/**
+ * The outbound text. Plain — no parse_mode. This function emits a fixed format we
+ * control, so it skips the escaping machinery telegram.ts needs for model output,
+ * and Telegram auto-links the bare URL.
+ */
+export function buildReminderText(
+  reminder: Pick<TimedDate, 'dueAt' | 'leadMinutes' | 'lineText' | 'leadMatch'>,
+  timeZone: string,
+  deepLink: string,
+): string {
+  const header =
+    reminder.leadMinutes > 0 ? `⏰ In ${describeLead(reminder.leadMinutes)}` : '⏰ Now'
+  const body = cleanLineText(reminder.lineText, reminder.leadMatch)
+  const when = formatInZone(reminder.dueAt, timeZone)
+
+  const lines = [body ? `${header} — ${body}` : header, '', when]
+  if (deepLink) lines.push('', deepLink)
+  return lines.join('\n')
+}
+
+/**
+ * What the bot promises right after the user confirms an addition.
+ *
+ * Runs the SAME deriveFromSegments the cron sweep uses, over the SAME
+ * {{date:…}} strings that were persisted with the job — so the bot cannot claim a
+ * reminder the sweep won't send. If the parser can't read it, this stays silent
+ * and the discrepancy is immediately visible.
+ */
+export function describeArmedReminders(
+  items: string[],
+  anchor: Date,
+  opts: DeriveOptions,
+): string {
+  const lines: string[] = []
+
+  for (const item of items ?? []) {
+    const segments: InlineSegment[] = splitDateTokens(item).map((run) => ({
+      text: run.text,
+      highlighted: run.isDate,
+    }))
+    for (const timed of deriveFromSegments(segments, anchor, opts)) {
+      lines.push(
+        `⏰ I'll text you ${formatInZone(timed.fireAt, opts.timeZone, ' at ')} ` +
+          `(${describeLead(timed.leadMinutes)} before).`,
+      )
+    }
+  }
+
+  return lines.join('\n')
+}

--- a/supabase/functions/_shared/reminderReply.test.ts
+++ b/supabase/functions/_shared/reminderReply.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest'
+
+import { DEFAULT_SNOOZE_MINUTES, parseReminderReply } from './reminderReply.ts'
+
+describe('parseReminderReply — done', () => {
+  it.each(['done', 'Done', 'done.', 'did it', 'finished', 'completed', '✅', '  done  '])(
+    '%j -> done',
+    (text) => {
+      expect(parseReminderReply(text)).toEqual({ kind: 'done' })
+    },
+  )
+})
+
+describe('parseReminderReply — snooze', () => {
+  it.each<[string, number]>([
+    ['snooze', DEFAULT_SNOOZE_MINUTES],
+    ['snooze 1h', 60],
+    ['snooze 30m', 30],
+    ['snooze for 2 hours', 120],
+    ['remind me in 30m', 30],
+    ['remind me again in 1 hour', 60],
+    ['later', DEFAULT_SNOOZE_MINUTES],
+  ])('%j -> %i minutes', (text, minutes) => {
+    expect(parseReminderReply(text)).toEqual({ kind: 'snooze', minutes })
+  })
+})
+
+// The whole point of a strict parser: an ordinary message must never be
+// hijacked into crossing something off the user's tracker.
+describe('parseReminderReply — leaves real messages alone', () => {
+  it.each([
+    '',
+    'what did I get done this week?',
+    'is the dietician appointment done?',
+    'remind me about the dentist',
+    'add buy more gels to running',
+    'done with the marathon block, what next?',
+    'snooze the whole idea of running',
+    'yes',
+  ])('%j -> null', (text) => {
+    expect(parseReminderReply(text)).toBeNull()
+  })
+})

--- a/supabase/functions/_shared/reminderReply.ts
+++ b/supabase/functions/_shared/reminderReply.ts
@@ -1,0 +1,57 @@
+// Deterministic keyword routing for a reply to a reminder — no AI call.
+//
+// HOUSE RULE: zero jsr:/npm:/https:// imports, zero top-level `Deno.*`.
+//
+// Deliberately strict: only a message that is ESSENTIALLY JUST the keyword
+// counts. Anything chattier falls through to the normal conversational flow, so
+// this can never hijack a real question.
+
+import { parseDurationPhrase } from './leadTime.ts'
+
+export const DEFAULT_SNOOZE_MINUTES = 60
+
+export type ReminderAction =
+  | { kind: 'done' }
+  | { kind: 'snooze'; minutes: number }
+  | null
+
+const DONE_RE =
+  /^(done|did it|did that|did|finished|finish|complete|completed|handled|taken care of|✅|☑️|✔️)$/i
+
+// "snooze", "snooze 30m", "snooze for 2 hours", "remind me in 1 hour",
+// "remind me again in 30 min", "later".
+const SNOOZE_RES = [
+  /^snooze(?:\s+for)?\s*(.*)$/i,
+  /^remind\s+me(?:\s+again)?(?:\s+in|\s+for)?\s*(.*)$/i,
+  /^later$/i,
+]
+
+const normalize = (text: string) =>
+  String(text ?? '')
+    .trim()
+    .replace(/^[\s"'“”]+|[\s"'“”.!]+$/g, '')
+    .replace(/\s+/g, ' ')
+
+/**
+ * Classify a bare reply. Returns null for anything that isn't unambiguously a
+ * "done" or a "snooze" — the caller then treats it as an ordinary message.
+ */
+export function parseReminderReply(text: string): ReminderAction {
+  const cleaned = normalize(text)
+  if (!cleaned) return null
+
+  if (DONE_RE.test(cleaned)) return { kind: 'done' }
+
+  for (const re of SNOOZE_RES) {
+    const match = cleaned.match(re)
+    if (!match) continue
+    const rest = (match[1] ?? '').trim()
+    if (!rest) return { kind: 'snooze', minutes: DEFAULT_SNOOZE_MINUTES }
+    const minutes = parseDurationPhrase(rest)
+    if (minutes) return { kind: 'snooze', minutes }
+    // "remind me about the dentist" — a real message, not a snooze.
+    return null
+  }
+
+  return null
+}

--- a/supabase/functions/_shared/strikeBlock.test.ts
+++ b/supabase/functions/_shared/strikeBlock.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from 'vitest'
+
+import { strikeBlock, type TiptapNode } from './strikeBlock.ts'
+
+const para = (id: string, ...texts: string[]): TiptapNode => ({
+  type: 'paragraph',
+  attrs: { id },
+  content: texts.map((text) => ({ type: 'text', text })),
+})
+
+const doc = (...content: TiptapNode[]): TiptapNode => ({ type: 'doc', content })
+
+const marksOf = (node: TiptapNode): string[][] =>
+  (node.content ?? []).map((t) => (t.marks ?? []).map((m) => String(m.type)))
+
+describe('strikeBlock', () => {
+  it('strikes every text node in the target block', () => {
+    const before = doc(para('a', 'Dietician appointment ', '8/17 8:20am'), para('b', 'other'))
+    const { doc: after, found } = strikeBlock(before, 'a')
+
+    expect(found).toBe(true)
+    expect(marksOf(after.content![0])).toEqual([['strike'], ['strike']])
+    expect(marksOf(after.content![1])).toEqual([[]]) // untouched
+  })
+
+  it('preserves existing marks alongside the strike', () => {
+    const before = doc({
+      type: 'paragraph',
+      attrs: { id: 'a' },
+      content: [
+        { type: 'text', text: '8/17', marks: [{ type: 'highlight', attrs: { color: '#67e8f9' } }] },
+      ],
+    })
+    const { doc: after } = strikeBlock(before, 'a')
+    expect(marksOf(after.content![0])).toEqual([['highlight', 'strike']])
+  })
+
+  it('is idempotent on an already-struck block', () => {
+    const once = strikeBlock(doc(para('a', 'done thing')), 'a').doc
+    const twice = strikeBlock(once, 'a').doc
+    expect(twice).toEqual(once)
+  })
+
+  it('also ticks the checkbox when the block is inside a taskItem', () => {
+    const before = doc({
+      type: 'taskList',
+      attrs: { id: 'list' },
+      content: [{ type: 'taskItem', attrs: { checked: false }, content: [para('a', 'buy gels')] }],
+    })
+    const { doc: after } = strikeBlock(before, 'a')
+    const item = after.content![0].content![0]
+    expect(item.attrs?.checked).toBe(true)
+    expect(marksOf(item.content![0])).toEqual([['strike']])
+  })
+
+  it('leaves a plain listItem parent alone', () => {
+    const before = doc({
+      type: 'bulletList',
+      attrs: { id: 'list' },
+      content: [{ type: 'listItem', content: [para('a', 'buy gels')] }],
+    })
+    const { doc: after } = strikeBlock(before, 'a')
+    expect(after.content![0].content![0].attrs?.checked).toBeUndefined()
+  })
+
+  it('returns the original doc for an unknown id', () => {
+    const before = doc(para('a', 'x'))
+    const result = strikeBlock(before, 'nope')
+    expect(result.found).toBe(false)
+    expect(result.doc).toBe(before)
+  })
+
+  it('does not mutate the input', () => {
+    const before = doc(para('a', 'x'))
+    const snapshot = JSON.parse(JSON.stringify(before))
+    strikeBlock(before, 'a')
+    expect(before).toEqual(snapshot)
+  })
+})

--- a/supabase/functions/_shared/strikeBlock.ts
+++ b/supabase/functions/_shared/strikeBlock.ts
@@ -1,0 +1,62 @@
+// Cross off a block in a Tiptap doc — the "done" reply's write path.
+//
+// Sibling of insertContent.ts `insertRelativeToBlock`: pure, immutable, walks
+// plain JSON. HOUSE RULE: zero jsr:/npm:/https:// imports, zero top-level `Deno.*`.
+
+export type TiptapNode = {
+  type?: string
+  text?: string
+  marks?: Array<{ type?: string; attrs?: Record<string, unknown> }>
+  attrs?: Record<string, unknown>
+  content?: TiptapNode[]
+}
+
+const strikeAllText = (node: TiptapNode): TiptapNode => {
+  if (node?.type === 'text') {
+    const marks = node.marks ?? []
+    if (marks.some((m) => m?.type === 'strike')) return node // already struck
+    return { ...node, marks: [...marks, { type: 'strike' }] }
+  }
+  if (!Array.isArray(node?.content)) return node
+  return { ...node, content: node.content.map(strikeAllText) }
+}
+
+/**
+ * Strike every text node inside the block with `blockId`, matching the user's own
+ * convention (they cross items off rather than deleting them). If that block sits
+ * directly inside a taskItem, the checkbox is ticked too.
+ *
+ * Idempotent: an already-struck block comes back unchanged. An unknown id returns
+ * the original doc with `found: false`.
+ */
+export function strikeBlock(
+  doc: TiptapNode,
+  blockId: string,
+): { doc: TiptapNode; found: boolean } {
+  if (!doc || typeof doc !== 'object' || !blockId) return { doc, found: false }
+
+  let found = false
+
+  const transform = (node: TiptapNode): TiptapNode => {
+    if (!Array.isArray(node.content)) return node
+
+    const content = node.content.map((child) => {
+      if (!found && child?.attrs?.id === blockId) {
+        found = true
+        return strikeAllText(child)
+      }
+      return transform(child)
+    })
+
+    const next: TiptapNode = { ...node, content }
+    // The struck block was one of MY children — if I'm a taskItem, tick me.
+    if (found && next.type === 'taskItem' && next.attrs?.checked !== true) {
+      const hitHere = node.content.some((child) => child?.attrs?.id === blockId)
+      if (hitHere) next.attrs = { ...(next.attrs ?? {}), checked: true }
+    }
+    return next
+  }
+
+  const nextDoc = transform(doc)
+  return found ? { doc: nextDoc, found: true } : { doc, found: false }
+}

--- a/supabase/functions/_shared/timeParse.test.ts
+++ b/supabase/functions/_shared/timeParse.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from 'vitest'
+
+import { parseTimeAfterDate } from './timeParse.ts'
+
+// The tail is whatever follows the date token inside the SAME highlighted run.
+const at = (tail: string) => {
+  const parsed = parseTimeAfterDate(tail)
+  return parsed ? `${String(parsed.hour).padStart(2, '0')}:${String(parsed.minute).padStart(2, '0')}` : null
+}
+
+describe('parseTimeAfterDate — accepts', () => {
+  const accepted: Array<[string, string]> = [
+    [' 8:20am', '08:20'],
+    [' 8:20 AM', '08:20'],
+    [' 8:20 a.m.', '08:20'],
+    [' 8pm', '20:00'],
+    [' 8 PM', '20:00'],
+    [' 20:00', '20:00'],
+    [' @ 8:20 AM', '08:20'],
+    [' @8:20', '08:20'],
+    [' at 5', '17:00'],
+    [' at 9', '09:00'],
+    [', 8:20am', '08:20'],
+    [' 8:20', '08:20'],
+    [' 1:00', '13:00'], // bare 1-6 reads as PM
+    [' 6:59', '18:59'],
+    [' 7:00', '07:00'], // 7-11 reads as AM
+    [' 12:00', '12:00'], // noon, not midnight
+    [' 12:00 AM', '00:00'], // explicit meridiem always wins
+    [' 12:30 PM', '12:30'],
+    [' 0:30', '00:30'],
+    [' 23:59', '23:59'],
+  ]
+
+  it.each(accepted)('%j -> %s', (tail, expected) => {
+    expect(at(tail)).toBe(expected)
+  })
+})
+
+// These rows matter most: they protect the 573 existing date-only highlights,
+// which must keep going to the daily list and never buzz a phone.
+describe('parseTimeAfterDate — rejects', () => {
+  const rejected = [
+    '', // "EOD 8/16" — nothing after the date
+    ' weekend', // "2/22 weekend"
+    ' 2026', // "8/17 2026"
+    ' 3rd',
+    ' 5k',
+    ' 1400',
+    ' 8.20am', // "." is deliberately not a separator ($8.50 would break)
+    ' 25:00',
+    ' 12:60',
+    ' 13pm', // meridiem with an impossible hour
+    ' 0pm',
+    ' 5-10 miles', // bare number, no marker
+    ' 5',
+    '-8/19 7pm', // a range: the tail of the FIRST date starts with "-"
+    ' /27', // slash-year leftovers never read as a time
+  ]
+
+  it.each(rejected)('%j -> null', (tail) => {
+    expect(parseTimeAfterDate(tail)).toBeNull()
+  })
+})
+
+it('reports the matched length so callers can advance past it', () => {
+  const parsed = parseTimeAfterDate(' 8:20am — text me 2 hours before')
+  expect(parsed?.length).toBe(' 8:20am'.length)
+})

--- a/supabase/functions/_shared/timeParse.ts
+++ b/supabase/functions/_shared/timeParse.ts
@@ -1,0 +1,70 @@
+// Clock-time parsing for the text that immediately follows a highlighted date.
+//
+// HOUSE RULE: zero jsr:/npm:/https:// imports, zero top-level `Deno.*` — Vitest
+// imports this directly.
+//
+// Design constraint that outranks everything else here: 573 of the user's 597
+// existing highlighted dates carry NO time and must keep behaving exactly as they
+// do today (daily list, never a push). So the grammar REQUIRES an unambiguous
+// marker — a bare number after a date never arms a reminder.
+
+export type ParsedTime = {
+  hour: number // 0-23
+  minute: number
+  /** Length of the matched run, so callers can advance past it. */
+  length: number
+}
+
+// Anchored at the start of the tail (the text right after the date token).
+//   [\s,]*      optional separator: "8/17, 8:20am"
+//   (@)|(at)    explicit markers that make a bare hour unambiguous
+//   (\d{1,2})   hour
+//   (:(\d{2}))? minutes
+//   meridiem    am/pm, optionally dotted
+//   (?![\w/:.]) the guard that kills "8/17 2026", "8/17 3rd", "8/17 5k",
+//               "8/17 1400", "8/17 8.20am" and slash-years
+export const TIME_RE =
+  /^[\s,]*(?:(@)\s*|(at)\s+)?(\d{1,2})(?::(\d{2}))?\s*(a\.m\.|am|p\.m\.|pm)?(?![\w/:.])/i
+
+/**
+ * Parse a clock time at the very start of `tail`.
+ *
+ * Accepted only when the time is unambiguous: it has minutes, or a meridiem, or
+ * an explicit "@"/"at" marker.
+ *
+ * Bare-hour disambiguation (no meridiem):
+ *   0:xx        -> midnight
+ *   1:00-6:59   -> +12 (PM — nobody schedules 1am)
+ *   7:00-11:59  -> as written (AM)
+ *   12:00-12:59 -> noon
+ *   13:00-23:59 -> 24-hour, as written
+ * An explicit meridiem always wins ("12:00 AM" -> 00:00).
+ */
+export function parseTimeAfterDate(tail: string): ParsedTime | null {
+  const match = String(tail ?? '').match(TIME_RE)
+  if (!match) return null
+
+  const [full, at, atWord, hourRaw, minuteRaw, meridiemRaw] = match
+  const marked = Boolean(at || atWord)
+  const hasMinutes = minuteRaw !== undefined
+  const meridiem = meridiemRaw ? meridiemRaw.replace(/\./g, '').toLowerCase() : undefined
+
+  // Ambiguous bare number ("8/17 5") — never arm a reminder off that.
+  if (!hasMinutes && !meridiem && !marked) return null
+
+  let hour = Number(hourRaw)
+  const minute = hasMinutes ? Number(minuteRaw) : 0
+  if (!Number.isFinite(hour) || !Number.isFinite(minute)) return null
+  if (minute > 59) return null
+
+  if (meridiem) {
+    if (hour > 12 || hour === 0) return null
+    if (meridiem === 'pm' && hour !== 12) hour += 12
+    if (meridiem === 'am' && hour === 12) hour = 0
+  } else {
+    if (hour > 23) return null
+    if (hour >= 1 && hour <= 6) hour += 12
+  }
+
+  return { hour, minute, length: full.length }
+}

--- a/supabase/functions/_shared/wallClock.test.ts
+++ b/supabase/functions/_shared/wallClock.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  formatInZone,
+  localHour,
+  localIsoDate,
+  localWallClock,
+  wallClockToUtc,
+  zoneOffsetMs,
+} from './wallClock.ts'
+
+const NY = 'America/New_York'
+const HOUR = 3600_000
+
+const iso = (ts: number) => new Date(ts).toISOString()
+
+describe('wallClockToUtc', () => {
+  it('converts an EDT summer wall clock', () => {
+    // 8:20 AM on Aug 17 2026 in New York (UTC-4) is 12:20 UTC.
+    const { ts, shifted } = wallClockToUtc(
+      { year: 2026, month: 8, day: 17, hour: 8, minute: 20 },
+      NY,
+    )
+    expect(iso(ts)).toBe('2026-08-17T12:20:00.000Z')
+    expect(shifted).toBe(false)
+  })
+
+  it('converts an EST winter wall clock', () => {
+    // 8:20 AM on Jan 17 2027 in New York (UTC-5) is 13:20 UTC.
+    const { ts } = wallClockToUtc({ year: 2027, month: 1, day: 17, hour: 8, minute: 20 }, NY)
+    expect(iso(ts)).toBe('2027-01-17T13:20:00.000Z')
+  })
+
+  it('handles a half-hour offset zone', () => {
+    const { ts } = wallClockToUtc(
+      { year: 2026, month: 8, day: 17, hour: 8, minute: 20 },
+      'Asia/Kolkata',
+    )
+    expect(iso(ts)).toBe('2026-08-17T02:50:00.000Z')
+  })
+
+  it('flags the spring-forward gap and converges forward', () => {
+    // 2026-03-08 02:30 does not exist in New York; it lands on 03:30 EDT.
+    const { ts, shifted } = wallClockToUtc(
+      { year: 2026, month: 3, day: 8, hour: 2, minute: 30 },
+      NY,
+    )
+    expect(shifted).toBe(true)
+    expect(localWallClock(ts, NY).hour).toBe(3)
+  })
+
+  it('picks the first (DST) occurrence of an ambiguous fall-back time', () => {
+    // 2026-11-01 01:30 happens twice; the EDT one is 05:30Z, the EST one 06:30Z.
+    const { ts } = wallClockToUtc({ year: 2026, month: 11, day: 1, hour: 1, minute: 30 }, NY)
+    expect(iso(ts)).toBe('2026-11-01T05:30:00.000Z')
+  })
+
+  it('round-trips any well-defined wall clock', () => {
+    for (let day = 1; day <= 28; day += 3) {
+      for (const hour of [0, 7, 13, 22, 23]) {
+        const wall = { year: 2026, month: 6, day, hour, minute: 45 }
+        const { ts } = wallClockToUtc(wall, NY)
+        expect(localWallClock(ts, NY)).toEqual(wall)
+      }
+    }
+  })
+})
+
+describe('zoneOffsetMs', () => {
+  it('is -4h during EDT and -5h during EST', () => {
+    expect(zoneOffsetMs(Date.parse('2026-08-17T12:00:00Z'), NY)).toBe(-4 * HOUR)
+    expect(zoneOffsetMs(Date.parse('2026-01-17T12:00:00Z'), NY)).toBe(-5 * HOUR)
+  })
+})
+
+// The `today` trap: generate-daily receives `today` from the browser, but the
+// cron function has to compute it. toISOString().slice(0,10) already says
+// "tomorrow" at 8pm Eastern, which would shift the whole year ladder by a day for
+// five hours every night.
+describe('localIsoDate — the `today` trap', () => {
+  it('is still the previous local day at 02:00 UTC in New York', () => {
+    const instant = Date.parse('2026-08-18T02:00:00Z')
+    expect(localIsoDate(instant, NY)).toBe('2026-08-17')
+    expect(new Date(instant).toISOString().slice(0, 10)).toBe('2026-08-18') // the trap
+  })
+
+  it('rolls at local midnight, not UTC midnight', () => {
+    expect(localIsoDate(Date.parse('2026-08-18T03:59:00Z'), NY)).toBe('2026-08-17')
+    expect(localIsoDate(Date.parse('2026-08-18T04:00:00Z'), NY)).toBe('2026-08-18')
+  })
+})
+
+describe('localHour', () => {
+  it('reports 0 (not 24) at exactly local midnight', () => {
+    expect(localHour(Date.parse('2026-08-18T04:00:00Z'), NY)).toBe(0)
+  })
+
+  it('reports the local hour, not the UTC one', () => {
+    expect(localHour(Date.parse('2026-08-17T12:20:00Z'), NY)).toBe(8)
+  })
+})
+
+describe('formatInZone', () => {
+  it('formats for the reminder body', () => {
+    expect(formatInZone(Date.parse('2026-08-17T12:20:00Z'), NY)).toBe('Mon Aug 17 · 8:20 AM')
+  })
+
+  it('takes a custom separator for the bot confirmation', () => {
+    expect(formatInZone(Date.parse('2026-08-17T12:20:00Z'), NY, ' at ')).toBe(
+      'Mon Aug 17 at 8:20 AM',
+    )
+  })
+})

--- a/supabase/functions/_shared/wallClock.ts
+++ b/supabase/functions/_shared/wallClock.ts
@@ -1,0 +1,130 @@
+// Wall-clock <-> UTC conversion for a fixed IANA time zone.
+//
+// HOUSE RULE for this module (and every pure module in _shared/): zero jsr:,
+// npm:, or https:// imports and zero top-level `Deno.*`, so Vitest can import it
+// directly. Intl only — the Deno edge runtime and Node both ship a full ICU, so
+// zones resolve identically in both.
+//
+// Extends the Intl.formatToParts pattern already used in telegram-bot/datetime.ts.
+
+export type WallClock = {
+  year: number
+  month: number // 1-12
+  day: number
+  hour: number // 0-23
+  minute: number
+}
+
+// hourCycle:'h23' — NOT hour12:false. Older ICU emits "24" for midnight under
+// hour12:false, which silently produces an off-by-one-day bug at exactly 00:00.
+const partsFormatter = (timeZone: string) =>
+  new Intl.DateTimeFormat('en-US', {
+    timeZone,
+    hourCycle: 'h23',
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+    second: '2-digit',
+  })
+
+const readParts = (instant: Date | number, timeZone: string): WallClock & { second: number } => {
+  const parts = partsFormatter(timeZone).formatToParts(new Date(instant))
+  const get = (type: string) => Number(parts.find((p) => p.type === type)?.value ?? '0')
+  let hour = get('hour')
+  if (hour === 24) hour = 0 // defensive: older-ICU midnight quirk
+  return {
+    year: get('year'),
+    month: get('month'),
+    day: get('day'),
+    hour,
+    minute: get('minute'),
+    second: get('second'),
+  }
+}
+
+/** Offset of `timeZone` from UTC at `instant`, in ms (positive east of UTC). */
+export const zoneOffsetMs = (instant: Date | number, timeZone: string): number => {
+  const p = readParts(instant, timeZone)
+  const asUtc = Date.UTC(p.year, p.month - 1, p.day, p.hour, p.minute, p.second)
+  return asUtc - new Date(instant).getTime()
+}
+
+/**
+ * Turn a local wall-clock reading into a UTC timestamp, by two-pass fixed point:
+ * guess with the offset at the naive instant, then re-solve once if that instant
+ * turned out to sit on the other side of a DST transition.
+ *
+ * DST edges (both once a year, pre-dawn, inside quiet hours):
+ *   - spring-forward gap (02:30 on a transition day) converges to 03:30 local;
+ *     `shifted` is true so the caller can log it.
+ *   - fall-back ambiguity picks the first (DST) occurrence.
+ */
+export const wallClockToUtc = (
+  wall: WallClock,
+  timeZone: string,
+): { ts: number; shifted: boolean } => {
+  const naive = Date.UTC(wall.year, wall.month - 1, wall.day, wall.hour, wall.minute)
+
+  const roundTrips = (ts: number) => {
+    const back = readParts(ts, timeZone)
+    return back.day === wall.day && back.hour === wall.hour && back.minute === wall.minute
+  }
+
+  // Pass 1 uses the offset in effect at the naive instant; pass 2 re-solves with
+  // the offset actually in effect at the answer. Exactly one of them round-trips
+  // whenever the wall clock is well-defined.
+  const first = naive - zoneOffsetMs(naive, timeZone)
+  if (roundTrips(first)) return { ts: first, shifted: false }
+
+  const second = naive - zoneOffsetMs(first, timeZone)
+  if (roundTrips(second)) return { ts: second, shifted: false }
+
+  // Neither round-trips: this wall clock doesn't exist (spring-forward gap). Keep
+  // the pre-transition offset, which lands the caller just past the gap — 02:30
+  // becomes 03:30 local rather than snapping backwards to 01:30.
+  return { ts: first, shifted: true }
+}
+
+/** Local calendar date as YYYY-MM-DD. */
+export const localIsoDate = (instant: Date | number, timeZone: string): string => {
+  const p = readParts(instant, timeZone)
+  const pad = (n: number) => String(n).padStart(2, '0')
+  return `${p.year}-${pad(p.month)}-${pad(p.day)}`
+}
+
+/** Local hour of day, 0-23. */
+export const localHour = (instant: Date | number, timeZone: string): number =>
+  readParts(instant, timeZone).hour
+
+/** Local wall-clock parts (no seconds) at an instant. */
+export const localWallClock = (instant: Date | number, timeZone: string): WallClock => {
+  const p = readParts(instant, timeZone)
+  return { year: p.year, month: p.month, day: p.day, hour: p.hour, minute: p.minute }
+}
+
+/**
+ * Human display of an instant in a zone, e.g. "Mon Aug 17 · 8:20 AM".
+ * Fixed format — the reminder message controls its own presentation.
+ */
+export const formatInZone = (
+  instant: Date | number,
+  timeZone: string,
+  separator = ' · ',
+): string => {
+  const parts = new Intl.DateTimeFormat('en-US', {
+    timeZone,
+    weekday: 'short',
+    month: 'short',
+    day: 'numeric',
+    hour: 'numeric',
+    minute: '2-digit',
+    hour12: true,
+  }).formatToParts(new Date(instant))
+  const get = (t: string) => parts.find((p) => p.type === t)?.value ?? ''
+  return (
+    `${get('weekday')} ${get('month')} ${get('day')}${separator}` +
+    `${get('hour')}:${get('minute')} ${get('dayPeriod')}`
+  )
+}

--- a/supabase/functions/generate-daily/index.ts
+++ b/supabase/functions/generate-daily/index.ts
@@ -5,7 +5,7 @@ import {
   buildDaily,
   buildTrackerContext,
   parseDateResolutions,
-} from './dailyHelpers.ts'
+} from '../_shared/dailyHelpers.ts'
 
 const ALLOWED_ORIGIN = Deno.env.get('ALLOWED_ORIGIN') || '*'
 const CORS_HEADERS = {

--- a/supabase/functions/send-reminders/index.ts
+++ b/supabase/functions/send-reminders/index.ts
@@ -1,0 +1,337 @@
+// Reminder sweep. Runs every 5 minutes; re-derives the complete reminder set
+// from the current tracker documents and sends whatever is due and unsent.
+//
+// The import graph is deliberately tiny — supabase-js plus the pure _shared
+// modules. NO grammY, NO telegramify-markdown, NO puppeteer: this cold-starts
+// 288 times a day, and it emits one fixed message format we control.
+//
+// Cost: ~8.6K invocations/month against a 500K free tier, ~1s each, and ZERO AI
+// tokens. Extraction is deterministic regex over document JSON.
+
+import 'jsr:@supabase/functions-js/edge-runtime.d.ts'
+import { createClient } from 'jsr:@supabase/supabase-js@2'
+
+import {
+  countOrphanedTimedHighlights,
+  deriveReminders,
+  type DerivedReminder,
+} from '../_shared/deriveReminders.ts'
+import { buildDeepLink } from '../_shared/deepLink.ts'
+import { buildReminderText, cleanLineText } from '../_shared/reminderMessage.ts'
+import { localIsoDate } from '../_shared/wallClock.ts'
+
+// --- Config ---
+const BOT_TOKEN = Deno.env.get('TELEGRAM_BOT_TOKEN') ?? ''
+// In a Telegram private chat, chat.id === from.id (see telegram-bot/auth.ts), so
+// the allowlisted user id IS the destination chat id.
+const CHAT_ID = Deno.env.get('TELEGRAM_ALLOWED_USER_ID') ?? ''
+const USER_TIMEZONE = Deno.env.get('USER_TIMEZONE') ?? 'America/New_York'
+const APP_URL = Deno.env.get('APP_URL') ?? 'https://life-tracker-mu-sandy.vercel.app'
+
+const num = (name: string, fallback: number): number => {
+  const parsed = Number(Deno.env.get(name))
+  return Number.isFinite(parsed) ? parsed : fallback
+}
+
+const DEFAULT_LEAD_MINUTES = num('REMINDER_DEFAULT_LEAD_MINUTES', 90)
+// Backfill guard: never send something that came due while the function was down.
+const GRACE_MINUTES = num('REMINDER_GRACE_MINUTES', 120)
+const QUIET_START_HOUR = num('REMINDER_QUIET_START_HOUR', 22)
+const QUIET_END_HOUR = num('REMINDER_QUIET_END_HOUR', 7)
+// A parse regression sends 10 texts and logs the overflow, not 600.
+const MAX_PER_TICK = num('REMINDER_MAX_PER_TICK', 10)
+// Deploy-day seatbelt: ignore anything that would have fired before this instant.
+const MIN_FIRE_AT = Deno.env.get('REMINDER_MIN_FIRE_AT') ?? ''
+const DRY_RUN = (Deno.env.get('REMINDER_DRY_RUN') ?? '') === '1'
+
+// The autosave debounce is 2s (useTrackers.js), so a tick can otherwise catch a
+// half-typed "8/17 8:20am" on its way to "8:20pm" and send it. Costs ≤1 minute
+// of latency to skip pages that were touched in the last minute.
+const STABILITY_WINDOW_MS = 60_000
+// Telegram sustains roughly one message per second to a single chat.
+const SEND_GAP_MS = 250
+// Don't remind someone about something that already happened.
+const PAST_DUE_TOLERANCE_MS = 15 * 60_000
+
+const MS_PER_MINUTE = 60_000
+
+const json = (body: unknown, status = 200) =>
+  new Response(JSON.stringify(body), { status, headers: { 'Content-Type': 'application/json' } })
+
+const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms))
+
+type SnoozeRow = {
+  id: string
+  block_id: string
+  page_id: string | null
+  fire_at: string
+  line_text: string | null
+}
+
+/** Direct fetch, not grammY — one dependency and one code path. */
+async function sendMessage(text: string): Promise<number | null> {
+  const resp = await fetch(`https://api.telegram.org/bot${BOT_TOKEN}/sendMessage`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      chat_id: CHAT_ID,
+      text,
+      // Otherwise Telegram fetches a link-preview card on every single reminder.
+      disable_web_page_preview: true,
+    }),
+  })
+  if (!resp.ok) {
+    throw new Error(`telegram sendMessage failed (${resp.status}) ${await resp.text().catch(() => '')}`)
+  }
+  const data = await resp.json().catch(() => null)
+  const id = data?.result?.message_id
+  return typeof id === 'number' ? id : null
+}
+
+Deno.serve(async (req) => {
+  // --- 1. Auth (mirrors check-scores) — fail closed BEFORE any comparison. ---
+  const cronSecret = Deno.env.get('CRON_SECRET')
+  if (!cronSecret) {
+    console.error('CRON_SECRET not configured')
+    return json({ error: 'Server misconfigured' }, 500)
+  }
+  if (req.headers.get('x-cron-secret') !== cronSecret) {
+    return json({ error: 'Unauthorized' }, 401)
+  }
+  if (!BOT_TOKEN || !CHAT_ID) {
+    console.error('TELEGRAM_BOT_TOKEN / TELEGRAM_ALLOWED_USER_ID not configured')
+    return json({ error: 'Telegram not configured' }, 500)
+  }
+
+  const supabase = createClient(
+    Deno.env.get('SUPABASE_URL') ?? '',
+    Deno.env.get('SUPABASE_SERVICE_ROLE_KEY') ?? '',
+  )
+
+  const now = Date.now()
+  const summary = {
+    ok: true,
+    dryRun: DRY_RUN,
+    derived: 0,
+    due: 0,
+    sent: 0,
+    skipped: 0,
+    snoozesSent: 0,
+    overflow: 0,
+    orphanedTimedHighlights: 0,
+  }
+
+  try {
+    // --- 4. Read the tracker pages. ---
+    const { data: pages, error: pagesError } = await supabase
+      .from('pages')
+      .select('id, title, content, section_id, user_id, updated_at')
+      .eq('is_tracker_page', true)
+    if (pagesError) {
+      console.error('load pages failed:', pagesError.message)
+      return json({ error: 'Failed to load pages' }, 500)
+    }
+    const allPages = pages ?? []
+    const userId = allPages[0]?.user_id
+    if (!userId) return json({ ...summary, note: 'no tracker pages' })
+
+    // --- 3. Any snoozes that have come due go out first. ---
+    if (!DRY_RUN) {
+      summary.snoozesSent = await sendDueSnoozes(supabase, now)
+    }
+
+    // --- 5. Stability guard. ---
+    const stablePages = allPages.filter(
+      (page) => now - Date.parse(page.updated_at ?? 0) > STABILITY_WINDOW_MS,
+    )
+
+    // --- 6. Derive. ⚠️ todayLocal MUST come from localIsoDate, not
+    // toISOString().slice(0,10) — see the `today` trap in deriveReminders.ts. ---
+    const todayLocal = localIsoDate(now, USER_TIMEZONE)
+    const derived = deriveReminders(
+      stablePages.map((page) => ({ id: page.id, title: page.title, content: page.content })),
+      {
+        todayLocal,
+        timeZone: USER_TIMEZONE,
+        defaultLeadMinutes: DEFAULT_LEAD_MINUTES,
+        quiet: { startHour: QUIET_START_HOUR, endHour: QUIET_END_HOUR },
+      },
+    )
+    summary.derived = derived.length
+
+    // --- 6b. Diagnostic: any timed highlight we could NOT reach at all. ---
+    summary.orphanedTimedHighlights = countOrphanedTimedHighlights(stablePages, derived.length)
+    if (summary.orphanedTimedHighlights > 0) {
+      console.warn(
+        `${summary.orphanedTimedHighlights} highlighted date(s) carry a clock time but produced ` +
+          'no reminder — a new class of unreachable date. Investigate.',
+      )
+    }
+
+    // --- 7. Filter. ---
+    const minFireAt = MIN_FIRE_AT ? Date.parse(MIN_FIRE_AT) : Number.NEGATIVE_INFINITY
+    const graceFloor = now - GRACE_MINUTES * MS_PER_MINUTE
+    const due = derived.filter(
+      (reminder) =>
+        reminder.fireAt <= now &&
+        reminder.fireAt >= graceFloor &&
+        reminder.fireAt >= minFireAt &&
+        reminder.dueAt >= now - PAST_DUE_TOLERANCE_MS,
+    )
+    summary.due = due.length
+
+    // --- 8. Cap. ---
+    const ordered = due.slice().sort((a, b) => a.fireAt - b.fireAt)
+    const batch = ordered.slice(0, MAX_PER_TICK)
+    summary.overflow = ordered.length - batch.length
+    if (summary.overflow > 0) {
+      console.warn(`${summary.overflow} reminder(s) over the per-tick cap; deferred to the next tick`)
+    }
+
+    // --- 9. Dry run stops here: nothing sent, nothing written. ---
+    if (DRY_RUN) {
+      return json({
+        ...summary,
+        preview: batch.map((r) => ({
+          dedupKey: r.dedupKey,
+          fireAt: new Date(r.fireAt).toISOString(),
+          dueAt: new Date(r.dueAt).toISOString(),
+          leadMinutes: r.leadMinutes,
+          lineText: r.lineText,
+        })),
+      })
+    }
+
+    // --- 10. Batch-resolve notebook ids for the deep links. ---
+    const pageById = new Map(allPages.map((page) => [page.id, page]))
+    const sectionIds = [
+      ...new Set(batch.map((r) => pageById.get(r.pageId ?? '')?.section_id).filter(Boolean)),
+    ]
+    const notebookBySection = new Map<string, string>()
+    if (sectionIds.length) {
+      const { data: sections } = await supabase
+        .from('sections')
+        .select('id, notebook_id')
+        .in('id', sectionIds as string[])
+      for (const section of sections ?? []) notebookBySection.set(section.id, section.notebook_id)
+    }
+
+    // --- 11. Claim, send, record. ---
+    for (const [index, reminder] of batch.entries()) {
+      const claimed = await claim(supabase, userId, reminder)
+      if (!claimed) {
+        summary.skipped += 1
+        continue
+      }
+
+      const page = pageById.get(reminder.pageId ?? '')
+      const deepLink = buildDeepLink(
+        {
+          notebookId: page?.section_id ? notebookBySection.get(page.section_id) : null,
+          sectionId: page?.section_id ?? null,
+          pageId: reminder.pageId,
+          blockId: reminder.blockId,
+        },
+        APP_URL,
+      )
+
+      try {
+        if (index > 0) await sleep(SEND_GAP_MS)
+        const messageId = await sendMessage(buildReminderText(reminder, USER_TIMEZONE, deepLink))
+        await supabase
+          .from('bot_reminders')
+          .update({
+            status: 'sent',
+            sent_at: new Date().toISOString(),
+            telegram_message_id: messageId,
+          })
+          .eq('id', claimed)
+        summary.sent += 1
+      } catch (err) {
+        // Drop the claim so the next tick retries rather than silently losing it.
+        console.error('send failed, releasing claim:', String(err))
+        await supabase.from('bot_reminders').delete().eq('id', claimed)
+      }
+    }
+
+    return json(summary)
+  } catch (err) {
+    console.error('send-reminders error:', String(err))
+    return json({ ok: false, error: String(err) }, 500)
+  }
+})
+
+/**
+ * Claim-insert (the check-scores dedup pattern): the unique index on
+ * (user_id, dedup_key) is the lock. A 23505 means another tick — or an earlier
+ * send of this exact reminder — already owns it.
+ */
+async function claim(
+  supabase: ReturnType<typeof createClient>,
+  userId: string,
+  reminder: DerivedReminder,
+): Promise<string | null> {
+  const { data, error } = await supabase
+    .from('bot_reminders')
+    .insert({
+      user_id: userId,
+      dedup_key: reminder.dedupKey,
+      source: 'derived',
+      block_id: reminder.blockId,
+      page_id: reminder.pageId,
+      due_at: new Date(reminder.dueAt).toISOString(),
+      lead_minutes: reminder.leadMinutes,
+      fire_at: new Date(reminder.fireAt).toISOString(),
+      // Store it already cleaned: this snapshot is what a "done" reply quotes
+      // back and what /reminders lists, and the lead clause is machine-facing.
+      line_text: cleanLineText(reminder.lineText, reminder.leadMatch),
+      status: 'pending',
+    })
+    .select('id')
+    .single()
+
+  if (error) {
+    if (error.code !== '23505') console.error('claim insert failed:', error.message)
+    return null
+  }
+  return data?.id ?? null
+}
+
+/** Snoozes are already-decided sends: one row, one message, no re-derivation. */
+async function sendDueSnoozes(
+  supabase: ReturnType<typeof createClient>,
+  now: number,
+): Promise<number> {
+  const { data, error } = await supabase
+    .from('bot_reminders')
+    .select('id, block_id, page_id, fire_at, line_text')
+    .eq('source', 'snooze')
+    .eq('status', 'pending')
+    .lte('fire_at', new Date(now).toISOString())
+    .order('fire_at', { ascending: true })
+    .limit(MAX_PER_TICK)
+  if (error || !data?.length) return 0
+
+  let sent = 0
+  for (const row of data as SnoozeRow[]) {
+    try {
+      const deepLink = buildDeepLink({ pageId: row.page_id, blockId: row.block_id }, APP_URL)
+      const messageId = await sendMessage(
+        buildReminderText(
+          { dueAt: Date.parse(row.fire_at), leadMinutes: 0, lineText: row.line_text ?? '', leadMatch: null },
+          USER_TIMEZONE,
+          deepLink,
+        ),
+      )
+      await supabase
+        .from('bot_reminders')
+        .update({ status: 'sent', sent_at: new Date().toISOString(), telegram_message_id: messageId })
+        .eq('id', row.id)
+      sent += 1
+      await sleep(SEND_GAP_MS)
+    } catch (err) {
+      console.error('snooze send failed:', String(err))
+    }
+  }
+  return sent
+}

--- a/supabase/functions/telegram-bot/capture.ts
+++ b/supabase/functions/telegram-bot/capture.ts
@@ -8,6 +8,7 @@
 import { callClaude } from './anthropic.ts'
 import { buildItems, insertRelativeToBlock } from './insertContent.ts'
 import type { Format, Placement, TiptapNode } from './insertContent.ts'
+import { buildDeepLink } from '../_shared/deepLink.ts'
 
 const APP_URL = (Deno.env.get('APP_URL') ?? 'https://life-tracker-mu-sandy.vercel.app').replace(/\/$/, '')
 
@@ -137,23 +138,8 @@ export async function classifyReply(userText: string, model: string): Promise<{ 
   }
 }
 
-function buildDeepLink(parts: {
-  notebookId?: string | null
-  sectionId?: string | null
-  pageId?: string | null
-  blockId?: string | null
-}): string {
-  const params = new URLSearchParams()
-  if (parts.notebookId) params.set('nb', parts.notebookId)
-  if (parts.sectionId) params.set('sec', parts.sectionId)
-  if (parts.pageId) params.set('pg', parts.pageId)
-  if (parts.blockId) params.set('block', parts.blockId)
-  const hash = params.size ? `#${params.toString()}` : ''
-  return APP_URL ? `${APP_URL}/${hash}` : hash
-}
-
 export type ApplyResult =
-  | { ok: true; deepLink: string }
+  | { ok: true; deepLink: string; pageTitle: string | null }
   | { ok: false; reason: 'anchor_missing' | 'conflict' | 'error' }
 
 /**
@@ -172,7 +158,7 @@ export async function applyPendingJob(
   for (let attempt = 0; attempt < 3; attempt++) {
     const { data: page, error } = await supabase
       .from('pages')
-      .select('content, updated_at, section_id')
+      .select('content, updated_at, section_id, title')
       .eq('id', job.page_id)
       .maybeSingle()
     if (error || !page) return { ok: false, reason: 'error' }
@@ -204,13 +190,18 @@ export async function applyPendingJob(
       const { data: section } = page.section_id
         ? await supabase.from('sections').select('notebook_id').eq('id', page.section_id).maybeSingle()
         : { data: null }
-      const deepLink = buildDeepLink({
-        notebookId: section?.notebook_id,
-        sectionId: page.section_id,
-        pageId: job.page_id,
-        blockId,
-      })
-      return { ok: true, deepLink }
+      const deepLink = buildDeepLink(
+        {
+          notebookId: section?.notebook_id,
+          sectionId: page.section_id,
+          pageId: job.page_id,
+          blockId,
+        },
+        APP_URL,
+      )
+      // The page title carries the tracker's month, which anchors any bare M/D
+      // in the confirmation's reminder derivation.
+      return { ok: true, deepLink, pageTitle: page.title ?? null }
     }
     // Zero rows matched -> a concurrent write landed; loop to re-read and re-apply.
   }

--- a/supabase/functions/telegram-bot/index.ts
+++ b/supabase/functions/telegram-bot/index.ts
@@ -18,6 +18,15 @@ import {
   purgeExpiredJobs,
 } from './capture.ts'
 import {
+  applyDone,
+  describeArmedForItems,
+  findTargetReminder,
+  listUpcomingReminders,
+  scheduleSnooze,
+} from './reminders.ts'
+import { parseReminderReply } from '../_shared/reminderReply.ts'
+import { describeLead } from '../_shared/reminderMessage.ts'
+import {
   closeActiveSessions,
   loadRecentTurns,
   persistAssistantTurn,
@@ -104,6 +113,52 @@ bot.command('new', async (ctx) => {
 // before the message:text tracker handler so it never collides with it.
 bot.command('blog', handleBlog)
 
+// /reminders -> what's armed for the next two weeks. Pure derivation, zero AI.
+// This is the feedback loop that makes the feature trustworthy instead of the
+// user hoping their phone buzzes.
+bot.command('reminders', async (ctx) => {
+  try {
+    const userId = await getUserId()
+    const text = await listUpcomingReminders(supabase, userId, new Date(), USER_TIMEZONE)
+    await sendReply(ctx.api, ctx.chat.id, text)
+  } catch (err) {
+    console.error('/reminders error:', String(err))
+    await sendReply(ctx.api, ctx.chat.id, 'Couldn’t read your reminders just now.')
+  }
+})
+
+/**
+ * Carry out a "done" or "snooze" on a reminder we sent.
+ *
+ * The confirmation is MANDATORY and quotes the line back with a link: an
+ * accidental cross-off is then visible, and one tap from being undone.
+ */
+async function handleReminderAction(
+  userId: string,
+  target: Awaited<ReturnType<typeof findTargetReminder>>,
+  action: NonNullable<ReturnType<typeof parseReminderReply>>,
+  now: Date,
+): Promise<string> {
+  if (!target) return 'I couldn’t tell which reminder you meant.'
+
+  if (action.kind === 'snooze') {
+    const { ok } = await scheduleSnooze(supabase, userId, target, action.minutes, now)
+    if (!ok) return 'Couldn’t snooze that just now — try again in a moment.'
+    return `⏰ Snoozed ${describeLead(action.minutes)} — I’ll ping you again then.`
+  }
+
+  const result = await applyDone(supabase, target, now)
+  if (!result.ok) {
+    if (result.reason === 'not_found') {
+      return 'That line isn’t in your tracker anymore, so there was nothing to cross off.'
+    }
+    return 'Couldn’t update your tracker just now — send that again in a moment.'
+  }
+
+  const quoted = result.quoted ? `\n\n"${result.quoted}"` : ''
+  return `✅ Crossed off:${quoted}\n\n[Open in tracker](${result.deepLink})`
+}
+
 /**
  * The whole conversational flow: session, dedup, pending-proposal capture, and
  * the agentic tool loop. Shared by the plain text handler and /think so the
@@ -142,6 +197,25 @@ async function handleUserMessage(ctx: any, text: string, forceMode?: SessionMode
     const { duplicate } = await persistUserTurn(supabase, sessionId, text, messageId)
     if (duplicate) return
 
+    // --- Is this message acting on a reminder we sent? ---
+    // Deterministic keyword match, no AI. Runs first so a quote-reply to a
+    // reminder always wins, but only fires on a bare "done"/"snooze" — anything
+    // chattier falls through untouched to the flow below.
+    const reminderAction = parseReminderReply(text)
+    if (reminderAction) {
+      const pendingPreview = await findPendingJob(supabase, { userId, sessionId, replyToMessageId })
+      // A pending preview owns bare confirmations ("done" could mean "yes, add it").
+      if (!pendingPreview) {
+        const target = await findTargetReminder(supabase, userId, now, replyToMessageId)
+        if (target) {
+          const reply = await handleReminderAction(userId, target, reminderAction, now)
+          await persistAssistantTurn(supabase, sessionId, reply)
+          await sendReply(ctx.api, chatId, reply)
+          return
+        }
+      }
+    }
+
     // --- Capture: is this message responding to a pending proposal? ---
     const pendingJob = await findPendingJob(supabase, { userId, sessionId, replyToMessageId })
     if (pendingJob) {
@@ -152,7 +226,16 @@ async function handleUserMessage(ctx: any, text: string, forceMode?: SessionMode
         let reply: string
         if (result.ok) {
           await deleteJob(supabase, pendingJob.id)
-          reply = `Added ✅ — [Open in tracker](${result.deepLink})`
+          // Derived, never asserted: this runs the same parser the cron sweep
+          // does over the same stored {{date:…}} strings, so the bot can't
+          // promise a text that won't arrive. Silence = nothing armed.
+          const armed = describeArmedForItems(
+            pendingJob.placement?.items ?? [],
+            result.pageTitle,
+            now,
+            USER_TIMEZONE,
+          )
+          reply = `Added ✅ — [Open in tracker](${result.deepLink})` + (armed ? `\n\n${armed}` : '')
         } else if (result.reason === 'anchor_missing') {
           await deleteJob(supabase, pendingJob.id)
           reply =

--- a/supabase/functions/telegram-bot/insertContent.ts
+++ b/supabase/functions/telegram-bot/insertContent.ts
@@ -6,6 +6,8 @@
 //   - Operates on serialized JSON (the bot has no live editor), so placement is
 //     resolved by walking the doc tree instead of resolving ProseMirror positions.
 
+import { DATE_HIGHLIGHT_COLOR, splitDateTokens } from '../_shared/dateToken.ts'
+
 export type TiptapNode = {
   type?: string
   text?: string
@@ -26,43 +28,26 @@ function createNodeId(): string {
 
 const LIST_TYPES = new Set(['bulletList', 'orderedList', 'taskList'])
 
-// The user highlights key dates in this cyan; the app treats a highlighted date
-// as an explicit due date. Mirrors aiInsertHelpers.js `makeHighlightedTextNode`
-// (same mark shape, different color — that one is the yellow review highlight).
-const DATE_HIGHLIGHT_COLOR = '#67e8f9'
-
-// Matches the {{date:…}} sentinel the model wraps a key date phrase in.
-const DATE_TOKEN_RE = /\{\{date:([^}]*)\}\}/g
-
 /**
  * Split an item string into inline text runs, turning each {{date:…}} token into
  * a cyan-highlighted run (the phrase inside the token) and leaving the rest plain.
- * Empty segments are dropped — ProseMirror rejects a text node with text:''.
+ *
+ * The token splitting itself lives in _shared/dateToken.ts because the bot's
+ * "⏰ I'll text you…" confirmation runs the SAME split through the reminder
+ * deriver — so the bot can't promise a reminder the cron won't send.
+ * Mirrors aiInsertHelpers.js `makeHighlightedTextNode` (same mark shape,
+ * different color — that one is the yellow review highlight).
  */
 export function buildInlineRuns(text: string): TiptapNode[] {
-  const runs: TiptapNode[] = []
-  let lastIndex = 0
-
-  const pushPlain = (segment: string) => {
-    if (segment) runs.push({ type: 'text', text: segment })
-  }
-
-  for (const match of text.matchAll(DATE_TOKEN_RE)) {
-    const start = match.index ?? 0
-    pushPlain(text.slice(lastIndex, start))
-    const phrase = (match[1] ?? '').trim()
-    if (phrase) {
-      runs.push({
-        type: 'text',
-        text: phrase,
-        marks: [{ type: 'highlight', attrs: { color: DATE_HIGHLIGHT_COLOR } }],
-      })
-    }
-    lastIndex = start + match[0].length
-  }
-  pushPlain(text.slice(lastIndex))
-
-  return runs
+  return splitDateTokens(text).map((run) =>
+    run.isDate
+      ? {
+          type: 'text',
+          text: run.text,
+          marks: [{ type: 'highlight', attrs: { color: DATE_HIGHLIGHT_COLOR } }],
+        }
+      : { type: 'text', text: run.text },
+  )
 }
 
 function makeParagraph(text: string, createdAt: string): TiptapNode {

--- a/supabase/functions/telegram-bot/prompt.test.ts
+++ b/supabase/functions/telegram-bot/prompt.test.ts
@@ -54,3 +54,28 @@ describe('buildSystemPrompt', () => {
     expect(prompt).toContain(display)
   })
 })
+
+describe('buildSystemPrompt — timed reminders', () => {
+  const base = buildSystemPrompt(false)
+
+  it('states the rule that decides whether a phone buzzes', () => {
+    expect(base).toContain(
+      'A highlighted date with a clock time arms a push reminder. A highlighted date alone never does.',
+    )
+  })
+
+  it('puts a stated time inside the token, with an explicit meridiem', () => {
+    expect(base).toContain('{{date:8/21 2:00 PM}}')
+    expect(base).toContain('INSIDE the token')
+  })
+
+  it('forbids inventing a time', () => {
+    expect(base).toContain('NEVER invent a time')
+  })
+
+  it('keeps the lead-time phrase outside the token', () => {
+    expect(base).toContain('(remind 3 hours before)')
+    expect(base).toContain('plain text OUTSIDE')
+    expect(base).toContain('(no reminder)')
+  })
+})

--- a/supabase/functions/telegram-bot/prompt.ts
+++ b/supabase/functions/telegram-bot/prompt.ts
@@ -50,6 +50,15 @@ Adding things to the tracker:
   "renew pass {{date:6/15}}", "Submit blog post by EOD {{date:6/15}}",
   "call w/ Sam {{date:6/16 6:59 PM}}". The M/D inside the token also makes it register as a due
   date. Leave incidental or context dates plain — only flag dates that matter. Not limited to "due".
+- A highlighted date with a clock time arms a push reminder. A highlighted date alone never does.
+- If the user stated a clock time, put it INSIDE the token, right after the date, always with an
+  explicit AM/PM — "{{date:8/21 2:00 PM}}", never a bare "2:00".
+- NEVER invent a time. If they gave a date but no time, the token has no time. Date-only is the
+  normal case and is exactly right.
+- If they asked to be reminded a certain amount ahead, append that phrase in plain text OUTSIDE
+  the token: "call the venue {{date:8/21 2:00 PM}} (remind 3 hours before)". Default is 90 minutes
+  ahead, so only add the phrase when they asked for something different.
+- If they said not to be reminded, append "(no reminder)" in plain text.
 - After proposing, keep your reply to one short line asking them to confirm to add it, or
   tell you what to change. Don't restate the items; the screenshot already shows them. The
   preview's caption already names the target section ("📍 Adding to …"), so don't restate

--- a/supabase/functions/telegram-bot/reminders.ts
+++ b/supabase/functions/telegram-bot/reminders.ts
@@ -1,0 +1,243 @@
+// Bot-side reminder handling: the post-confirmation "I'll text you…" line, the
+// /reminders listing, and the done / snooze replies.
+//
+// All the parsing is pure and lives in _shared/; this module is only the Supabase
+// and Telegram plumbing around it. Zero AI calls — every path here is
+// deterministic, which is what makes it cheap enough to run on every message.
+
+import {
+  deriveReminders,
+  snoozeDedupKey,
+  type DeriveOptions,
+  type DerivedReminder,
+} from '../_shared/deriveReminders.ts'
+import { resolveTrackerAnchor } from '../_shared/dailyHelpers.ts'
+import { cleanLineText, describeArmedReminders, describeLead } from '../_shared/reminderMessage.ts'
+import { buildDeepLink } from '../_shared/deepLink.ts'
+import { strikeBlock, type TiptapNode } from '../_shared/strikeBlock.ts'
+import { formatInZone, localIsoDate } from '../_shared/wallClock.ts'
+import { DEFAULT_LEAD_MINUTES } from '../_shared/leadTime.ts'
+
+type SupabaseLike = { from: (table: string) => any }
+
+const APP_URL = Deno.env.get('APP_URL') ?? 'https://life-tracker-mu-sandy.vercel.app'
+const QUIET_START_HOUR = 22
+const QUIET_END_HOUR = 7
+
+/** A reminder sent in the last N hours can be acted on by a bare keyword. */
+const RECENT_REMINDER_HOURS = 6
+const LIST_HORIZON_DAYS = 14
+
+export const deriveOptionsFor = (now: Date, timeZone: string): DeriveOptions => ({
+  todayLocal: localIsoDate(now, timeZone),
+  timeZone,
+  defaultLeadMinutes: DEFAULT_LEAD_MINUTES,
+  quiet: { startHour: QUIET_START_HOUR, endHour: QUIET_END_HOUR },
+})
+
+/**
+ * What the bot promises after applying a confirmed addition.
+ *
+ * Runs the SAME deriver the cron sweep uses over the SAME persisted
+ * {{date:…}} strings, so the bot cannot claim a reminder the sweep won't send.
+ * Silence here means the parser couldn't read it — which is exactly the signal
+ * the user needs, immediately and visibly.
+ */
+export function describeArmedForItems(
+  items: string[],
+  pageTitle: unknown,
+  now: Date,
+  timeZone: string,
+): string {
+  const opts = deriveOptionsFor(now, timeZone)
+  const anchor = resolveTrackerAnchor(pageTitle, opts.todayLocal)
+  return describeArmedReminders(items, anchor, opts)
+}
+
+async function loadTrackerPages(supabase: SupabaseLike, userId: string) {
+  const { data } = await supabase
+    .from('pages')
+    .select('id, title, content, section_id')
+    .eq('user_id', userId)
+    .eq('is_tracker_page', true)
+  return data ?? []
+}
+
+/** /reminders — everything armed in the next 14 days, plus pending snoozes. */
+export async function listUpcomingReminders(
+  supabase: SupabaseLike,
+  userId: string,
+  now: Date,
+  timeZone: string,
+): Promise<string> {
+  const pages = await loadTrackerPages(supabase, userId)
+  const horizon = now.getTime() + LIST_HORIZON_DAYS * 86_400_000
+
+  const derived = deriveReminders(pages, deriveOptionsFor(now, timeZone))
+    .filter((r) => r.fireAt >= now.getTime() && r.fireAt <= horizon)
+    .sort((a, b) => a.fireAt - b.fireAt)
+
+  const { data: snoozes } = await supabase
+    .from('bot_reminders')
+    .select('fire_at, line_text')
+    .eq('user_id', userId)
+    .eq('source', 'snooze')
+    .eq('status', 'pending')
+    .gte('fire_at', new Date(now.getTime()).toISOString())
+    .order('fire_at', { ascending: true })
+
+  const lines: string[] = []
+  for (const reminder of derived) {
+    lines.push(
+      `• ${formatInZone(reminder.fireAt, timeZone, ' at ')} — ${summarize(reminder)} ` +
+        `_(${describeLead(reminder.leadMinutes)} before)_`,
+    )
+  }
+  for (const snooze of snoozes ?? []) {
+    lines.push(
+      `• ${formatInZone(Date.parse(snooze.fire_at), timeZone, ' at ')} — ` +
+        `${snooze.line_text ?? 'snoozed reminder'} _(snoozed)_`,
+    )
+  }
+
+  if (!lines.length) {
+    return `Nothing armed in the next ${LIST_HORIZON_DAYS} days. Highlight a date **with a clock time** to arm one.`
+  }
+  return [`**Armed for the next ${LIST_HORIZON_DAYS} days:**`, ...lines].join('\n')
+}
+
+const summarize = (reminder: DerivedReminder): string => {
+  const text = cleanLineText(reminder.lineText, reminder.leadMatch)
+  return text.length > 80 ? `${text.slice(0, 79)}…` : text
+}
+
+export type SentReminder = {
+  id: string
+  block_id: string
+  page_id: string | null
+  line_text: string | null
+  sent_at: string | null
+}
+
+const SENT_COLS = 'id, block_id, page_id, line_text, sent_at'
+
+/**
+ * Which reminder is this reply about?
+ *   1. A quote-reply to the reminder message itself — highest precedence, works
+ *      at any age.
+ *   2. Otherwise the most recent reminder sent in the last few hours.
+ * Returns null when neither applies, so the message goes down the normal path.
+ */
+export async function findTargetReminder(
+  supabase: SupabaseLike,
+  userId: string,
+  now: Date,
+  replyToMessageId?: number | null,
+): Promise<SentReminder | null> {
+  if (replyToMessageId) {
+    const { data } = await supabase
+      .from('bot_reminders')
+      .select(SENT_COLS)
+      .eq('user_id', userId)
+      .eq('telegram_message_id', replyToMessageId)
+      .maybeSingle()
+    if (data) return data as SentReminder
+  }
+
+  const cutoff = new Date(now.getTime() - RECENT_REMINDER_HOURS * 3_600_000).toISOString()
+  const { data } = await supabase
+    .from('bot_reminders')
+    .select(SENT_COLS)
+    .eq('user_id', userId)
+    .eq('status', 'sent')
+    .gte('sent_at', cutoff)
+    .order('sent_at', { ascending: false })
+    .limit(1)
+    .maybeSingle()
+  return (data as SentReminder) ?? null
+}
+
+export type DoneResult =
+  | { ok: true; quoted: string; deepLink: string }
+  | { ok: false; reason: 'not_found' | 'conflict' | 'error' }
+
+/**
+ * Cross the reminder's block off in the tracker.
+ *
+ * Same OCC pattern as capture.ts applyPendingJob: re-read, write under an
+ * updated_at guard, retry a couple of times on a concurrent write.
+ */
+export async function applyDone(
+  supabase: SupabaseLike,
+  reminder: SentReminder,
+  now: Date,
+): Promise<DoneResult> {
+  if (!reminder.page_id) return { ok: false, reason: 'not_found' }
+
+  for (let attempt = 0; attempt < 3; attempt++) {
+    const { data: page, error } = await supabase
+      .from('pages')
+      .select('content, updated_at, section_id')
+      .eq('id', reminder.page_id)
+      .maybeSingle()
+    if (error || !page) return { ok: false, reason: 'error' }
+
+    const { doc, found } = strikeBlock(page.content as TiptapNode, reminder.block_id)
+    if (!found) return { ok: false, reason: 'not_found' }
+
+    const { data: written } = await supabase
+      .from('pages')
+      .update({ content: doc, updated_at: now.toISOString() })
+      .eq('id', reminder.page_id)
+      .eq('updated_at', page.updated_at)
+      .select('updated_at')
+      .maybeSingle()
+
+    if (written) {
+      const { data: section } = page.section_id
+        ? await supabase.from('sections').select('notebook_id').eq('id', page.section_id).maybeSingle()
+        : { data: null }
+      return {
+        ok: true,
+        quoted: (reminder.line_text ?? '').replace(/\s+/g, ' ').trim(),
+        deepLink: buildDeepLink(
+          {
+            notebookId: section?.notebook_id,
+            sectionId: page.section_id,
+            pageId: reminder.page_id,
+            blockId: reminder.block_id,
+          },
+          APP_URL,
+        ),
+      }
+    }
+    // Zero rows matched -> a concurrent write landed; re-read and re-apply.
+  }
+  return { ok: false, reason: 'conflict' }
+}
+
+/**
+ * Re-arm a reminder for later. Writes a ledger row only — no `pages` write at
+ * all — which the sweep's snooze pass picks up.
+ */
+export async function scheduleSnooze(
+  supabase: SupabaseLike,
+  userId: string,
+  reminder: SentReminder,
+  minutes: number,
+  now: Date,
+): Promise<{ ok: boolean; fireAt: number }> {
+  const fireAt = now.getTime() + minutes * 60_000
+  const { error } = await supabase.from('bot_reminders').insert({
+    user_id: userId,
+    dedup_key: snoozeDedupKey(reminder.block_id, fireAt),
+    source: 'snooze',
+    block_id: reminder.block_id,
+    page_id: reminder.page_id,
+    fire_at: new Date(fireAt).toISOString(),
+    line_text: reminder.line_text,
+    status: 'pending',
+  })
+  // 23505 means an identical snooze already exists — same outcome for the user.
+  return { ok: !error || error.code === '23505', fireAt }
+}

--- a/supabase/functions/telegram-bot/telegram.ts
+++ b/supabase/functions/telegram-bot/telegram.ts
@@ -101,6 +101,7 @@ export async function registerCommands(api: any): Promise<void> {
     await api.setMyCommands([
       { command: 'new', description: 'Start a fresh conversation' },
       { command: 'think', description: 'Deep thinking mode (until /new)' },
+      { command: 'reminders', description: "What's armed for the next 14 days" },
       { command: 'blog', description: 'Draft a GRC blog post from a race recap' },
     ])
   } catch (_err) {

--- a/supabase/functions/telegram-bot/tools.ts
+++ b/supabase/functions/telegram-bot/tools.ts
@@ -143,7 +143,15 @@ export function buildTools(
               'plus a clock time if present) — keep qualifier words like "by", "EOD", or "due" ' +
               'OUTSIDE the token. E.g. "Submit GRC blog post by EOD {{date:6/15}}", ' +
               '"call w/ Sam {{date:6/16 6:59 PM}}", "renew pass {{date:6/15}}". The M/D inside the ' +
-              "token also makes it register as a due date. Don't wrap incidental/context dates.",
+              "token also makes it register as a due date. Don't wrap incidental/context dates.\n" +
+              'A highlighted date with a clock time arms a push reminder; a highlighted date alone ' +
+              'never does. Put a stated clock time INSIDE the token with an explicit AM/PM ' +
+              '("{{date:8/21 2:00 PM}}", never a bare "2:00"). NEVER invent a time — date-only is ' +
+              'the normal case. If the user asked to be reminded a certain amount ahead, append ' +
+              'that phrase in plain text OUTSIDE the token, e.g. ' +
+              '"call the venue {{date:8/21 2:00 PM}} (remind 3 hours before)"; the default is 90 ' +
+              'minutes ahead, so only say otherwise when they asked. If they said not to be ' +
+              'reminded, append "(no reminder)".',
           },
         },
         required: ['placement', 'format', 'items'],

--- a/supabase/migrations/20260809000000_add_bot_reminders.sql
+++ b/supabase/migrations/20260809000000_add_bot_reminders.sql
@@ -1,0 +1,56 @@
+-- Timed reminders derived from highlighted dates that carry a clock time.
+--
+-- THIS TABLE IS A SEND LEDGER, NOT A SCHEDULE. Nothing is ever "armed" here.
+-- Every tick of send-reminders re-derives the complete reminder set from the
+-- current documents and consults this table only to answer "did I already send
+-- this one?". That is why editing a tracker line needs no invalidation: the old
+-- dedup_key simply stops being derived, and the new one has no row yet.
+--
+-- (The alternative — a table of scheduled rows — would need invalidation on
+-- every edit, and pages.updated_at churns every 2 seconds while the user types.)
+--
+-- Written via the service role (which bypasses RLS). The SELECT policy below is
+-- defensive, scoped to the single owning user, matching the project's RLS style.
+
+create table public.bot_reminders (
+  id uuid primary key default gen_random_uuid(),
+  user_id uuid not null references auth.users(id),
+
+  -- Deterministic identity. Derived: 'd:<block_id>:<due_at_iso>:<lead_minutes>'
+  --                        Snooze:  's:<block_id>:<fire_at_iso>'
+  -- Deliberately EXCLUDES line text: fixing a typo must not re-fire.
+  -- Deliberately INCLUDES due_at + lead: editing either yields a new key.
+  dedup_key text not null,
+  source text not null default 'derived' check (source in ('derived', 'snooze')),
+
+  block_id text not null,
+  page_id uuid references public.pages(id) on delete cascade,
+  due_at timestamptz,                 -- null for snoozes
+  lead_minutes integer,
+  fire_at timestamptz not null,       -- effective send time, post-quiet-hours
+  line_text text,                     -- snapshot, for debugging only
+
+  status text not null default 'pending' check (status in ('pending', 'sent')),
+  telegram_message_id bigint,         -- routes a "done"/"snooze" reply back here
+  sent_at timestamptz,
+  created_at timestamptz not null default now()
+);
+
+-- The dedup gate. A claim-insert that hits 23505 means "already handled".
+create unique index bot_reminders_dedup on public.bot_reminders (user_id, dedup_key);
+
+-- Sweep lookup for pending snoozes.
+create index bot_reminders_pending_idx on public.bot_reminders (status, fire_at);
+
+-- Indexed FK (project convention — see 20260403000000_add_missing_fk_indexes.sql).
+create index bot_reminders_page_id_idx on public.bot_reminders (page_id);
+
+-- Quote-reply lookup: which reminder is the user replying "done" to?
+create index bot_reminders_tg_msg_idx on public.bot_reminders (telegram_message_id)
+  where telegram_message_id is not null;
+
+alter table public.bot_reminders enable row level security;
+
+create policy "Users can read their bot_reminders"
+  on public.bot_reminders for select to authenticated
+  using ((select auth.uid()) = user_id);

--- a/supabase/migrations/20260809000001_schedule_bot_reminders.sql
+++ b/supabase/migrations/20260809000001_schedule_bot_reminders.sql
@@ -1,0 +1,33 @@
+-- Schedule the reminder sweep. DELIBERATELY SPLIT from the table migration:
+-- nothing runs on a timer until the function has been verified by hand with
+-- REMINDER_DRY_RUN=1. Apply this one LAST.
+--
+-- pg_cron is already enabled (see 20260329000001_add_pg_cron_scores.sql).
+
+-- Retention. A purged row would be re-derived, but its fire_at is then far past
+-- and the sweep's 2h grace filter rejects it — so 90 days is three orders of
+-- magnitude more margin than the backfill guard needs.
+select cron.schedule(
+  'purge-bot-reminders',
+  '23 4 * * *',
+  $$ delete from public.bot_reminders where fire_at < now() - interval '90 days' $$
+);
+
+-- Every 5 minutes. 288 invocations/day (~8.6K/month against a 500K free tier),
+-- ~1s each, and zero AI tokens — extraction is pure regex over document JSON.
+--
+-- Same Vault-sourced secret check-scores uses (see the migration above).
+select cron.schedule(
+  'send-bot-reminders',
+  '*/5 * * * *',
+  $$
+  select net.http_post(
+    url := 'https://ogzpgnxmcifaqliuxxzu.supabase.co/functions/v1/send-reminders',
+    headers := jsonb_build_object(
+      'Content-Type', 'application/json',
+      'x-cron-secret', (select decrypted_secret from vault.decrypted_secrets where name = 'cron_secret' limit 1)
+    ),
+    body := '{}'::jsonb
+  );
+  $$
+);


### PR DESCRIPTION
Highlight a date **with a clock time** in a tracker page and the Telegram bot texts you before it happens.

```
Dietician appointment  8/17 8:20am                     → texts before it
                       ^^^^^^^^^^^ highlighted cyan

Flight to Denver  9/26 6:15am — text me 1 day before   → texts 9/25 6:15am
Call venue        8/21 2pm (remind 3 hours before)     → texts 8/21 11:00am
Standup           8/13 9am — no reminder               → silent
Free Epic check   EOD 8/16                             → unchanged; daily list only
```

**Highlight = when. Line text = how early.** Default lead 90 minutes.

Three properties the design is built around:

1. **Zero AI tokens in the scheduled loop.** Extraction is deterministic regex over document JSON. 288 invocations/day, ~1s each.
2. **The existing 573 date-only highlights are untouched.** A bare date never arms a push. The time grammar requires an unambiguous marker — minutes, a meridiem, or an explicit `@`/`at` — so `8/17 2026`, `8/17 5k`, `12/28/30`, and `8/17 1400` all parse to nothing.
3. **Every highlighted date is reachable** (see Part 1 — this fixes a pre-existing gap).

## Part 1 — multi-column table rows are now anchored

`serializeNode` set `suppressAnchors = true` for the entire multi-column table branch, so no cid, no block id, and no daily-list candidate. **24 highlighted dates** across the user's six Rewards tables were invisible to the AI Daily list.

Body rows now register one row-level anchor appended after the closing pipe, resolving to the first `attrs.id` found walking the row. Cells stay anchor-free — a `⟦c42⟧` mid-pipe-row would be noise, which is why the original code suppressed them. Header rows are skipped.

All 24 affected dates are future expirations with explicit slash-years, so `bucketForDate` classifies them `later` and **the daily list gains zero noise today**.

## Part 2 — shared modules

`dailyHelpers.ts` + its test move to `supabase/functions/_shared/` (two consumers now, so a peer-function reach-in would be the wrong shape). Additive changes: `cidSegments` and `cidToPageId` on `TrackerContext`, and `resolveTokenDate` extracted so the year ladder applies **per token** rather than per line — a line with two timed dates arms two reminders.

New pure modules, all under the house rule *zero `jsr:`/`npm:`/`https://` imports, zero top-level `Deno.*`* so Vitest imports them directly:

| Module | Role |
|---|---|
| `timeParse` | the clock-time grammar |
| `leadTime` | "how early", with suppression and prose rejection |
| `wallClock` | zone-correct wall-clock ↔ UTC, DST edges |
| `deriveReminders` | the whole derivation |
| `deepLink` | one implementation, lifted out of `capture.ts` |
| `dateToken` | the `{{date:…}}` splitter, shared with `insertContent` |
| `reminderMessage` | outbound wording + the bot's confirmation |
| `reminderReply` | done/snooze keyword routing |
| `strikeBlock` | the "done" write |

## Part 3 — `bot_reminders` is a send ledger, not a schedule

Nothing is ever "armed" in the DB. Every tick re-derives the complete set from the current documents and consults the table only for "did I already send this?".

| Action | Result |
|---|---|
| Edit `8:20am` → `9:20am` before it fires | old key never derived again → can't fire; new key has no row → fires ✅ |
| Fix a typo in the task text | same key (text isn't in it) → no re-fire ✅ |
| Change the lead phrase | new key → fires ✅ |
| Delete the line | never derived → no cleanup needed ✅ |

The alternative — scheduled rows — would need invalidation on every edit, and `pages.updated_at` churns every 2 seconds while typing.

## Part 4 — the sweep

`send-reminders`, cron-secret auth (fails closed), tiny import graph (no grammY, no puppeteer). A **60s stability guard** skips pages touched recently, so a tick can't catch a half-typed `8:20am` en route to `8:20pm`. Plus a backfill grace window, a `MIN_FIRE_AT` deploy seatbelt, a per-tick cap, and **`REMINDER_DRY_RUN`**.

Quiet hours (22:00–07:00) **defer rather than drop**, with an escape hatch: a 6am flight fires at 4:45am rather than being pushed to 7am, *after takeoff*.

## Part 5 — bot integration

The post-confirmation line is **derived, not asserted** — `describeArmedReminders` runs the same `deriveFromSegments` the cron does over the same persisted `{{date:…}}` strings, so the bot cannot promise a text that won't arrive. Silence means the parser couldn't read it, which is exactly the signal needed.

Also `/reminders` (14-day horizon, zero AI), and done/snooze replies routed by strict keyword match — a pending preview job always wins a bare "done", and anything chattier than a keyword falls through untouched. Cross-off confirmations are mandatory and quote the line back with a link, so an accidental one is visible and one tap from being fixed.

## Test plan

714 unit tests pass; production build clean.

- [x] `timeParse` — the **reject** rows especially; they protect the 573 working highlights
- [x] `leadTime` — suppression beats leads; `finish 3 days before the wedding` and `20 mi before work` correctly find no clause
- [x] `wallClock` — EDT/EST, spring-forward gap, fall-back ambiguity, `Asia/Kolkata`, round-trip property, and **the `today` trap** (`2026-08-18T02:00Z` in New York → `2026-08-17`)
- [x] `deriveReminders` — ⭐ date-only → zero reminders for nine real tracker strings; ⭐ a timed date in a 4-column table row → one reminder with the right block id; pairing across a space but not a hard break; lead scoping per visual line; quiet-hours deferral and its escape hatch; dedup-key stability
- [x] `deepLink` — round-trips through the real front-end `parseDeepLink` (key order is load-bearing)
- [x] `strikeBlock`, `reminderMessage`, `reminderReply`, `dailyHelpers` regressions
- [ ] Manual rollout below

## Rollout — nothing is scheduled yet

The two migrations are **deliberately split** and **neither has been applied**:

1. Deploy `send-reminders`.
2. Apply `20260809000000_add_bot_reminders.sql` (table only). Set `REMINDER_DRY_RUN=1`, `REMINDER_MIN_FIRE_AT=<now>`.
3. `curl` it → expect `orphanedTimedHighlights: 0` and a handful of `derived` (the three legacy `6/16 6:59 PM` doc-string examples).
4. Add a real test line with date **and** time both cyan; dry-run again; confirm the `fire_at`.
5. `REMINDER_DRY_RUN=0` → phone buzzes; tap the link; curl again → `sent: 0` (dedup holds).
6. Check the multi-column table case and re-run AI Daily.
7. **Only then** apply `20260809000001_schedule_bot_reminders.sql` (the `*/5` cron).

## Notes

- The plan's worked example said `8/17 8:20am` texts at 6:50am, but 6:50 falls inside the 22:00–07:00 quiet window it also specifies. The quiet rule wins and it defers to 7:00 — still well before the appointment. Encoded explicitly in the tests.
- `resolveTokenDate` takes `(token, lineText, anchor)`; the plan listed a `today` parameter that the implementation has no use for, so it was dropped rather than left as a no-op.

## Known limitations (documented, deferred)

`day`/`week` leads straddling a DST boundary land an hour off twice a year · fall-back ambiguous times pick the DST occurrence · `8.20am` / `1400` / `8h30` don't parse (`.` is deliberately not a separator — `Pay $8.50 before…`) · `8/17-8/19 7pm` attaches to `8/19`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)