### PR TITLE
fix: render the reminder deep link as tappable text

### DIFF
--- a/supabase/functions/_shared/reminderMessage.test.ts
+++ b/supabase/functions/_shared/reminderMessage.test.ts
@@ -54,31 +54,45 @@ describe('cleanLineText', () => {
 })
 
 describe('buildReminderText', () => {
-  it('renders header, local time, and the link', () => {
-    const text = buildReminderText(
-      {
-        dueAt: Date.parse('2026-08-17T12:20:00Z'),
-        leadMinutes: 90,
-        lineText: 'Dietician appointment  8/17 8:20am',
-        leadMatch: null,
-      },
-      NY,
-      'https://example.test/#nb=1&block=2',
-    )
-    expect(text).toBe(
+  const reminder = {
+    dueAt: Date.parse('2026-08-17T12:20:00Z'),
+    leadMinutes: 90,
+    lineText: 'Dietician appointment  8/17 8:20am',
+    leadMatch: null,
+  }
+  const link = 'https://example.test/#nb=1&sec=2&block=3'
+
+  it('renders the link as tappable "Open in tracker" text', () => {
+    expect(buildReminderText(reminder, NY, link)).toBe(
       '⏰ In 90 minutes — Dietician appointment 8/17 8:20am\n\n' +
         'Mon Aug 17 · 8:20 AM\n\n' +
-        'https://example.test/#nb=1&block=2',
+        '<a href="https://example.test/#nb=1&amp;sec=2&amp;block=3">Open in tracker</a>',
     )
   })
 
-  it('omits the link line when there is nothing to link to', () => {
-    const text = buildReminderText(
-      { dueAt: Date.parse('2026-08-17T12:20:00Z'), leadMinutes: 30, lineText: 'Thing', leadMatch: null },
-      NY,
-      '',
+  it('escapes HTML-significant characters in the user\'s own line text', () => {
+    const spicy = { ...reminder, lineText: 'Email <sam@x.com> re: A&B  8/17 8:20am' }
+    const text = buildReminderText(spicy, NY, '')
+    expect(text).toContain('Email &lt;sam@x.com&gt; re: A&amp;B')
+    expect(text).not.toContain('<sam@')
+  })
+
+  it('falls back to a bare URL in plain mode', () => {
+    expect(buildReminderText(reminder, NY, link, 'plain')).toBe(
+      '⏰ In 90 minutes — Dietician appointment 8/17 8:20am\n\n' +
+        'Mon Aug 17 · 8:20 AM\n\n' +
+        link,
     )
-    expect(text.split('\n')).toHaveLength(3)
+  })
+
+  it('leaves the plain build unescaped so Telegram auto-links it', () => {
+    const spicy = { ...reminder, lineText: 'Email <sam@x.com> re: A&B' }
+    expect(buildReminderText(spicy, NY, link, 'plain')).toContain('Email <sam@x.com> re: A&B')
+  })
+
+  it('omits the link line when there is nothing to link to', () => {
+    expect(buildReminderText(reminder, NY, '').split('\n')).toHaveLength(3)
+    expect(buildReminderText(reminder, NY, '', 'plain').split('\n')).toHaveLength(3)
   })
 })
 

--- a/supabase/functions/_shared/reminderMessage.ts
+++ b/supabase/functions/_shared/reminderMessage.ts
@@ -49,22 +49,43 @@ export function cleanLineText(
 }
 
 /**
- * The outbound text. Plain — no parse_mode. This function emits a fixed format we
- * control, so it skips the escaping machinery telegram.ts needs for model output,
- * and Telegram auto-links the bare URL.
+ * Escape for Telegram's HTML parse mode, which needs only these three — unlike
+ * MarkdownV2, which would need every one of `_*[]()~\`>#+-=|{}.!` escaped in the
+ * user's own tracker text. A dash or a period in a task line is common enough
+ * that MarkdownV2 here would be a steady source of 400s.
+ */
+const escapeHtml = (value: string): string =>
+  value.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
+
+/**
+ * The outbound reminder.
+ *
+ * 'html' is what actually gets sent: the link renders as tappable "Open in
+ * tracker" text, matching the bot's "Added ✅" confirmation. 'plain' is the
+ * fallback if Telegram ever rejects the markup — it degrades to a bare URL,
+ * which Telegram auto-links, rather than dropping the message.
  */
 export function buildReminderText(
   reminder: Pick<TimedDate, 'dueAt' | 'leadMinutes' | 'lineText' | 'leadMatch'>,
   timeZone: string,
   deepLink: string,
+  format: 'html' | 'plain' = 'html',
 ): string {
   const header =
     reminder.leadMinutes > 0 ? `⏰ In ${describeLead(reminder.leadMinutes)}` : '⏰ Now'
   const body = cleanLineText(reminder.lineText, reminder.leadMatch)
   const when = formatInZone(reminder.dueAt, timeZone)
 
-  const lines = [body ? `${header} — ${body}` : header, '', when]
-  if (deepLink) lines.push('', deepLink)
+  if (format === 'plain') {
+    const lines = [body ? `${header} — ${body}` : header, '', when]
+    if (deepLink) lines.push('', deepLink)
+    return lines.join('\n')
+  }
+
+  const heading = body ? `${header} — ${escapeHtml(body)}` : header
+  const lines = [heading, '', escapeHtml(when)]
+  // The href needs escaping too: a deep link carries & between its hash params.
+  if (deepLink) lines.push('', `<a href="${escapeHtml(deepLink)}">Open in tracker</a>`)
   return lines.join('\n')
 }
 

--- a/supabase/functions/send-reminders/index.ts
+++ b/supabase/functions/send-reminders/index.ts
@@ -69,17 +69,31 @@ type SnoozeRow = {
 }
 
 /** Direct fetch, not grammY — one dependency and one code path. */
-async function sendMessage(text: string): Promise<number | null> {
-  const resp = await fetch(`https://api.telegram.org/bot${BOT_TOKEN}/sendMessage`, {
+async function post(text: string, html: boolean): Promise<Response> {
+  return await fetch(`https://api.telegram.org/bot${BOT_TOKEN}/sendMessage`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({
       chat_id: CHAT_ID,
       text,
+      ...(html ? { parse_mode: 'HTML' } : {}),
       // Otherwise Telegram fetches a link-preview card on every single reminder.
       disable_web_page_preview: true,
     }),
   })
+}
+
+/**
+ * Send the HTML build so the deep link renders as tappable "Open in tracker"
+ * text. If Telegram rejects the markup, resend the plain build — a formatting
+ * edge case should cost the user a pretty link, never the reminder itself.
+ */
+async function sendMessage(html: string, plain: string): Promise<number | null> {
+  let resp = await post(html, true)
+  if (!resp.ok) {
+    console.error(`HTML send rejected (${resp.status}), falling back to plain text`)
+    resp = await post(plain, false)
+  }
   if (!resp.ok) {
     throw new Error(`telegram sendMessage failed (${resp.status}) ${await resp.text().catch(() => '')}`)
   }
@@ -237,7 +251,10 @@ Deno.serve(async (req) => {
 
       try {
         if (index > 0) await sleep(SEND_GAP_MS)
-        const messageId = await sendMessage(buildReminderText(reminder, USER_TIMEZONE, deepLink))
+        const messageId = await sendMessage(
+          buildReminderText(reminder, USER_TIMEZONE, deepLink),
+          buildReminderText(reminder, USER_TIMEZONE, deepLink, 'plain'),
+        )
         await supabase
           .from('bot_reminders')
           .update({
@@ -316,12 +333,15 @@ async function sendDueSnoozes(
   for (const row of data as SnoozeRow[]) {
     try {
       const deepLink = buildDeepLink({ pageId: row.page_id, blockId: row.block_id }, APP_URL)
+      const snoozed = {
+        dueAt: Date.parse(row.fire_at),
+        leadMinutes: 0,
+        lineText: row.line_text ?? '',
+        leadMatch: null,
+      }
       const messageId = await sendMessage(
-        buildReminderText(
-          { dueAt: Date.parse(row.fire_at), leadMinutes: 0, lineText: row.line_text ?? '', leadMatch: null },
-          USER_TIMEZONE,
-          deepLink,
-        ),
+        buildReminderText(snoozed, USER_TIMEZONE, deepLink),
+        buildReminderText(snoozed, USER_TIMEZONE, deepLink, 'plain'),
       )
       await supabase
         .from('bot_reminders')


### PR DESCRIPTION
The sweep sent reminders with no `parse_mode`, so the deep link showed up as a raw URL dumped at the bottom. Now it renders as **Open in tracker**, matching the bot's "Added ✅" confirmation.

```
⏰ In 90 minutes — Dietician appointment 8/17 8:20am

Mon Aug 17 · 8:20 AM

Open in tracker          ← tappable, was a raw https://… before
```

**HTML, not MarkdownV2.** The message embeds the user's own tracker line, and MarkdownV2 requires escaping every one of `_*[]()~\`>#+-=|{}.!` — a dash or a period in a task line is common enough that it would be a steady source of 400s. HTML needs only `&`, `<`, `>`. The href is escaped too, since a deep link carries `&` between hash params.

**Fallback kept.** `buildReminderText` gained a `format` parameter; if Telegram ever rejects the markup, the sender retries the plain build. A formatting edge case costs a pretty link, never the reminder.

## Test plan

717 unit tests pass. New coverage in `reminderMessage.test.ts`:
- [x] link renders as `<a href=…>Open in tracker</a>` with `&amp;` in the href
- [x] `<`, `>`, `&` in the user's line text are escaped
- [x] plain build still emits the bare URL, unescaped
- [x] both builds omit the link line when there's nothing to link to
- [x] Deployed; verified against a live reminder

🤖 Generated with [Claude Code](https://claude.com/claude-code)